### PR TITLE
Clean up requests when sender dies

### DIFF
--- a/src/request.h
+++ b/src/request.h
@@ -54,6 +54,7 @@ Request *request_from_invocation (GDBusMethodInvocation *invocation);
 void request_export (Request *request,
                      GDBusConnection *connection);
 void request_unexport (Request *request);
+void close_requests_for_sender (const char *sender);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpImplRequest, g_object_unref)
 

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "xdp-utils.h"
+#include "request.h"
 
 G_LOCK_DEFINE (app_ids);
 static GHashTable *app_ids;
@@ -171,6 +172,8 @@ name_owner_changed (GDBusConnection *connection,
       if (app_ids)
         g_hash_table_remove (app_ids, name);
       G_UNLOCK (app_ids);
+
+      close_requests_for_sender (name);
     }
 }
 


### PR DESCRIPTION
When we notice a name owner disappearing, clean up all outstanding
requests for that sender, and close dialogs.