### PR TITLE
Use permissions store to implement a simple 'remember latest choice' mechanism

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -10,6 +10,14 @@ xdp_dbus_built_sources = src/xdp-dbus.c src/xdp-dbus.h
 xdp_impl_dbus_built_sources = src/xdp-impl-dbus.c src/xdp-impl-dbus.h
 BUILT_SOURCES += $(xdp_dbus_built_sources) $(xdp_impl_dbus_built_sources)
 
+FLATPAK_IFACE_FILES =\
+	$(FLATPAK_INTERFACES_DIR)/org.freedesktop.portal.Documents.xml \
+	$(NULL)
+
+FLATPAK_IMPL_IFACE_FILES =\
+	$(FLATPAK_INTERFACES_DIR)/org.freedesktop.impl.portal.PermissionStore.xml \
+	$(NULL)
+
 PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.Request.xml \
 	data/org.freedesktop.portal.FileChooser.xml \
@@ -25,22 +33,23 @@ PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.Print.xml \
 	$(NULL)
 
-$(xdp_dbus_built_sources) : $(FLATPAK_INTERFACES_DIR)/org.freedesktop.portal.Documents.xml $(PORTAL_IFACE_FILES)
+$(xdp_dbus_built_sources) : $(FLATPAK_IFACE_FILES) $(PORTAL_IFACE_FILES)
 	$(AM_V_GEN) $(GDBUS_CODEGEN)                            \
 		--interface-prefix org.freedesktop.portal.      \
 		--c-namespace Xdp                               \
 		--generate-c-code $(builddir)/src/xdp-dbus      \
 		--annotate "org.freedesktop.portal.Documents.Add()" "org.gtk.GDBus.C.UnixFD" "true" \
 		--annotate "org.freedesktop.portal.Documents.AddNamed()" "org.gtk.GDBus.C.UnixFD" "true" \
-		$(FLATPAK_INTERFACES_DIR)/org.freedesktop.portal.Documents.xml     \
+		$(FLATPAK_IFACE_FILES) \
 		$(PORTAL_IFACE_FILES) \
 		$(NULL)
 
-$(xdp_impl_dbus_built_sources) : $(PORTAL_IMPL_IFACE_FILES)
+$(xdp_impl_dbus_built_sources) : $(FLATPAK_IMPL_IFACE_FILES) $(PORTAL_IMPL_IFACE_FILES)
 	$(AM_V_GEN) $(GDBUS_CODEGEN)                            \
 		--interface-prefix org.freedesktop.impl.portal. \
 		--c-namespace XdpImpl                           \
 		--generate-c-code $(builddir)/src/xdp-impl-dbus \
+		$(FLATPAK_IMPL_IFACE_FILES) \
 		$(PORTAL_IMPL_IFACE_FILES) \
 		$(NULL)
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -20,6 +20,8 @@
 #include "xdp-impl-dbus.h"
 
 #define TABLE_NAME "desktop-used-apps"
+#define USE_DEFAULT_APP_THRESHOLD 5
+
 typedef struct _OpenURI OpenURI;
 
 typedef struct _OpenURIClass OpenURIClass;
@@ -196,6 +198,9 @@ handle_open_uri (XdpOpenURI *object,
   GList *infos, *l;
   g_autofree char *uri_scheme = NULL;
   g_autofree char *content_type = NULL;
+  g_autofree char *latest_chosen_id = NULL;
+  gint latest_chosen_count = 0;
+  GVariant *actual_options = NULL;
   int i;
 
   uri_scheme = g_uri_parse_scheme (arg_uri);
@@ -225,6 +230,43 @@ handle_open_uri (XdpOpenURI *object,
   choices[i] = NULL;
   g_list_free_full (infos, g_object_unref);
 
+  if (get_latest_choice_info (app_id, content_type, &latest_chosen_id, &latest_chosen_count) &&
+      (latest_chosen_count >= USE_DEFAULT_APP_THRESHOLD))
+    {
+      /* If a recommended choice is found, just use it and skip the chooser dialog */
+      launch_application_with_uri (latest_chosen_id, arg_uri, arg_parent_window);
+
+      /* We need to close the request before completing, so do it here */
+      xdp_request_complete_close (XDP_REQUEST (request), invocation);
+      xdp_open_uri_complete_open_uri (object, invocation, request->id);
+      return TRUE;
+    }
+  else if (latest_chosen_id != NULL)
+    {
+      GVariantBuilder opts_builder;
+      GVariantIter iter;
+      GVariant *child;
+
+      /* Add extra options to the request for the backend */
+      g_variant_builder_init (&opts_builder, G_VARIANT_TYPE ("a{sv}"));
+      g_variant_iter_init (&iter, arg_options);
+      while ((child = g_variant_iter_next_value (&iter)))
+        {
+          g_variant_builder_add_value (&opts_builder, child);
+          g_variant_unref (child);
+        }
+      g_variant_builder_add (&opts_builder,
+                             "{sv}",
+                             "latest-choice",
+                             g_variant_new_string (latest_chosen_id));
+      actual_options = g_variant_builder_end (&opts_builder);
+    }
+  else
+    {
+      /* No need to add the extra option to the list */
+      actual_options = arg_options;
+    }
+
   g_object_set_data_full (G_OBJECT (request), "uri", g_strdup (arg_uri), g_free);
   g_object_set_data_full (G_OBJECT (request), "parent-window", g_strdup (arg_parent_window), g_free);
   g_object_set_data_full (G_OBJECT (request), "content-type", g_strdup (content_type), g_free);
@@ -233,7 +275,7 @@ handle_open_uri (XdpOpenURI *object,
                                                           sender, app_id,
                                                           arg_parent_window,
                                                           (const char * const *)choices,
-                                                          arg_options,
+                                                          actual_options,
                                                           &app_chooser_impl_handle,
                                                           NULL, &error))
     {

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -33,6 +33,7 @@ struct _OpenURIClass
 };
 
 static XdpImplAppChooser *app_chooser_impl;
+static XdpImplPermissionStore *permission_store_impl;
 static OpenURI *open_uri;
 
 GType open_uri_get_type (void) G_GNUC_CONST;
@@ -272,6 +273,17 @@ open_uri_create (GDBusConnection *connection,
   if (app_chooser_impl == NULL)
     {
       g_warning ("Failed to create app chooser proxy: %s\n", error->message);
+      return NULL;
+    }
+
+  permission_store_impl = xdp_impl_permission_store_proxy_new_sync (connection,
+                                                                    G_DBUS_PROXY_FLAGS_NONE,
+                                                                    "org.freedesktop.impl.portal.PermissionStore",
+                                                                    "/org/freedesktop/impl/portal/PermissionStore",
+                                                                    NULL, &error);
+  if (permission_store_impl == NULL)
+    {
+      g_warning ("No permission store: %s", error->message);
       return NULL;
     }
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -307,7 +307,11 @@ update_permissions_store (const char *app_id,const char *content_type, const cha
   if (get_latest_choice_info (app_id, content_type, &latest_chosen_id, &latest_chosen_count) &&
       (g_strcmp0 (chosen_id, latest_chosen_id) == 0))
     {
-      latest_chosen_count++;
+      /* same app chosen once again: update the counter */
+      if (latest_chosen_count >= USE_DEFAULT_APP_THRESHOLD)
+        latest_chosen_count = USE_DEFAULT_APP_THRESHOLD;
+      else
+        latest_chosen_count++;
     }
   else
     {


### PR DESCRIPTION
For now, it uses a hardcoded threshold of 5 consecutive executions to determine whether we want to hint the backend, suggesting it to use the default option right away.

This addresses issue https://github.com/flatpak/xdg-desktop-portal/issues/10