### PR TITLE
Add a portal for  network connectivity

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -3,6 +3,7 @@ introspection_DATA = \
 	data/org.freedesktop.portal.FileChooser.xml \
 	data/org.freedesktop.portal.OpenURI.xml \
 	data/org.freedesktop.portal.Print.xml \
+	data/org.freedesktop.portal.NetworkMonitor.xml \
 	data/org.freedesktop.impl.portal.FileChooser.xml \
 	data/org.freedesktop.impl.portal.AppChooser.xml \
 	data/org.freedesktop.impl.portal.Print.xml \

--- a/data/org.freedesktop.portal.NetworkMonitor.xml
+++ b/data/org.freedesktop.portal.NetworkMonitor.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2016 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, write to the
+ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ Boston, MA 02110-1301, USA.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+<node xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd" name="/">
+  <interface name="org.freedesktop.portal.NetworkMonitor">
+    <signal name="changed">
+      <arg type="b" name="available"/>
+    </signal>
+    <property name="available" type="b" access="read"/>
+    <property name="metered" type="b" access="read"/>
+    <property name="connectivity" type="u" access="read"/>
+  </interface>
+</node>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -15,6 +15,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.FileChooser.xml \
 	data/org.freedesktop.portal.OpenURI.xml \
 	data/org.freedesktop.portal.Print.xml \
+	data/org.freedesktop.portal.NetworkMonitor.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -67,6 +68,8 @@ xdg_desktop_portal_SOURCES = \
         src/open-uri.h                  \
         src/print.c                     \
         src/print.h                     \
+        src/network-monitor.c           \
+        src/network-monitor.h           \
 	src/request.c                   \
 	src/request.h                   \
 	src/xdp-utils.c             \

--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -1,0 +1,86 @@
+#include "config.h"
+
+#include <string.h>
+#include <gio/gio.h>
+
+#include "network-monitor.h"
+#include "xdp-dbus.h"
+
+typedef struct _NetworkMonitor NetworkMonitor;
+typedef struct _NetworkMonitorClass NetworkMonitorClass;
+
+struct _NetworkMonitor
+{
+  XdpNetworkMonitorSkeleton parent_instance;
+
+  GNetworkMonitor *monitor;
+};
+
+struct _NetworkMonitorClass
+{
+  XdpNetworkMonitorSkeletonClass parent_class;
+};
+
+static NetworkMonitor *network_monitor;
+
+GType network_monitor_get_type (void) G_GNUC_CONST;
+static void network_monitor_iface_init (XdpNetworkMonitorIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (NetworkMonitor, network_monitor, XDP_TYPE_NETWORK_MONITOR_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_NETWORK_MONITOR, network_monitor_iface_init));
+
+static void
+network_monitor_iface_init (XdpNetworkMonitorIface *iface)
+{
+}
+
+static void
+notify (GObject *object, GParamSpec *pspec, NetworkMonitor *nm)
+{
+  if (strcmp (pspec->name, "network-available") == 0)
+    xdp_network_monitor_set_available (XDP_NETWORK_MONITOR (nm),
+                                       g_network_monitor_get_network_available (nm->monitor));
+  else if (strcmp (pspec->name, "network-metered") == 0)
+    xdp_network_monitor_set_metered (XDP_NETWORK_MONITOR (nm),
+                                     g_network_monitor_get_network_metered (nm->monitor));
+  else if (strcmp (pspec->name, "connectivity") == 0)
+    xdp_network_monitor_set_connectivity (XDP_NETWORK_MONITOR (nm),
+                                          g_network_monitor_get_connectivity (nm->monitor));
+}
+
+static void
+changed (GNetworkMonitor *monitor, gboolean available, XdpNetworkMonitor *nm)
+{
+  xdp_network_monitor_emit_changed (nm, available);
+}
+
+static void
+network_monitor_init (NetworkMonitor *nm)
+{
+  nm->monitor = g_network_monitor_get_default ();
+
+  g_signal_connect (nm->monitor, "notify", G_CALLBACK (notify), nm);
+  g_signal_connect (nm->monitor, "network-changed", G_CALLBACK (changed), nm);
+
+  xdp_network_monitor_set_available (XDP_NETWORK_MONITOR (nm),
+                                     g_network_monitor_get_network_available (nm->monitor));
+  xdp_network_monitor_set_metered (XDP_NETWORK_MONITOR (nm),
+                                   g_network_monitor_get_network_metered (nm->monitor));
+  xdp_network_monitor_set_connectivity (XDP_NETWORK_MONITOR (nm),
+                                        g_network_monitor_get_connectivity (nm->monitor));
+}
+
+static void
+network_monitor_class_init (NetworkMonitorClass *klass)
+{
+}
+
+GDBusInterfaceSkeleton *
+network_monitor_create (GDBusConnection *connection)
+{
+  g_autoptr(GError) error = NULL;
+
+  network_monitor = g_object_new (network_monitor_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (network_monitor);
+}

--- a/src/network-monitor.h
+++ b/src/network-monitor.h
@@ -1,0 +1,3 @@
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * network_monitor_create (GDBusConnection *connection);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -18,6 +18,7 @@
 #include "open-uri.h"
 #include "print.h"
 #include "request.h"
+#include "network-monitor.h"
 
 static GMainLoop *loop = NULL;
 XdpDocuments *documents = NULL;
@@ -331,6 +332,29 @@ on_bus_acquired (GDBusConnection *connection,
 
       g_debug ("providing portal %s", g_dbus_interface_skeleton_get_info (skeleton)->name);
     }
+
+  {
+  GDBusInterfaceSkeleton *skeleton = network_monitor_create (connection);
+  if (skeleton != NULL)
+    {
+      g_dbus_interface_skeleton_set_flags (skeleton,
+                                           G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
+      g_signal_connect (skeleton, "g-authorize-method",
+                        G_CALLBACK (authorize_callback),
+                        NULL);
+
+      if (!g_dbus_interface_skeleton_export (skeleton,
+                                             connection,
+                                             "/org/freedesktop/portal/desktop",
+                                             &error))
+        {
+          g_warning ("error: %s\n", error->message);
+          g_clear_error (&error);
+        }
+    }
+
+  g_debug ("providing portal %s", g_dbus_interface_skeleton_get_info (skeleton)->name);
+  }
 }
 
 static void


### PR DESCRIPTION
Can just proxy the GLibNetworkMonitor functionality over dbus, and make it work in GLib