### PR TITLE
Alter pkg-config to reflect the architecture-independent development files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ lib_LTLIBRARIES =
 include data/Makefile.am.inc
 include src/Makefile.am.inc
 
-pkgconfigdir = $(libdir)/pkgconfig
+pkgconfigdir = $(datadir)/pkgconfig
 pkgconfig_DATA = xdg-desktop-portal.pc
 EXTRA_DIST += xdg-desktop-portal.pc.in
 

--- a/xdg-desktop-portal.pc.in
+++ b/xdg-desktop-portal.pc.in
@@ -1,8 +1,5 @@
 prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
 datarootdir=@datarootdir@
-includedir=@includedir@
 datadir=@datadir@
 
 interfaces_dir=${datadir}/dbus-1/interfaces/

--- a/xdg-desktop-portal.pc.in
+++ b/xdg-desktop-portal.pc.in
@@ -10,5 +10,3 @@ interfaces_dir=${datadir}/dbus-1/interfaces/
 Name: xdg-desktop-portal
 Description: Desktop integration portal
 Version: @VERSION@
-Requires: glib-2.0 gio-2.0 flatpak
-Requires.private: gio-unix-2.0


### PR DESCRIPTION
xdg-desktop-portal's .pc file is written as though it described a library that is linked to libflatpak and GLib, but in fact the only development files in xdg-desktop-portal are D-Bus introspection XML used as an interface description language.

This forces having Flatpak development files (libflatpak-dev or flatpak-devel depending on distribution) when developing against xdg-desktop-portal and checking for it with pkg-config, even though that is not actually necessary: it is true to say that xdg-desktop-portal depends on Flatpak and GLib *at runtime*, but .pc files are all about development dependencies rather than runtime dependencies.

The .pc file can also be installed in /usr/share/pkgconfig instead of /usr/lib/pkgconfig (or /usr/lib64 or /usr/lib/x86_64-linux-gnu or whatever the right ${libdir} is for the current distribution).

[yelp-xsl](https://sources.debian.net/src/yelp-xsl/3.20.1-2/yelp-xsl.pc.in/) and [wayland-protocols](https://sources.debian.net/src/wayland-protocols/1.7-1/wayland-protocols.pc.in/) are good examples of similar data packages with .pc files.