### PR TITLE
Use the wrong type when forwarding the 'handle' parameter

### DIFF
--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -385,7 +385,7 @@ send_filechooser_response (GTask *task,
     writable = FALSE;
 
   g_variant_builder_init (&b, G_VARIANT_TYPE_TUPLE);
-  g_variant_builder_add (&b, "s", handle);
+  g_variant_builder_add (&b, "o", handle);
   g_variant_builder_add (&b, "u", response);
 
   if (strcmp (data->signal_name, "OpenFilesResponse") == 0)


### PR DESCRIPTION
The symbol used to described handlers in the GVariant format string for
messages received from the implementating backend is 'o', so we need to
honor that when forwarding it to the sandboxed app, which expects that.