### PR TITLE
Split out document portal code

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -84,6 +84,8 @@ xdg_desktop_portal_SOURCES = \
 	src/proxy-resolver.h		\
 	src/request.c			\
 	src/request.h			\
+        src/documents.c                 \
+        src/documents.h                 \
 	src/xdp-utils.c			\
 	src/xdp-utils.h			\
 	src/xdg-desktop-resources.c	\

--- a/src/documents.c
+++ b/src/documents.c
@@ -1,0 +1,116 @@
+#include "config.h"
+
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+#include "xdp-dbus.h"
+
+static XdpDocuments *documents = NULL;
+static char *documents_mountpoint = NULL;
+
+void
+init_document_proxy (GDBusConnection *connection)
+{
+  documents = xdp_documents_proxy_new_sync (connection, 0,
+                                            "org.freedesktop.portal.Documents",
+                                            "/org/freedesktop/portal/documents",
+                                            NULL, NULL);
+  xdp_documents_call_get_mount_point_sync (documents,
+                                           &documents_mountpoint,
+                                           NULL, NULL);
+}
+
+char *
+register_document (const char *uri,
+                   const char *app_id,
+                   gboolean for_save,
+                   gboolean writable,
+                   GError **error)
+{
+  g_autofree char *doc_id = NULL;
+  g_autofree char *path = NULL;
+  g_autofree char *basename = NULL;
+  g_autofree char *dirname = NULL;
+  GUnixFDList *fd_list = NULL;
+  int fd, fd_in;
+  g_autoptr(GFile) file = NULL;
+  gboolean ret = FALSE;
+  const char *permissions[5];
+  g_autofree char *fuse_path = NULL;
+  int i;
+
+  if (app_id == NULL || *app_id == 0)
+    return g_strdup (uri);
+
+  file = g_file_new_for_uri (uri);
+  path = g_file_get_path (file);
+  basename = g_path_get_basename (path);
+  dirname = g_path_get_dirname (path);
+
+  if (for_save)
+    fd = open (dirname, O_PATH | O_CLOEXEC);
+  else
+    fd = open (path, O_PATH | O_CLOEXEC);
+
+  if (fd == -1)
+    {
+      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Failed to open %s", uri);
+      return NULL;
+    }
+ fd_list = g_unix_fd_list_new ();
+  fd_in = g_unix_fd_list_append (fd_list, fd, error);
+  close (fd);
+
+  if (fd_in == -1)
+    return NULL;
+
+  i = 0;
+  permissions[i++] = "read";
+  if (writable)
+    permissions[i++] = "write";
+  permissions[i++] = "grant";
+  permissions[i++] = NULL;
+
+  if (for_save)
+    ret = xdp_documents_call_add_named_sync (documents,
+                                             g_variant_new_handle (fd_in),
+                                             basename,
+                                             TRUE,
+                                             TRUE,
+                                             fd_list,
+                                             &doc_id,
+                                             NULL,
+                                             NULL,
+                                             error);
+  else
+    ret = xdp_documents_call_add_sync (documents,
+                                       g_variant_new_handle (fd_in),
+                                       TRUE,
+                                       TRUE,
+                                       fd_list,
+                                       &doc_id,
+                                       NULL,
+                                       NULL,
+                                       error);
+  g_object_unref (fd_list);
+
+  if (!ret)
+    return NULL;
+
+  if (!xdp_documents_call_grant_permissions_sync (documents,
+                                                  doc_id,
+                                                  app_id,
+                                                  permissions,
+                                                  NULL,
+                                                  error))
+    return NULL;
+
+  return g_build_filename (documents_mountpoint, doc_id, basename, NULL);
+}

--- a/src/documents.h
+++ b/src/documents.h
@@ -1,0 +1,7 @@
+void init_document_proxy (GDBusConnection *connection);
+
+char *register_document (const char *uri,
+                         const char *app_id,
+                         gboolean for_save,
+                         gboolean writable,
+                         GError **error);

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -14,11 +14,9 @@
 
 #include "file-chooser.h"
 #include "request.h"
+#include "documents.h"
 #include "xdp-dbus.h"
 #include "xdp-impl-dbus.h"
-
-extern XdpDocuments *documents;
-extern char *documents_mountpoint;
 
 typedef struct _FileChooser FileChooser;
 typedef struct _FileChooserClass FileChooserClass;
@@ -44,96 +42,6 @@ G_DEFINE_TYPE_WITH_CODE (FileChooser, file_chooser, XDP_TYPE_FILE_CHOOSER_SKELET
 
 G_LOCK_DEFINE (request_by_handle);
 static GHashTable *request_by_handle;
-
-static char *
-register_document (const char *uri,
-                   gboolean for_save,
-                   const char *app_id,
-                   gboolean writable,
-                   GError **error)
-{
-  g_autofree char *doc_id = NULL;
-  g_autofree char *path = NULL;
-  g_autofree char *basename = NULL;
-  g_autofree char *dirname = NULL;
-  GUnixFDList *fd_list = NULL;
-  int fd, fd_in;
-  g_autoptr(GFile) file = NULL;
-  gboolean ret = FALSE;
-  const char *permissions[5];
-  g_autofree char *fuse_path = NULL;
-  int i;
-
-  if (app_id == NULL || *app_id == 0)
-    return g_strdup (uri);
-
-  file = g_file_new_for_uri (uri);
-  path = g_file_get_path (file);
-  basename = g_path_get_basename (path);
-  dirname = g_path_get_dirname (path);
-
-  if (for_save)
-    fd = open (dirname, O_PATH | O_CLOEXEC);
-  else
-    fd = open (path, O_PATH | O_CLOEXEC);
-
-  if (fd == -1)
-    {
-      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
-                   "Failed to open %s", uri);
-      return NULL;
-    }
-
-  fd_list = g_unix_fd_list_new ();
-  fd_in = g_unix_fd_list_append (fd_list, fd, error);
-  close (fd);
-
-  if (fd_in == -1)
-    return NULL;
-
-  i = 0;
-  permissions[i++] = "read";
-  if (writable)
-    permissions[i++] = "write";
-  permissions[i++] = "grant";
-  permissions[i++] = NULL;
-
-  if (for_save)
-    ret = xdp_documents_call_add_named_sync (documents,
-                                             g_variant_new_handle (fd_in),
-                                             basename,
-                                             TRUE,
-                                             TRUE,
-                                             fd_list,
-                                             &doc_id,
-                                             NULL,
-                                             NULL,
-                                             error);
-  else
-    ret = xdp_documents_call_add_sync (documents,
-                                       g_variant_new_handle (fd_in),
-                                       TRUE,
-                                       TRUE,
-                                       fd_list,
-                                       &doc_id,
-                                       NULL,
-                                       NULL,
-                                       error);
-  g_object_unref (fd_list);
-
-  if (!ret)
-    return NULL;
-
-  if (!xdp_documents_call_grant_permissions_sync (documents,
-                                                  doc_id,
-                                                  app_id,
-                                                  permissions,
-                                                  NULL,
-                                                  error))
-    return NULL;
-
-  return g_build_filename (documents_mountpoint, doc_id, basename, NULL);
-}
 
 static void
 register_handle (const char *handle, Request *request)
@@ -345,7 +253,7 @@ static void emit_response (XdpImplFileChooser *object,
   for (i = 0; arg_uris[i] != NULL; i++)
     {
       const char *uri = arg_uris[i];
-      ruri = register_document (uri, for_save, request->app_id, writable, &error);
+      ruri = register_document (uri, request->app_id, for_save, writable, &error);
       if (ruri == NULL)
         {
           g_warning ("Failed to register %s: %s\n", uri, error->message);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -3,27 +3,18 @@
 #include <locale.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
-#include <gio/gio.h>
-#include <gio/gunixfdlist.h>
 
 #include "xdp-utils.h"
 #include "xdp-dbus.h"
+#include "request.h"
+#include "documents.h"
 #include "file-chooser.h"
 #include "open-uri.h"
 #include "print.h"
-#include "request.h"
 #include "network-monitor.h"
 #include "proxy-resolver.h"
 
 static GMainLoop *loop = NULL;
-XdpDocuments *documents = NULL;
-char *documents_mountpoint = NULL;
 
 static gboolean opt_verbose;
 static gboolean opt_replace;
@@ -278,11 +269,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   xdp_connection_track_name_owners (connection);
 
-  documents = xdp_documents_proxy_new_sync (connection, 0,
-                                            "org.freedesktop.portal.Documents",
-                                            "/org/freedesktop/portal/documents",
-                                            NULL, NULL);
-  xdp_documents_call_get_mount_point_sync (documents, &documents_mountpoint, NULL, NULL);
+  init_document_proxy (connection);
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.AppChooser");
   if (implementation != NULL)


### PR DESCRIPTION
The function to register a file in the documents portal is somewhat
long, and can be used by multiple portals. Break it out into its
own file.