### PR TITLE
Simplify filechooser portal api

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -37,7 +37,7 @@
         @response: Numeric response
         @results: Vardict with the results of the call
 
-        Presents a file chooser dialog to the user to open a single file.
+        Presents a file chooser dialog to the user to open one or more files.
 
         The @parent_window identifier must be of the form "x11:$XID" for an X11
         window. Support for other window systems may be added in the future.
@@ -51,68 +51,9 @@
             </para></listitem>
           </varlistentry>
           <varlistentry>
-            <term>filters a(sa(us))</term>
+            <term>multiple b</term>
             <listitem><para>
-              A list of serialized file filters.
-              See org.freedesktop.portal.FileChooser.OpenFile() for details.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>choices a(ssa(ss)s)</term>
-            <listitem><para>
-              A list of serialized combo boxes.
-              See org.freedesktop.portal.FileChooser.OpenFile() for details.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-
-        The following results get returned via the @results vardict:
-        <variablelist>
-          <varlistentry>
-            <term>uris as</term>
-            <listitem><para>
-              An array of strings containing the uri of the selected file.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>choices a(ss)</term>
-            <listitem><para>
-              An array of pairs of strings, corresponding to the passed-in choices.
-              See org.freedesktop.portal.FileChooser.OpenFile() for details.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-    -->
-    <method name="OpenFile">
-      <arg type="o" name="handle" direction="in"/>
-      <arg type="s" name="app_id" direction="in"/>
-      <arg type="s" name="parent_window" direction="in"/>
-      <arg type="s" name="title" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <arg type="u" name="response" direction="out"/>
-      <arg type="a{sv}" name="results" direction="out"/>
-    </method>
-    <!--
-        OpenFiles:
-        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
-        @app_id: App id of the application
-        @parent_window: Identifier for the application window
-        @title: Title for the file chooser dialog
-        @options: Vardict with optional further information
-        @response: Numeric response
-        @results: Vardict with the results of the call
-
-        Presents a file chooser dialog to the user to open multiple files.
-
-        The @parent_window identifier must be of the form "x11:$XID" for an X11
-        window. Support for other window systems may be added in the future.
-
-        Supported keys in the @options vardict include:
-        <variablelist>
-          <varlistentry>
-            <term>accept_label s</term>
-            <listitem><para>
-              The label for the accept button. Mnemonic underlines are allowed.
+              Whether to allow selection of multiple files. Default is no.
             </para></listitem>
           </varlistentry>
           <varlistentry>
@@ -148,7 +89,7 @@
           </varlistentry>
         </variablelist>
     -->
-    <method name="OpenFiles">
+    <method name="OpenFile">
       <arg type="o" name="handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -39,7 +39,7 @@
       @options: Vardict with optional further information
       @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
-      Asks to open a single file.
+      Asks to open a one or more files.
 
       The @parent_window identifier must be of the form "x11:$XID" for an X11
       window. Support for other window systems may be added in the future.
@@ -50,6 +50,12 @@
           <term>accept_label s</term>
           <listitem><para>
             Label for the accept button. Mnemonic underlines are allowed.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>multiple b</term>
+          <listitem><para>
+            Whether multiple files can be selected or not. Default is single-selection.
           </para></listitem>
         </varlistentry>
         <varlistentry>
@@ -100,7 +106,7 @@
         <varlistentry>
           <term>uris as</term>
           <listitem><para>
-            An array of strings containing the uri of the selected file.
+            An array of strings containing the uris of the selected files.
           </para></listitem>
         </varlistentry>
         <varlistentry>
@@ -119,65 +125,6 @@
       </variablelist>
     -->
     <method name="OpenFile">
-      <arg type="s" name="parent_window" direction="in"/>
-      <arg type="s" name="title" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <arg type="o" name="handle" direction="out"/>
-    </method>
-    <!--
-      OpenFiles:
-      @parent_window: Identifier for the application window
-      @title: Title for the file chooser dialog
-      @options: Vardict with optional further information
-      @handle: Object path for the #org.freedesktop.portal.Request object representing this call
-
-      Asks to open multiple files.
-
-      The @parent_window identifier must be of the form "x11:$XID" for an X11
-      window. Support for other window systems may be added in the future.
-
-      Supported keys in the @options vardict include:
-      <variablelist>
-        <varlistentry>
-          <term>accept_label s</term>
-          <listitem><para>
-            Label for the accept button. Mnemonic underlines are allowed.
-          </para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>filters a(sa(us))</term>
-          <listitem><para>
-            List of serialized file filters.
-            See org.freedesktop.portal.FileChooser.OpenFile() for details.
-          </para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>choices a(ssa(ss)s)</term>
-          <listitem><para>
-            List of serialized combo boxes.
-            See org.freedesktop.portal.FileChooser.OpenFile() for details.
-          </para></listitem>
-        </varlistentry>
-      </variablelist>
-
-      The following results get returned via the #org.freedesktop.portal.Request::Response signal:
-      <variablelist>
-        <varlistentry>
-          <term>uris as</term>
-          <listitem><para>
-            An array of strings containing the uris of the selected files.
-          </para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>choices a(ss)</term>
-          <listitem><para>
-            An array of pairs of strings, corresponding to the passed-in choices.
-            See org.freedesktop.portal.FileChooser.OpenFile() for details.
-          </para></listitem>
-        </varlistentry>
-      </variablelist>
-    -->
-    <method name="OpenFiles">
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="title" direction="in"/>
       <arg type="a{sv}" name="options" direction="in"/>

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -382,6 +382,7 @@ check_choices (GVariant *value,
 
 static XdpOptionKey open_file_options[] = {
   { "accept_label", G_VARIANT_TYPE_STRING },
+  { "multiple", G_VARIANT_TYPE_BOOLEAN },
   { "filters", (const GVariantType *)"a(sa(us))" },
   { "choices", (const GVariantType *)"a(ssa(ss)s)" }
 };
@@ -456,83 +457,6 @@ handle_open_file (XdpFileChooser *object,
                                         g_object_ref (request));
 
   xdp_file_chooser_complete_open_file (object, invocation, request->id);
-
-  return TRUE;
-}
-
-static void
-open_files_done (GObject *source,
-                 GAsyncResult *result,
-                 gpointer data)
-{
-  g_autoptr(Request) request = data;
-  guint response;
-  GVariant *options;
-  g_autoptr(GError) error = NULL;
-  g_autoptr(GTask) task = NULL;
-
-  if (!xdp_impl_file_chooser_call_open_files_finish (XDP_IMPL_FILE_CHOOSER (source),
-                                                     &response,
-                                                     &options,
-                                                     result,
-                                                     &error))
-    {
-      g_warning ("Backend call failed: %s", error->message);
-    }
-
-  g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
-  if (options)
-    g_object_set_data_full (G_OBJECT (request), "options", g_variant_ref (options), (GDestroyNotify)g_variant_unref);
-
-  task = g_task_new (NULL, NULL, NULL, NULL);
-  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
-  g_task_run_in_thread (task, send_response_in_thread_func);
-}
-
-static gboolean
-handle_open_files (XdpFileChooser *object,
-                   GDBusMethodInvocation *invocation,
-                   const gchar *arg_parent_window,
-                   const gchar *arg_title,
-                   GVariant *arg_options)
-{
-  Request *request = request_from_invocation (invocation);
-  const char *app_id = request->app_id;
-  g_autoptr(GError) error = NULL;
-  XdpImplRequest *impl_request;
-  GVariantBuilder options;
-
-  REQUEST_AUTOLOCK (request);
-
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
-  xdp_filter_options (arg_options, &options,
-                      open_file_options, G_N_ELEMENTS (open_file_options));
-
-  impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                  G_DBUS_PROXY_FLAGS_NONE,
-                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
-                                                  request->id,
-                                                  NULL, &error);
-  if (!impl_request)
-    {
-      g_dbus_method_invocation_return_gerror (invocation, error);
-      return TRUE;
-    }
-
-  request_set_impl_request (request, impl_request);
-  request_export (request, g_dbus_method_invocation_get_connection (invocation));
-
-  xdp_impl_file_chooser_call_open_files (impl,
-                                         request->id,
-                                         app_id,
-                                         arg_parent_window,
-                                         arg_title,
-                                         g_variant_builder_end (&options),
-                                         NULL,
-                                         open_files_done,
-                                         g_object_ref (request));
-
-  xdp_file_chooser_complete_open_files (object, invocation, request->id);
 
   return TRUE;
 }
@@ -629,7 +553,6 @@ static void
 file_chooser_iface_init (XdpFileChooserIface *iface)
 {
   iface->handle_open_file = handle_open_file;
-  iface->handle_open_files = handle_open_files;
   iface->handle_save_file = handle_save_file;
 }
 


### PR DESCRIPTION
The OpenFile and OpenFiles methods were not really different
enough to justify the code duplication. Just add a boolean
option 'multiple' instead.