### PR TITLE
Add an inhibit portal

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -8,10 +8,12 @@ introspection_DATA = \
 	data/org.freedesktop.portal.ProxyResolver.xml \
 	data/org.freedesktop.portal.Screenshot.xml \
 	data/org.freedesktop.portal.Notification.xml \
+	data/org.freedesktop.portal.Inhibit.xml \
 	data/org.freedesktop.impl.portal.Request.xml \
 	data/org.freedesktop.impl.portal.FileChooser.xml \
 	data/org.freedesktop.impl.portal.AppChooser.xml \
 	data/org.freedesktop.impl.portal.Print.xml \
 	data/org.freedesktop.impl.portal.Screenshot.xml \
 	data/org.freedesktop.impl.portal.Notification.xml \
+	data/org.freedesktop.impl.portal.Inhibit.xml \
 	$(NULL)

--- a/data/org.freedesktop.impl.portal.Inhibit.xml
+++ b/data/org.freedesktop.impl.portal.Inhibit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2016 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.impl.portal.Inhibit:
+      @short_description: Inhibit portal backend interface
+
+      The inhibit portal lets sandboxed applications inhibit the user
+      session from ending, suspending, idling or getting switched away.
+  -->
+  <interface name="org.freedesktop.impl.portal.Inhibit">
+    <!--
+        Inhibit:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @app_id: Application id
+        @window: Identifier for the window
+        @flags: Flags identifying what is inhibited
+        @options: Vardict with optional further information
+
+        Inhibits session status changes. As a side-effect of this call,
+        a #org.freedesktop.impl.portal.Request object is exported on the
+        object path @handle. To end the inhibition, call
+        org.freedesktop.impl.portal.Request.Close() on that object.
+
+        The flags determine what changes are inhibited:
+        <simplelist>
+          <member>1: Logout</member>
+          <member>2: User Switch</member>
+          <member>4: Suspend</member>
+          <member>8: Idle</member>
+        </simplelist>
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>reason s</term>
+            <listitem><para>User-visible reason for the inhibition.</para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="Inhibit">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="window" direction="in"/>
+      <arg type="u" name="flags" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+    </method>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2016 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Inhibit:
+      @short_description: Portal for inhibiting session transitions
+
+      This simple interface lets sandboxed applications inhibit the user
+      session from ending, suspending, idling or getting switched away.
+  -->
+  <interface name="org.freedesktop.portal.Inhibit">
+    <!--
+        Inhibit:
+        @window: Identifier for the window
+        @flags: Flags identifying what is inhibited
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Inhibits a session status changes. To remove the inhibition,
+        call org.freedesktop.portal.Request.Close() on the returned
+        handle.
+
+        The flags determine what changes are inhibited:
+        <simplelist>
+          <member>1: Logout</member>
+          <member>2: User Switch</member>
+          <member>4: Suspend</member>
+          <member>8: Idle</member>
+        </simplelist>
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>reason s</term>
+            <listitem><para>User-visible reason for the inhibition.</para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="Inhibit">
+      <arg type="s" name="window" direction="in"/>
+      <arg type="u" name="flags" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+  </interface>
+</node>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -9,12 +9,14 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.portal.NetworkMonitor.xml 	\
 	$(top_srcdir)/data/org.freedesktop.portal.ProxyResolver.xml 	\
 	$(top_srcdir)/data/org.freedesktop.portal.Notification.xml 	\
+	$(top_srcdir)/data/org.freedesktop.portal.Inhibit.xml	 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Request.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.FileChooser.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.AppChooser.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Print.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Screenshot.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Notification.xml	\
+	$(top_srcdir)/data/org.freedesktop.impl.portal.Inhibit.xml	\
 	$(NULL)
 
 xml_files = 								\
@@ -26,12 +28,14 @@ xml_files = 								\
 	portal-org.freedesktop.portal.NetworkMonitor.xml		\
 	portal-org.freedesktop.portal.ProxyResolver.xml			\
 	portal-org.freedesktop.portal.Notification.xml			\
+	portal-org.freedesktop.portal.Inhibit.xml			\
 	portal-org.freedesktop.impl.portal.Request.xml 			\
 	portal-org.freedesktop.impl.portal.FileChooser.xml		\
 	portal-org.freedesktop.impl.portal.AppChooser.xml 		\
 	portal-org.freedesktop.impl.portal.Print.xml 			\
 	portal-org.freedesktop.impl.portal.Screenshot.xml 		\
 	portal-org.freedesktop.impl.portal.Notification.xml 		\
+	portal-org.freedesktop.impl.portal.Inhibit.xml	 		\
 	$(NULL)
 
 EXTRA_DIST = \

--- a/doc/portal-docs.xml
+++ b/doc/portal-docs.xml
@@ -29,6 +29,7 @@
     <xi:include href="portal-org.freedesktop.portal.NetworkMonitor.xml"/>
     <xi:include href="portal-org.freedesktop.portal.ProxyResolver.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Notification.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.Inhibit.xml"/>
   </reference>
   <reference>
     <title>Portal Backend API Reference</title>
@@ -52,5 +53,6 @@
     <xi:include href="portal-org.freedesktop.impl.portal.Print.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Screenshot.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Notification.xml"/>
+    <xi:include href="portal-org.freedesktop.impl.portal.Inhibit.xml"/>
   </reference>
 </book>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -27,6 +27,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.ProxyResolver.xml \
 	data/org.freedesktop.portal.Screenshot.xml \
 	data/org.freedesktop.portal.Notification.xml \
+	data/org.freedesktop.portal.Inhibit.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -36,6 +37,7 @@ PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.Print.xml \
 	data/org.freedesktop.impl.portal.Screenshot.xml \
 	data/org.freedesktop.impl.portal.Notification.xml \
+	data/org.freedesktop.impl.portal.Inhibit.xml \
 	$(NULL)
 
 $(xdp_dbus_built_sources) : $(FLATPAK_IFACE_FILES) $(PORTAL_IFACE_FILES)
@@ -91,6 +93,8 @@ xdg_desktop_portal_SOURCES = \
 	src/screenshot.h		\
         src/notification.c              \
         src/notification.h              \
+        src/inhibit.c                   \
+        src/inhibit.h                   \
 	src/request.c			\
 	src/request.h			\
         src/documents.c                 \

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <gio/gio.h>
+
+#include "inhibit.h"
+#include "request.h"
+#include "permissions.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+
+#define TABLE_NAME "inhibit"
+
+enum {
+  INHIBIT_LOGOUT  = 1,
+  INHIBIT_SWITCH  = 2,
+  INHIBIT_SUSPEND = 4,
+  INHIBIT_IDLE    = 8
+};
+
+#define INHIBIT_ALL (INHIBIT_LOGOUT|INHIBIT_SWITCH|INHIBIT_SUSPEND|INHIBIT_IDLE)
+
+typedef struct _Inhibit Inhibit;
+typedef struct _InhibitClass InhibitClass;
+
+struct _Inhibit
+{
+  XdpInhibitSkeleton parent_instance;
+};
+
+struct _InhibitClass
+{
+  XdpInhibitSkeletonClass parent_class;
+};
+
+static XdpImplInhibit *impl;
+static Inhibit *inhibit;
+
+GType inhibit_get_type (void) G_GNUC_CONST;
+static void inhibit_iface_init (XdpInhibitIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Inhibit, inhibit, XDP_TYPE_INHIBIT_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_INHIBIT, inhibit_iface_init));
+
+static void
+inhibit_done (GObject *source,
+              GAsyncResult *result,
+              gpointer data)
+{
+  g_autoptr(Request) request = data;
+  g_autoptr(GError) error = NULL;
+  if (!xdp_impl_inhibit_call_inhibit_finish (impl, result, &error))
+    g_warning ("Backend call failed: %s", error->message);
+}
+
+static guint32
+get_allowed_inhibit (const char *app_id)
+{
+  g_autoptr(GVariant) out_perms = NULL;
+  g_autoptr(GVariant) out_data = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (!xdp_impl_permission_store_call_lookup_sync (get_permission_store (),
+                                                   TABLE_NAME,
+                                                   "inhibit",
+                                                   &out_perms,
+                                                   &out_data,
+                                                   NULL,
+                                                   &error))
+    {
+      g_warning ("Error getting permissions: %s", error->message);
+      g_clear_error (&error);
+    }
+
+  if (out_perms != NULL)
+    {
+      const char **perms;
+      if (g_variant_lookup (out_perms, app_id, "^a&s", &perms))
+        {
+          guint32 ret = 0;
+          int i;
+
+          for (i = 0; perms[i]; i++)
+            {
+              if (strcmp (perms[i], "logout") == 0)
+                ret |= INHIBIT_LOGOUT;
+              else if (strcmp (perms[i], "switch") == 0)
+                ret |= INHIBIT_SWITCH;
+              else if (strcmp (perms[i], "suspend") == 0)
+                ret |= INHIBIT_SUSPEND;
+              else if (strcmp (perms[i], "idle") == 0)
+                ret |= INHIBIT_IDLE;
+              else
+                g_warning ("unknown inhibit flag in permission store: %s", perms[i]);
+            }
+            return ret;
+        }
+    }
+
+  return INHIBIT_ALL; /* all allowed */
+}
+
+static void
+handle_inhibit_in_thread_func (GTask        *task,
+                               gpointer      source_object,
+                               gpointer      task_data,
+                               GCancellable *cancellable)
+{
+  Request *request = (Request *)task_data;
+  const char *window;
+  guint32 flags;
+  GVariant *options;
+
+  REQUEST_AUTOLOCK (request);
+
+  window = (const char *)g_object_get_data (G_OBJECT (request), "window");
+  flags = GPOINTER_TO_UINT (g_object_get_data (G_OBJECT (request), "flags"));
+  options = (GVariant *)g_object_get_data (G_OBJECT (request), "options");
+
+  flags = flags & get_allowed_inhibit (request->app_id);
+  if (flags == 0)
+    return;
+
+  xdp_impl_inhibit_call_inhibit (impl,
+                                 request->id,
+                                 request->app_id,
+                                 window,
+                                 flags,
+                                 options,
+                                 NULL,
+                                 inhibit_done,
+                                 g_object_ref (request));
+}
+
+static gboolean
+inhibit_handle_inhibit (XdpInhibit *object,
+                        GDBusMethodInvocation *invocation,
+                        const char *arg_window,
+                        guint32 arg_flags,
+                        GVariant *options)
+{
+  Request *request = request_from_invocation (invocation);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpImplRequest) impl_request = NULL;
+  g_autoptr(GTask) task = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  if ((arg_flags & ~INHIBIT_ALL) != 0)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_IO_ERROR, G_IO_ERROR_FAILED,
+                                             "Invalid flags");
+      return TRUE;
+    }
+
+  g_object_set_data_full (G_OBJECT (request), "window", g_strdup (arg_window), g_free);
+  g_object_set_data (G_OBJECT (request), "flags", GUINT_TO_POINTER (arg_flags));
+  g_object_set_data_full (G_OBJECT (request), "options", g_variant_ref (options), (GDestroyNotify)g_variant_unref);
+
+  impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                                  G_DBUS_PROXY_FLAGS_NONE,
+                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                                  request->id,
+                                                  NULL, &error);
+  if (!impl_request)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  request_set_impl_request (request, impl_request);
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  task = g_task_new (object, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
+  g_task_run_in_thread (task, handle_inhibit_in_thread_func);
+
+  xdp_inhibit_complete_inhibit (object, invocation, request->id);
+
+  return TRUE;
+}
+
+static void
+inhibit_class_init (InhibitClass *klass)
+{
+}
+
+static void
+inhibit_iface_init (XdpInhibitIface *iface)
+{
+  iface->handle_inhibit = inhibit_handle_inhibit;
+}
+
+static void
+inhibit_init (Inhibit *resolver)
+{
+}
+
+GDBusInterfaceSkeleton *
+inhibit_create (GDBusConnection *connection,
+                     const char *dbus_name)
+{
+  g_autoptr(GError) error = NULL;
+
+  impl = xdp_impl_inhibit_proxy_new_sync (connection,
+                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          dbus_name,
+                                          "/org/freedesktop/portal/desktop",
+                                          NULL, &error);
+  if (impl == NULL)
+    {
+      g_warning ("Failed to create inhibit proxy: %s", error->message);
+      return NULL;
+    }
+
+  inhibit = g_object_new (inhibit_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (inhibit);
+}

--- a/src/inhibit.h
+++ b/src/inhibit.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * inhibit_create (GDBusConnection *connection,
+                                         const char *dbus_name);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -37,6 +37,7 @@
 #include "proxy-resolver.h"
 #include "screenshot.h"
 #include "notification.h"
+#include "inhibit.h"
 
 static GMainLoop *loop = NULL;
 
@@ -320,6 +321,11 @@ on_bus_acquired (GDBusConnection *connection,
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   notification_create (connection, implementation->dbus_name));
+
+  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Inhibit");
+  if (implementation != NULL)
+    export_portal_implementation (connection,
+                                  inhibit_create (connection, implementation->dbus_name));
 }
 
 static void


### PR DESCRIPTION
This lets sandboxed apps inhibit session status changes, such
as suspend or idle. This is the API that lets movie players
prevent the screensaver from kicking in halfway through the
movie.