### PR TITLE
Autodetect dying client and implicitly close outstanding requests

### DIFF
--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -74,6 +74,25 @@ lookup_request_by_handle (const char *handle)
 }
 
 static gboolean
+close_request (Request *request, GError **error)
+{
+  if (request->exported)
+    {
+      const char *handle = g_object_get_data (G_OBJECT (request), "impl-handle");
+
+      if (!xdp_impl_file_chooser_call_close_sync (impl,
+                                                  request->sender, request->app_id, handle,
+                                                  NULL, error))
+        return FALSE;
+
+      unregister_handle (handle);
+      request_unexport (request);
+    }
+
+  return TRUE;
+}
+
+static gboolean
 handle_close (XdpRequest *object,
               GDBusMethodInvocation *invocation,
               Request *request)
@@ -82,25 +101,32 @@ handle_close (XdpRequest *object,
 
   REQUEST_AUTOLOCK (request);
 
-  if (request->exported)
+  if (!close_request (request, &error))
     {
-      const char *handle = g_object_get_data (G_OBJECT (request), "impl-handle");
-
-      if (!xdp_impl_file_chooser_call_close_sync (impl,
-                                                  request->sender, request->app_id, handle,
-                                                  NULL, &error))
-        {
-          g_dbus_method_invocation_return_gerror (invocation, error);
-          return TRUE;
-        }
-
-      unregister_handle (handle);
-      request_unexport (request);
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
     }
 
   xdp_request_complete_close (XDP_REQUEST (request), invocation);
 
   return TRUE;
+}
+
+static void
+sender_died (Request *request)
+{
+  REQUEST_AUTOLOCK (request);
+  close_request (request, NULL);
+}
+
+static Request *
+get_request (GDBusMethodInvocation *invocation)
+{
+  Request *request = request_from_invocation (invocation);
+
+  g_signal_connect (request, "sender-died", G_CALLBACK (sender_died), NULL);
+
+  return request;
 }
 
 typedef struct {
@@ -139,7 +165,7 @@ handle_open_file (XdpFileChooser *object,
                   const gchar *arg_title,
                   GVariant *arg_options)
 {
-  Request *request = request_from_invocation (invocation);
+  Request *request = get_request (invocation);
   const char *app_id = request->app_id;
   const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
   g_autoptr(GError) error = NULL;
@@ -181,7 +207,7 @@ handle_open_files (XdpFileChooser *object,
                    const gchar *arg_title,
                    GVariant *arg_options)
 {
-  Request *request = request_from_invocation (invocation);
+  Request *request = get_request (invocation);
   const char *app_id = request->app_id;
   const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
   g_autoptr(GError) error = NULL;
@@ -230,7 +256,7 @@ handle_save_file (XdpFileChooser *object,
                   const gchar *arg_title,
                   GVariant *arg_options)
 {
-  Request *request = request_from_invocation (invocation);
+  Request *request = get_request (invocation);
   const char *app_id = request->app_id;
   const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
   g_autoptr(GError) error = NULL;

--- a/src/print.c
+++ b/src/print.c
@@ -73,6 +73,43 @@ lookup_request_by_handle (const char *handle)
 }
 
 static gboolean
+close_request (Request *request,
+               GError **error)
+{
+  if (request->exported)
+    {
+      const char *handle = g_object_get_data (G_OBJECT (request), "impl-handle");
+
+      if (!xdp_impl_print_call_close_sync (impl,
+                                           request->sender, request->app_id, handle,
+                                           NULL, error))
+        return FALSE;
+
+      unregister_handle (handle);
+      request_unexport (request);
+    }
+
+  return TRUE;
+}
+
+static void
+sender_died (Request *request)
+{
+  REQUEST_AUTOLOCK (request);
+  close_request (request, NULL);
+}
+
+static Request *
+get_request (GDBusMethodInvocation *invocation)
+{
+  Request *request = request_from_invocation (invocation);
+
+  g_signal_connect (request, "sender-died", G_CALLBACK (sender_died), NULL);
+
+  return request;
+}
+
+static gboolean
 handle_close (XdpRequest *object,
               GDBusMethodInvocation *invocation,
               Request *request)
@@ -80,21 +117,10 @@ handle_close (XdpRequest *object,
   g_autoptr(GError) error = NULL;
 
   REQUEST_AUTOLOCK (request);
-
-  if (request->exported)
+  if (!close_request (request, &error))
     {
-      const char *handle = g_object_get_data (G_OBJECT (request), "impl-handle");
-
-      if (!xdp_impl_print_call_close_sync (impl,
-                                           request->sender, request->app_id, handle,
-                                           NULL, &error))
-        {
-          g_dbus_method_invocation_return_gerror (invocation, error);
-          return TRUE;
-        }
-
-      unregister_handle (handle);
-      request_unexport (request);
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
     }
 
   xdp_request_complete_close (XDP_REQUEST (request), invocation);
@@ -110,7 +136,7 @@ handle_print_file (XdpPrint *object,
                   const gchar *arg_filename,
                   GVariant *arg_options)
 {
-  Request *request = request_from_invocation (invocation);
+  Request *request = get_request (invocation);
   const char *app_id = request->app_id;
   const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
   g_autoptr(GError) error = NULL;

--- a/src/request.c
+++ b/src/request.c
@@ -57,6 +57,8 @@ request_finalize (GObject *object)
 {
   Request *request = (Request *)object;
 
+  xdp_unregister_request (request);
+
   G_LOCK (requests);
   g_hash_table_remove (requests, request->id);
   G_UNLOCK (requests);
@@ -125,6 +127,8 @@ request_init_invocation (GDBusMethodInvocation  *invocation, const char *app_id)
   g_hash_table_insert (requests, id, request);
 
   G_UNLOCK (requests);
+
+  xdp_register_request (request);
 
   g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (request),
                                        G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);

--- a/src/request.c
+++ b/src/request.c
@@ -2,6 +2,13 @@
 
 #include <string.h>
 
+enum {
+  SENDER_DIED,
+  LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL];
+
 static void request_skeleton_iface_init (XdpRequestIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Request, request, XDP_TYPE_REQUEST_SKELETON,
@@ -80,6 +87,14 @@ request_class_init (RequestClass *klass)
 
   gobject_class = G_OBJECT_CLASS (klass);
   gobject_class->finalize  = request_finalize;
+
+  signals[SENDER_DIED] = g_signal_new ("sender-died",
+                                       G_TYPE_FROM_CLASS (klass),
+                                       G_SIGNAL_RUN_LAST,
+                                       0,
+                                       NULL, NULL,
+                                       NULL,
+                                       G_TYPE_NONE, 0);
 }
 
 static gboolean
@@ -171,6 +186,12 @@ request_unexport (Request *request)
   request->exported = FALSE;
   g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (request));
   g_object_unref (request);
+}
+
+void
+request_sender_died (Request *request)
+{
+  g_signal_emit (request, signals[SENDER_DIED], 0);
 }
 
 typedef struct {

--- a/src/request.h
+++ b/src/request.h
@@ -28,6 +28,7 @@ Request *request_from_invocation (GDBusMethodInvocation *invocation);
 void request_export (Request *request,
                      GDBusConnection *connection);
 void request_unexport (Request *request);
+void request_sender_died (Request *request);
 
 static inline void
 auto_unlock_helper (GMutex **mutex)

--- a/src/request.h
+++ b/src/request.h
@@ -1,7 +1,5 @@
+#include "xdp-utils.h"
 #include "xdp-dbus.h"
-
-typedef struct _Request Request;
-typedef struct _RequestClass RequestClass;
 
 struct _Request
 {

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -73,6 +73,43 @@ lookup_request_by_handle (const char *handle)
 }
 
 static gboolean
+close_request (Request *request,
+               GError **error)
+{
+  if (request->exported)
+    {
+      const char *handle = g_object_get_data (G_OBJECT (request), "impl-handle");
+
+      if (!xdp_impl_screenshot_call_close_sync (impl,
+                                                request->sender, request->app_id, handle,
+                                                NULL, error))
+        return FALSE;
+
+      unregister_handle (handle);
+      request_unexport (request);
+    }
+
+  return TRUE;
+}
+
+static void
+sender_died (Request *request)
+{
+  REQUEST_AUTOLOCK (request);
+  close_request (request, NULL);
+}
+
+static Request *
+get_request (GDBusMethodInvocation *invocation)
+{
+  Request *request = request_from_invocation (invocation);
+
+  g_signal_connect (request, "sender-died", G_CALLBACK (sender_died), NULL);
+
+  return request;
+}
+
+static gboolean
 handle_close (XdpRequest *object,
               GDBusMethodInvocation *invocation,
               Request *request)
@@ -80,21 +117,10 @@ handle_close (XdpRequest *object,
   g_autoptr(GError) error = NULL;
 
   REQUEST_AUTOLOCK (request);
-
-  if (request->exported)
+  if (!close_request (request, &error))
     {
-      const char *handle = g_object_get_data (G_OBJECT (request), "impl-handle");
-
-      if (!xdp_impl_screenshot_call_close_sync (impl,
-                                                request->sender, request->app_id, handle,
-                                                NULL, &error))
-        {
-          g_dbus_method_invocation_return_gerror (invocation, error);
-          return TRUE;
-        }
-
-      unregister_handle (handle);
-      request_unexport (request);
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
     }
 
   xdp_request_complete_close (XDP_REQUEST (request), invocation);
@@ -108,7 +134,7 @@ handle_screenshot (XdpScreenshot *object,
                    const gchar *arg_parent_window,
                    GVariant *arg_options)
 {
-  Request *request = request_from_invocation (invocation);
+  Request *request = get_request (invocation);
   const char *app_id = request->app_id;
   const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
   g_autoptr(GError) error = NULL;

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -207,6 +207,11 @@ name_owner_changed (GDBusConnection *connection,
 
       if (data)
         {
+          GSList *l;
+
+          for (l = data->requests; l; l = l->next)
+            request_sender_died ((Request *)l->data);
+
           app_id_data_free (data);
         }
     }

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -23,6 +23,9 @@
 
 #include <gio/gio.h>
 
+typedef struct _Request Request;
+typedef struct _RequestClass RequestClass;
+
 char * xdp_invocation_lookup_app_id_sync (GDBusMethodInvocation *invocation,
                                           GCancellable          *cancellable,
                                           GError               **error);

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -30,6 +30,8 @@ char * xdp_invocation_lookup_app_id_sync (GDBusMethodInvocation *invocation,
                                           GCancellable          *cancellable,
                                           GError               **error);
 void   xdp_connection_track_name_owners  (GDBusConnection       *connection);
+void   xdp_register_request              (Request               *request);
+void   xdp_unregister_request            (Request               *request);
 
 
 #endif /* __XDP_UTILS_H__ */


### PR DESCRIPTION
We should get told by dbus when a client dies, and could then close any outstanding Request objects.