### PR TITLE
notification: Fix copy+paste error

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -419,7 +419,7 @@ remove_done (GObject *source,
   g_autoptr(Request) request = data;
   g_autoptr(GError) error = NULL;
 
-  if (!xdp_impl_notification_call_add_notification_finish (impl, result, &error))
+  if (!xdp_impl_notification_call_remove_notification_finish (impl, result, &error))
     {
       g_warning ("Backend call failed: %s", error->message);
     }


### PR DESCRIPTION
There shouldn't be a difference between the add- and remove-finish
functions, but still ...