### PR TITLE
Make email portal race narrower

### DIFF
--- a/src/email.c
+++ b/src/email.c
@@ -153,6 +153,8 @@ handle_compose_email (XdpEmail *object,
   xdp_filter_options (arg_options, &options,
                       compose_email_options, G_N_ELEMENTS (compose_email_options));
 
+  xdp_email_complete_compose_email (object, invocation, request->id);
+
   xdp_impl_email_call_compose_email (impl,
                                      request->id,
                                      app_id,
@@ -161,8 +163,6 @@ handle_compose_email (XdpEmail *object,
                                      NULL,
                                      compose_email_done,
                                      g_object_ref (request));
-
-  xdp_email_complete_compose_email (object, invocation, request->id);
 
   return TRUE;
 }


### PR DESCRIPTION
The portal API pattern is inherently racy: The app receives the
response call with the handle of the Request object, but the
Response signal may have already been emitted from the portal
by the time the app has set up a listener for it. Normally, this
should not matter, since the portal api is expected to involve user
interaction - by the time the user is done with a dialog, the
app has certainly established its signal listener.

But, in the case of the email portal, we don't wait for the
'dialog' to be done, we simply launch the email client and
return, which can be rather quick.

To make this race less likely, at least complete the ComposeEmail
call before forwarding it to the backend.