### PR TITLE
Change the email portal api to take fds

### DIFF
--- a/data/org.freedesktop.portal.Email.xml
+++ b/data/org.freedesktop.portal.Email.xml
@@ -26,7 +26,7 @@
       This simple portal lets sandboxed applications request to send an email,
       optionally providing an address, subject, body and attachments.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Email">
     <!--
@@ -69,9 +69,9 @@
             </para></listitem>
           </varlistentry>
           <varlistentry>
-            <term>attachments as</term>
+            <term>attachment_fds ah</term>
             <listitem><para>
-              The uris for files to attach.
+              File descriptors for files to attach.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -59,6 +59,7 @@ $(xdp_dbus_built_sources) : $(FLATPAK_IFACE_FILES) $(PORTAL_IFACE_FILES)
 		--annotate "org.freedesktop.portal.Documents.AddNamed()" "org.gtk.GDBus.C.UnixFD" "true" \
 		--annotate "org.freedesktop.portal.Print.Print()" "org.gtk.GDBus.C.UnixFD" "true" \
 		--annotate "org.freedesktop.portal.OpenURI.OpenFile()" "org.gtk.GDBus.C.UnixFD" "true" \
+		--annotate "org.freedesktop.portal.Email.ComposeEmail()" "org.gtk.GDBus.C.UnixFD" "true" \
 		$^ \
 		$(NULL)
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -493,24 +493,10 @@ handle_open_in_thread_func (GTask *task,
     }
   else
     {
-      g_autofree char *proc_path = NULL;
-      int fd_flags;
-      char path_buffer[PATH_MAX + 1];
-      g_autofree char *rewritten_path = NULL;
-      char *path;
-      ssize_t symlink_size;
-      struct stat st_buf;
-      struct stat real_st_buf;
+      g_autofree char *path = NULL;
 
-      proc_path = g_strdup_printf ("/proc/self/fd/%d", fd);
-
-      if (fd == -1 ||
-          (fd_flags = fcntl (fd, F_GETFL)) == 0 ||
-          ((fd_flags & O_PATH) != O_PATH) ||
-          ((fd_flags & O_NOFOLLOW) == O_NOFOLLOW) ||
-          fstat (fd, &st_buf) < 0 ||
-          (st_buf.st_mode & S_IFMT) != S_IFREG ||
-          (symlink_size = readlink (proc_path, path_buffer, PATH_MAX)) < 0)
+      path = xdp_get_path_for_fd (request->app_info, fd);
+      if (path == NULL)
         {
           /* Reject the request */
           if (request->exported)
@@ -520,53 +506,6 @@ handle_open_in_thread_func (GTask *task,
               request_unexport (request);
             }
           return;
-        }
-
-      path_buffer[symlink_size] = 0;
-
-      path = path_buffer;
-
-      if (request->app_info != NULL)
-        {
-          if (g_str_has_prefix (path, "/newroot/usr/"))
-            {
-              g_autofree char * usr_root =
-                g_key_file_get_string (request->app_info,
-                                       "Instance", "runtime-path", NULL);
-              if (usr_root)
-                {
-                  rewritten_path = g_build_filename (usr_root, path + strlen ("/newroot/usr/"), NULL);
-                  path = rewritten_path;
-                }
-            }
-          else if (g_str_has_prefix (path, "/newroot/app/"))
-            {
-              g_autofree char * app_root =
-                g_key_file_get_string (request->app_info,
-                                       "Instance", "app-path", NULL);
-              if (app_root)
-                {
-                  rewritten_path = g_build_filename (app_root, path + strlen ("/newroot/app/"), NULL);
-                  path = rewritten_path;
-                }
-            }
-          else if (g_str_has_prefix (path, "/newroot/"))
-            path = path + strlen ("/newroot");
-
-          /* Verify that this is the same file as the app opened */
-          if (stat (path, &real_st_buf) < 0 ||
-              st_buf.st_dev != real_st_buf.st_dev ||
-              st_buf.st_ino != real_st_buf.st_ino)
-            {
-              /* Different files on the inside and the outside, reject the request */
-              if (request->exported)
-                {
-                  g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
-                  xdp_request_emit_response (XDP_REQUEST (request), 2, g_variant_builder_end (&opts_builder));
-                  request_unexport (request);
-                }
-              return;
-            }
         }
 
       get_content_type_for_file (path, &content_type);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -326,7 +326,7 @@ xdp_get_path_for_fd (GKeyFile *app_info,
   char path_buffer[PATH_MAX + 1];
   g_autofree char *rewritten_path = NULL;
   char *path;
-  ssize_t symlink_size;
+  ssize_t symlink_size = 0;
   struct stat st_buf;
   struct stat real_st_buf;
 

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -58,3 +58,6 @@ typedef enum {
 #define XDG_DESKTOP_PORTAL_ERROR xdg_desktop_portal_error_quark ()
 
 GQuark  xdg_desktop_portal_error_quark (void);
+
+char *xdp_get_path_for_fd (GKeyFile *app_info,
+                           int fd);


### PR DESCRIPTION
This not only fixes the issue of guaranteeing that the sandboxed app has access to the file it wants to attach, it also fixes the problem where /tmp inside the sandbox is different from /tmp outside the sandbox, since we do the necessary path translation here to make sure that the portal backend gets a path that it can access.