### PR TITLE
Supporting different xdg-desktop-portal versions in apps

### DIFF
--- a/data/org.freedesktop.portal.Account.xml
+++ b/data/org.freedesktop.portal.Account.xml
@@ -78,5 +78,6 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Device.xml
+++ b/data/org.freedesktop.portal.Device.xml
@@ -44,5 +44,6 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -213,5 +213,6 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -60,5 +60,6 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.NetworkMonitor.xml
+++ b/data/org.freedesktop.portal.NetworkMonitor.xml
@@ -67,5 +67,6 @@
         </simplelist>
     -->
     <property name="connectivity" type="u" access="read"/>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -154,5 +154,6 @@
       <arg type="s" name="action"/>
       <arg type="av" name="parameter"/>
     </signal>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.OpenURI.xml
+++ b/data/org.freedesktop.portal.OpenURI.xml
@@ -61,5 +61,6 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -370,5 +370,6 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.ProxyResolver.xml
+++ b/data/org.freedesktop.portal.ProxyResolver.xml
@@ -42,5 +42,6 @@
       <arg type="s" name="uri" direction="in"/>
       <arg type="as" name="proxies" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -65,5 +65,6 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/account.c
+++ b/src/account.c
@@ -203,6 +203,37 @@ account_iface_init (XdpAccountIface *iface)
   iface->handle_get_user_information = handle_get_user_information;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+account_set_property (GObject *object,
+                      guint prop_id,
+                      const GValue *value,
+                      GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+account_get_property (GObject *object,
+                      guint prop_id,
+                      GValue *value,
+                      GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+
 static void
 account_init (Account *fc)
 {
@@ -211,6 +242,12 @@ account_init (Account *fc)
 static void
 account_class_init (AccountClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = account_set_property;
+  object_class->get_property = account_get_property;
+
+  xdp_account_override_properties (object_class, PROP_VERSION);
 }
 
 GDBusInterfaceSkeleton *

--- a/src/device.c
+++ b/src/device.c
@@ -327,6 +327,36 @@ device_iface_init (XdpDeviceIface *iface)
   iface->handle_access_device = handle_access_device;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+device_set_property (GObject *object,
+                     guint prop_id,
+                     const GValue *value,
+                     GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+device_get_property (GObject *object,
+                     guint prop_id,
+                     GValue *value,
+                     GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
 static void
 device_init (Device *fc)
 {
@@ -335,6 +365,12 @@ device_init (Device *fc)
 static void
 device_class_init (DeviceClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = device_set_property;
+  object_class->get_property = device_get_property;
+
+  xdp_device_override_properties (object_class, PROP_VERSION);
 }
 
 GDBusInterfaceSkeleton *

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -558,6 +558,36 @@ file_chooser_iface_init (XdpFileChooserIface *iface)
   iface->handle_save_file = handle_save_file;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+file_chooser_set_property (GObject *object,
+                           guint prop_id,
+                           const GValue *value,
+                           GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+file_chooser_get_property (GObject *object,
+                           guint prop_id,
+                           GValue *value,
+                           GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
 static void
 file_chooser_init (FileChooser *fc)
 {
@@ -566,6 +596,12 @@ file_chooser_init (FileChooser *fc)
 static void
 file_chooser_class_init (FileChooserClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = file_chooser_set_property;
+  object_class->get_property = file_chooser_get_property;
+
+  xdp_file_chooser_override_properties (object_class, PROP_VERSION);
 }
 
 GDBusInterfaceSkeleton *

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -204,9 +204,45 @@ inhibit_handle_inhibit (XdpInhibit *object,
   return TRUE;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+inhibit_set_property (GObject *object,
+                      guint prop_id,
+                      const GValue *value,
+                      GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+inhibit_get_property (GObject *object,
+                      guint prop_id,
+                      GValue *value,
+                      GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
 static void
 inhibit_class_init (InhibitClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = inhibit_set_property;
+  object_class->get_property = inhibit_get_property;
+
+  xdp_inhibit_override_properties (object_class, PROP_VERSION);
 }
 
 static void

--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -78,6 +78,37 @@ changed (GNetworkMonitor *monitor,
   xdp_network_monitor_emit_changed (nm, available);
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+network_monitor_set_property (GObject *object,
+                              guint prop_id,
+                              const GValue *value,
+                              GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+network_monitor_get_property (GObject *object,
+                              guint prop_id,
+                              GValue *value,
+                              GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+
 static void
 network_monitor_init (NetworkMonitor *nm)
 {
@@ -97,6 +128,12 @@ network_monitor_init (NetworkMonitor *nm)
 static void
 network_monitor_class_init (NetworkMonitorClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = network_monitor_set_property;
+  object_class->get_property = network_monitor_get_property;
+
+  xdp_network_monitor_override_properties (object_class, PROP_VERSION);
 }
 
 GDBusInterfaceSkeleton *

--- a/src/notification.c
+++ b/src/notification.c
@@ -513,12 +513,6 @@ name_owner_changed (GDBusConnection *connection,
     }
 }
 
-
-static void
-notification_class_init (NotificationClass *klass)
-{
-}
-
 static void
 notification_iface_init (XdpNotificationIface *iface)
 {
@@ -526,9 +520,50 @@ notification_iface_init (XdpNotificationIface *iface)
   iface->handle_remove_notification = notification_handle_remove_notification;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+notification_set_property (GObject *object,
+                           guint prop_id,
+                           const GValue *value,
+                           GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+notification_get_property (GObject *object,
+                           guint prop_id,
+                           GValue *value,
+                           GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
 static void
 notification_init (Notification *resolver)
 {
+}
+
+static void
+notification_class_init (NotificationClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = notification_set_property;
+  object_class->get_property = notification_get_property;
+
+  xdp_notification_override_properties (object_class, PROP_VERSION);
 }
 
 GDBusInterfaceSkeleton *

--- a/src/print.c
+++ b/src/print.c
@@ -260,6 +260,36 @@ print_iface_init (XdpPrintIface *iface)
   iface->handle_prepare_print = handle_prepare_print;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+print_set_property (GObject *object,
+                    guint prop_id,
+                    const GValue *value,
+                    GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+print_get_property (GObject *object,
+                    guint prop_id,
+                    GValue *value,
+                    GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
 static void
 print_init (Print *fc)
 {
@@ -268,6 +298,12 @@ print_init (Print *fc)
 static void
 print_class_init (PrintClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = print_set_property;
+  object_class->get_property = print_get_property;
+
+  xdp_print_override_properties (object_class, PROP_VERSION);
 }
 
 GDBusInterfaceSkeleton *

--- a/src/proxy-resolver.c
+++ b/src/proxy-resolver.c
@@ -67,9 +67,45 @@ proxy_resolver_handle_lookup (XdpProxyResolver *object,
   return TRUE;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+proxy_resolver_set_property (GObject *object,
+                             guint prop_id,
+                             const GValue *value,
+                             GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+proxy_resolver_get_property (GObject *object,
+                             guint prop_id,
+                             GValue *value,
+                             GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
 static void
 proxy_resolver_class_init (ProxyResolverClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = proxy_resolver_set_property;
+  object_class->get_property = proxy_resolver_get_property;
+
+  xdp_proxy_resolver_override_properties (object_class, PROP_VERSION);
 }
 
 static void

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -187,6 +187,36 @@ screenshot_iface_init (XdpScreenshotIface *iface)
   iface->handle_screenshot = handle_screenshot;
 }
 
+enum {
+  PROP_0,
+  PROP_VERSION
+};
+
+static void
+screenshot_set_property (GObject *object,
+                         guint prop_id,
+                         const GValue *value,
+                         GParamSpec *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+screenshot_get_property (GObject *object,
+                         guint prop_id,
+                         GValue *value,
+                         GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_VERSION:
+      g_value_set_uint (value, 1);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
 static void
 screenshot_init (Screenshot *fc)
 {
@@ -195,6 +225,12 @@ screenshot_init (Screenshot *fc)
 static void
 screenshot_class_init (ScreenshotClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = screenshot_set_property;
+  object_class->get_property = screenshot_get_property;
+
+  xdp_screenshot_override_properties (object_class, PROP_VERSION);
 }
 
 GDBusInterfaceSkeleton *


### PR DESCRIPTION
I've looked a little at the portal's documentation and I think there isn't any documented way for a flatpak application to know which version of xdg-desktop-portal is installed in the system it's running on. I also think the apps can't define in their manifest which xdg-desktop-portal version they require to work properly.

This will be important to maintain compatibility with distros that don't upgrade often. For example, if Debian Stretch is released with xdg-desktop-portal 0.1 and camera support is added in version 0.2, applications using this feature will probably won't work in Debian and users won't know it until they try the app.

In Android they have solved [this way](https://developer.android.com/guide/topics/manifest/uses-sdk-element.html):
- Each Android release has an API version
- The apps define in their manifest the minimum and maximum API Levels under which they are able to run, as well as the preferred API Level that they are designed to support. (Note that the docs recommend [not to set a maxSdkVersion](https://developer.android.com/guide/topics/manifest/uses-sdk-element.html))
- The apps can[ check the platform version at runtime](https://developer.android.com/training/basics/supporting-devices/platforms.html#version-codes), in order to offer a degraded experience for older api versons.
