### PR TITLE
If the random request ID creates a collision, pick a new random ID.

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -166,9 +166,9 @@ request_init_invocation (GDBusMethodInvocation  *invocation, const char *app_id)
 
   G_LOCK (requests);
 
-  r = g_random_int ();
   do
     {
+      r = g_random_int ();
       g_free (id);
       id = g_strdup_printf ("/org/freedesktop/portal/desktop/request/%u", r);
     }


### PR DESCRIPTION
Fix for bug  #100, avoiding an infinite loop on collisions.