### PR TITLE
Fix error using file filters with MIME content types.

### DIFF
--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -224,7 +224,6 @@ check_filter (GVariant *filter,
         }
       else if (type == 1)
         {
-        }
           /* TODO: validate content type */
           if (string[0] == 0)
             {
@@ -234,6 +233,7 @@ check_filter (GVariant *filter,
                                    "invalid content type");
               return FALSE;
             }
+        }
       else
         {
           g_set_error (error,


### PR DESCRIPTION
Opening a chooser with a MIME content type filter gives an "invalid filter type: 1" error. This PR fixes the problem.