### PR TITLE
Need notification portal

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -1,15 +1,17 @@
 introspectiondir = $(datadir)/dbus-1/interfaces
 introspection_DATA = \
+	data/org.freedesktop.portal.Request.xml \
 	data/org.freedesktop.portal.FileChooser.xml \
 	data/org.freedesktop.portal.OpenURI.xml \
 	data/org.freedesktop.portal.Print.xml \
 	data/org.freedesktop.portal.NetworkMonitor.xml \
 	data/org.freedesktop.portal.ProxyResolver.xml \
 	data/org.freedesktop.portal.Screenshot.xml \
-	data/org.freedesktop.portal.Request.xml \
+	data/org.freedesktop.portal.Notification.xml \
+	data/org.freedesktop.impl.portal.Request.xml \
 	data/org.freedesktop.impl.portal.FileChooser.xml \
 	data/org.freedesktop.impl.portal.AppChooser.xml \
 	data/org.freedesktop.impl.portal.Print.xml \
 	data/org.freedesktop.impl.portal.Screenshot.xml \
-	data/org.freedesktop.impl.portal.Request.xml \
+	data/org.freedesktop.impl.portal.Notification.xml \
 	$(NULL)

--- a/data/org.freedesktop.impl.portal.Notification.xml
+++ b/data/org.freedesktop.impl.portal.Notification.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2016 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.impl.portal.Notification:
+      @short_description: Notification portal backend interface
+
+      This notification interface lets sandboxed applications
+      send and withdraw notifications.
+  -->
+  <interface name="org.freedesktop.impl.portal.Notification">
+    <!--
+        AddNotification:
+        @app_id: App id of the application
+        @id: Application-provided ID for this notification
+        @notification: Vardict with the serialized notification
+
+        Sends a notification.
+
+        The ID can be used to later withdraw the notification.
+        If the application reuses the same ID without withdrawing,
+        the notification is replaced by the new one.
+
+        The format of the @notification is the same as for
+        org.freedesktop.portal.Notification.AddNotification().
+    -->
+    <method name="AddNotification">
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="id" direction="in"/>
+      <arg type="a{sv}" name="notification" direction="in"/>
+    </method>
+    <!--
+        RemoveNotification:
+        @app_id: App id of the application
+        @id: Application-provided ID for this notification
+
+        Withdraws a notification.
+    -->
+    <method name="RemoveNotification">
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="id" direction="in"/>
+    </method>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2016 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Notification:
+      @short_description: Portal for sending notifications
+
+      This simple interface lets sandboxed applications send and withdraw
+      notifications. It is not possible for the application to learn
+      if the notification was actually presented to the user. Not a
+      portal in the strict sense, since there is no user interaction.
+
+      Note that in contrast to most other portal requests, notifications
+      are expected to outlast the running application. If a user clicks
+      on a notification after the application has exited, it will get
+      activated again.
+  -->
+  <interface name="org.freedesktop.portal.Notification">
+    <!--
+        AddNotification:
+        @id: Application-provided ID for this notification
+        @notification: Vardict with the serialized notification
+
+        Sends a notification.
+
+        The ID can be used to later withdraw the notification.
+        If the application reuses the same ID without withdrawing,
+        the notification is replaced by the new one.
+
+        The format of the serialized notification is a vardict, with
+        the following supported keys, all of which are optional:
+        <variablelist>
+          <varlistentry>
+            <term>title s</term>
+            <listitem><para>
+              User-visible string to display as the title.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>body s</term>
+            <listitem><para>
+              User-visible string to display as the body.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>icon v</term>
+            <listitem><para>
+              Serialized icon (see g_icon_serialize()).
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>priority s</term>
+            <listitem><para>
+              The priority for the notification. Supported values: low, normal,
+              high, urgent.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>default-action s</term>
+            <listitem><para>
+              Name of an action that is exported by the application. This
+              action will be activated when the user clicks on the notification.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>default-action-target v</term>
+            <listitem><para>
+              Target parameter to send along when activating the default action.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>buttons aa{sv}</term>
+            <listitem><para>
+              Array of serialized buttons to add to the notification.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        The format for serialized buttons is a vardict with the following supported keys:
+        <variablelist>
+          <varlistentry>
+            <term>label s</term>
+            <listitem><para>
+              User-visible label for the button. Mandatory.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>action s</term>
+            <listitem><para>
+              Name of an action that is exported by the application. The action
+              will be activated when the user clicks on the button. Mandatory.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>target v</term>
+            <listitem><para>
+              Target parameter to send along when activating the action.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="AddNotification">
+      <arg type="s" name="id" direction="in"/>
+      <arg type="a{sv}" name="notification" direction="in"/>
+    </method>
+    <!--
+        RemoveNotification:
+        @id: Application-provided ID for this notification
+
+        Withdraws a notification.
+    -->
+    <method name="RemoveNotification">
+      <arg type="s" name="id" direction="in"/>
+    </method>
+  </interface>
+</node>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -8,11 +8,13 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.portal.Screenshot.xml 	\
 	$(top_srcdir)/data/org.freedesktop.portal.NetworkMonitor.xml 	\
 	$(top_srcdir)/data/org.freedesktop.portal.ProxyResolver.xml 	\
+	$(top_srcdir)/data/org.freedesktop.portal.Notification.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Request.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.FileChooser.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.AppChooser.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Print.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Screenshot.xml 	\
+	$(top_srcdir)/data/org.freedesktop.impl.portal.Notification.xml	\
 	$(NULL)
 
 xml_files = 								\
@@ -23,11 +25,13 @@ xml_files = 								\
 	portal-org.freedesktop.portal.Screenshot.xml 			\
 	portal-org.freedesktop.portal.NetworkMonitor.xml		\
 	portal-org.freedesktop.portal.ProxyResolver.xml			\
+	portal-org.freedesktop.portal.Notification.xml			\
 	portal-org.freedesktop.impl.portal.Request.xml 			\
 	portal-org.freedesktop.impl.portal.FileChooser.xml		\
 	portal-org.freedesktop.impl.portal.AppChooser.xml 		\
 	portal-org.freedesktop.impl.portal.Print.xml 			\
 	portal-org.freedesktop.impl.portal.Screenshot.xml 		\
+	portal-org.freedesktop.impl.portal.Notification.xml 		\
 	$(NULL)
 
 EXTRA_DIST = \

--- a/doc/portal-docs.xml
+++ b/doc/portal-docs.xml
@@ -28,6 +28,7 @@
     <xi:include href="portal-org.freedesktop.portal.Screenshot.xml"/>
     <xi:include href="portal-org.freedesktop.portal.NetworkMonitor.xml"/>
     <xi:include href="portal-org.freedesktop.portal.ProxyResolver.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.Notification.xml"/>
   </reference>
   <reference>
     <title>Portal Backend API Reference</title>
@@ -50,5 +51,6 @@
     <xi:include href="portal-org.freedesktop.impl.portal.AppChooser.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Print.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Screenshot.xml"/>
+    <xi:include href="portal-org.freedesktop.impl.portal.Notification.xml"/>
   </reference>
 </book>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -26,6 +26,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.NetworkMonitor.xml \
 	data/org.freedesktop.portal.ProxyResolver.xml \
 	data/org.freedesktop.portal.Screenshot.xml \
+	data/org.freedesktop.portal.Notification.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -34,6 +35,7 @@ PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.AppChooser.xml \
 	data/org.freedesktop.impl.portal.Print.xml \
 	data/org.freedesktop.impl.portal.Screenshot.xml \
+	data/org.freedesktop.impl.portal.Notification.xml \
 	$(NULL)
 
 $(xdp_dbus_built_sources) : $(FLATPAK_IFACE_FILES) $(PORTAL_IFACE_FILES)
@@ -87,6 +89,8 @@ xdg_desktop_portal_SOURCES = \
 	src/proxy-resolver.h		\
 	src/screenshot.c		\
 	src/screenshot.h		\
+        src/notification.c              \
+        src/notification.h              \
 	src/request.c			\
 	src/request.h			\
         src/documents.c                 \

--- a/src/notification.c
+++ b/src/notification.c
@@ -1,0 +1,392 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <gio/gio.h>
+
+#include "notification.h"
+#include "request.h"
+#include "permissions.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+
+#define TABLE_NAME "notifications"
+
+typedef struct _Notification Notification;
+typedef struct _NotificationClass NotificationClass;
+
+struct _Notification
+{
+  XdpNotificationSkeleton parent_instance;
+};
+
+struct _NotificationClass
+{
+  XdpNotificationSkeletonClass parent_class;
+};
+
+static XdpImplNotification *impl;
+static Notification *notification;
+
+GType notification_get_type (void) G_GNUC_CONST;
+static void notification_iface_init (XdpNotificationIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Notification, notification, XDP_TYPE_NOTIFICATION_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_NOTIFICATION, notification_iface_init));
+
+static void
+add_done (GObject *source,
+          GAsyncResult *result,
+          gpointer data)
+{
+  g_autoptr(Request) request = data;
+  g_autoptr(GError) error = NULL;
+
+  if (!xdp_impl_notification_call_add_notification_finish (impl, result, &error))
+    g_warning ("Backend call failed: %s", error->message);
+}
+
+static gboolean
+get_notification_allowed (const char *app_id)
+{
+  g_autoptr(GVariant) out_perms = NULL;
+  g_autoptr(GVariant) out_data = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (!xdp_impl_permission_store_call_lookup_sync (get_permission_store (),
+                                                   TABLE_NAME,
+                                                   "notification",
+                                                   &out_perms,
+                                                   &out_data,
+                                                   NULL,
+                                                   &error))
+    {
+      g_warning ("Error getting permissions: %s", error->message);
+      return TRUE;
+    }
+
+  if (out_perms != NULL)
+    {
+      const char **perms;
+      if (g_variant_lookup (out_perms, app_id, "^a&s", &perms))
+        return !g_strv_contains (perms, "no");
+    }
+
+  return TRUE;
+}
+
+
+static void
+handle_add_in_thread_func (GTask        *task,
+                           gpointer      source_object,
+                           gpointer      task_data,
+                           GCancellable *cancellable)
+{
+  Request *request = (Request *)task_data;
+  const char *id;
+  GVariant *notification;
+
+  REQUEST_AUTOLOCK (request);
+
+  if (!get_notification_allowed (request->app_id))
+    return;
+
+  id = (const char *)g_object_get_data (G_OBJECT (request), "id");
+  notification = (GVariant *)g_object_get_data (G_OBJECT (request), "notification");
+
+  xdp_impl_notification_call_add_notification (impl,
+                                               request->app_id,
+                                               id,
+                                               notification,
+                                               NULL,
+                                               add_done,
+                                               g_object_ref (request));
+}
+
+static gboolean
+check_value_type (const char *key,
+                  GVariant *value,
+                  const GVariantType *type,
+                  GError **error)
+{
+  if (g_variant_is_of_type (value, type))
+    return TRUE;
+
+  g_set_error (error,
+               G_IO_ERROR, G_IO_ERROR_FAILED,
+               "expected type for key %s is %s, found %s",
+               key, (const char *)type, (const char *)g_variant_get_type (value));
+
+  return FALSE;
+}
+
+static gboolean
+check_priority (GVariant *value,
+                GError **error)
+{
+  const char *priorities[] = { "low", "normal", "high", "urgent", NULL };
+
+  if (!check_value_type ("priority", value, G_VARIANT_TYPE_STRING, error))
+    return FALSE;
+
+  if (!g_strv_contains (priorities, g_variant_get_string (value, NULL)))
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "%s not a priority", g_variant_get_string (value, NULL));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+check_button (GVariant *button,
+              GError **error)
+{
+  int i;
+  gboolean has_label = FALSE;
+  gboolean has_action = FALSE;
+
+  for (i = 0; i < g_variant_n_children (button); i++)
+    {
+      const char *key;
+      g_autoptr(GVariant) value = NULL;
+
+      g_variant_get_child (button, i, "{&sv}", &key, &value);
+      if (strcmp (key, "label") == 0)
+        has_label = TRUE;
+      else if (strcmp (key, "action") == 0)
+        has_action = TRUE;
+      else if (strcmp (key, "target") == 0)
+        ;
+      else
+        {
+          g_set_error (error,
+                       G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "%s not valid key", key);
+          return FALSE;
+        }
+    }
+
+  if (!has_label)
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "label key is missing");
+      return FALSE;
+    }
+
+  if (!has_action)
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "action key is missing");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+check_buttons (GVariant *value,
+               GError **error)
+{
+  int i;
+
+  if (!check_value_type ("buttons", value, G_VARIANT_TYPE ("aa{sv}"), error))
+    return FALSE;
+
+  for (i = 0; i < g_variant_n_children (value); i++)
+    {
+      g_autoptr(GVariant) button = g_variant_get_child_value (value, i);
+
+      if (!check_button (button, error))
+        {
+          g_prefix_error (error, "invalid button: ");
+          return FALSE;
+        }
+    }
+  return TRUE;
+}
+
+static gboolean
+check_serialized_icon (GVariant *value,
+                       GError **error)
+{
+  g_autoptr(GIcon) icon = NULL;
+
+  if (g_variant_is_of_type (value, G_VARIANT_TYPE_STRING) ||
+      g_variant_is_of_type (value, G_VARIANT_TYPE("(sv)")))
+    icon = g_icon_deserialize (value);
+
+  if (!icon)
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "invalid icon");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+check_notification (GVariant *notification,
+                    GError **error)
+{
+  int i;
+
+  if (!check_value_type ("notification", notification, G_VARIANT_TYPE_VARDICT, error))
+    return FALSE;
+
+  for (i = 0; i < g_variant_n_children (notification); i++)
+    {
+      const char *key;
+      g_autoptr(GVariant) value = NULL;
+
+      g_variant_get_child (notification, i, "{&sv}", &key, &value);
+      if (strcmp (key, "title") == 0 ||
+          strcmp (key, "body") == 0)
+        {
+          if (!check_value_type (key, value, G_VARIANT_TYPE_STRING, error))
+            return FALSE;
+        }
+      else if (strcmp (key, "icon") == 0)
+        {
+          if (!check_serialized_icon (value, error))
+            return FALSE;
+        }
+      else if (strcmp (key, "priority") == 0)
+        {
+          if (!check_priority (value, error))
+            return FALSE;
+        }
+      else if (strcmp (key, "default-action") == 0)
+        {
+          if (!check_value_type (key, value, G_VARIANT_TYPE_STRING, error))
+            return FALSE;
+        }
+      else if (strcmp (key, "default-action-target") == 0)
+        ;
+      else if (strcmp (key, "buttons") == 0)
+        {
+          if (!check_buttons (value, error))
+            return FALSE;
+        }
+      else
+        {
+          g_set_error (error,
+                       G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "%s not valid key", key);
+          return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
+static gboolean
+notification_handle_add_notification (XdpNotification *object,
+                                      GDBusMethodInvocation *invocation,
+                                      const char *arg_id,
+                                      GVariant *notification)
+{
+  Request *request = request_from_invocation (invocation);
+  g_autoptr(GTask) task = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_object_set_data_full (G_OBJECT (request), "id", g_strdup (arg_id), g_free);
+  g_object_set_data_full (G_OBJECT (request), "notification", g_variant_ref (notification), (GDestroyNotify)g_variant_unref);
+
+  if (!check_notification (notification, &error))
+    {
+      g_prefix_error (&error, "invalid notification: ");
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  task = g_task_new (object, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
+  g_task_run_in_thread (task, handle_add_in_thread_func);
+
+  xdp_notification_complete_add_notification (object, invocation);
+
+  return TRUE;
+}
+
+static gboolean
+notification_handle_remove_notification (XdpNotification *object,
+                                         GDBusMethodInvocation *invocation,
+                                         const char *arg_id)
+{
+  g_autoptr(Request) request = request_from_invocation (invocation);
+
+  xdp_impl_notification_call_remove_notification (impl,
+                                                  request->app_id,
+                                                  arg_id,
+                                                  NULL,
+                                                  NULL, NULL);
+
+  xdp_notification_complete_remove_notification (object, invocation);
+
+  return TRUE;
+}
+
+static void
+notification_class_init (NotificationClass *klass)
+{
+}
+
+static void
+notification_iface_init (XdpNotificationIface *iface)
+{
+  iface->handle_add_notification = notification_handle_add_notification;
+  iface->handle_remove_notification = notification_handle_remove_notification;
+}
+
+static void
+notification_init (Notification *resolver)
+{
+}
+
+GDBusInterfaceSkeleton *
+notification_create (GDBusConnection *connection,
+                     const char *dbus_name)
+{
+  g_autoptr(GError) error = NULL;
+
+  impl = xdp_impl_notification_proxy_new_sync (connection,
+                                               G_DBUS_PROXY_FLAGS_NONE,
+                                               dbus_name,
+                                               "/org/freedesktop/portal/desktop",
+                                               NULL, &error);
+  if (impl == NULL)
+    {
+      g_warning ("Failed to create notification proxy: %s", error->message);
+      return NULL;
+    }
+
+  notification = g_object_new (notification_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (notification);
+}

--- a/src/notification.h
+++ b/src/notification.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * notification_create (GDBusConnection *connection,
+                                              const char *dbus_name);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -36,6 +36,7 @@
 #include "network-monitor.h"
 #include "proxy-resolver.h"
 #include "screenshot.h"
+#include "notification.h"
 
 static GMainLoop *loop = NULL;
 
@@ -314,6 +315,11 @@ on_bus_acquired (GDBusConnection *connection,
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   screenshot_create (connection, implementation->dbus_name));
+
+  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Notification");
+  if (implementation != NULL)
+    export_portal_implementation (connection,
+                                  notification_create (connection, implementation->dbus_name));
 }
 
 static void


### PR DESCRIPTION
We want apps to (optionally) be allowed to send desktop-global notifications. Need a portal for this.

org.gtk.Notifications=talk is not the anwer, because that would be a way to give an app broad access to notifications in a static fashion. What we would like is a more dynamic portal that lets you give/take access to notification at runtime in a similar fashion to how it looks on e.g. iOS or android, or in fact how the GPS access stuff looks in gnome today (i.e. you'll see a list of apps in the control center and you can give individual apps access to it or not. Maybe we can even give multiple levels of access.).
