### PR TITLE
Add screen cast portal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,15 @@ PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0])
 AC_SUBST(BASE_CFLAGS)
 AC_SUBST(BASE_LIBS)
 
+AC_ARG_ENABLE(pipewire,
+	      [AS_HELP_STRING([--enable-pipewire],[Enable PipeWire support. Needed for screen cast portal])],
+	      enable_pipewire=$enableval, enable_pipewire=yes)
+if test x$enable_pipewire = xyes ; then
+	PKG_CHECK_MODULES(PIPEWIRE, [libpipewire-0.1 >= 0.1.8])
+	AC_DEFINE([HAVE_PIPEWIRE],[1], [Define to enable PipeWire support])
+fi
+AM_CONDITIONAL([HAVE_PIPEWIRE],[test "$enable_pipewire" = "yes"])
+
 PKG_CHECK_EXISTS([flatpak],
                  [AC_SUBST([FLATPAK_INTERFACES_DIR],
                            [`$PKG_CONFIG --variable=interfaces_dir flatpak`])],

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -1,6 +1,7 @@
 introspectiondir = $(datadir)/dbus-1/interfaces
 dist_introspection_DATA = \
 	data/org.freedesktop.portal.Request.xml \
+	data/org.freedesktop.portal.Session.xml \
 	data/org.freedesktop.portal.FileChooser.xml \
 	data/org.freedesktop.portal.OpenURI.xml \
 	data/org.freedesktop.portal.Print.xml \
@@ -13,6 +14,7 @@ dist_introspection_DATA = \
 	data/org.freedesktop.portal.Account.xml \
 	data/org.freedesktop.portal.Email.xml \
 	data/org.freedesktop.impl.portal.Request.xml \
+	data/org.freedesktop.impl.portal.Session.xml \
 	data/org.freedesktop.impl.portal.FileChooser.xml \
 	data/org.freedesktop.impl.portal.AppChooser.xml \
 	data/org.freedesktop.impl.portal.Print.xml \

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -13,6 +13,7 @@ dist_introspection_DATA = \
 	data/org.freedesktop.portal.Device.xml \
 	data/org.freedesktop.portal.Account.xml \
 	data/org.freedesktop.portal.Email.xml \
+	data/org.freedesktop.portal.ScreenCast.xml \
 	data/org.freedesktop.impl.portal.Request.xml \
 	data/org.freedesktop.impl.portal.Session.xml \
 	data/org.freedesktop.impl.portal.FileChooser.xml \
@@ -24,4 +25,5 @@ dist_introspection_DATA = \
 	data/org.freedesktop.impl.portal.Access.xml \
 	data/org.freedesktop.impl.portal.Account.xml \
 	data/org.freedesktop.impl.portal.Email.xml \
+	data/org.freedesktop.impl.portal.ScreenCast.xml \
 	$(NULL)

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2017 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.impl.portal.ScreenCast:
+      @short_description: Screen cast portal
+  -->
+  <interface name="org.freedesktop.impl.portal.ScreenCast">
+    <!--
+        CreateSession:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session being created
+        @app_id: App id of the application
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Create a screen cast session.
+
+        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>session_id s</term>
+            <listitem><para>
+              The session id. A string representing the created screen cast session.
+            </para></listitem>
+          </varlistentry>
+      </variablelist>
+    -->
+    <method name="CreateSession">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+    <!--
+        SelectSources:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @app_id: App id of the application
+        @session_id: Session identifier
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Configure what the screen cast session should record.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>types u</term>
+            <listitem><para>
+              Bitmask of what type of content to record. Default is MONITOR.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>multiple b</term>
+            <listitem><para>
+              Whether to allow selecting multiple sources. Default is no.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        For available source types, see the AvailableSourceTypes property.
+    -->
+    <method name="SelectSources">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+    <!--
+        Start:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @app_id: App id of the application
+        @parent_window: Identifier for the application window
+        @session_id: Identifier for the screen cast session
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Start the screen cast session. This will typically result the portal presenting
+        a dialog letting the user do the selection set up by SelectSources.
+
+        The @parent_window identifier must be of the form "x11:$XID" for an X11
+        window. Support for other window systems may be added in the future.
+
+        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>streams a(ua{sv})</term>
+            <listitem><para>
+              An array of PipeWire streams. Each stream consists of a PipeWire
+              node ID (the first element in the tuple, and a Vardict of
+              properties.
+
+              The array will contain a single stream if 'multiple' (see
+              SelectSources) was set to 'false', or at least one stream if
+              'multiple' was set to 'true' as part of the SelectSources method.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        Stream properties include:
+        <variablelist>
+          <varlistentry>
+            <term>position (ii)</term>
+            <listitem><para>
+              A tuple consisting of the position (x, y) in the compositor
+              coordinate space. Note that the position may not be equivalent to a
+              position in a pixel coordinate space. Only available for monitor
+              streams.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>size (ii)</term>
+            <listitem><para>
+              A tuple consisting of (width, height). The size represents the size
+              of the stream as it is displayed in the compositor coordinate
+              space. Note that this size may not be equivalent to a size in a
+              pixel coordinate space. The size may differ from the size of the
+              stream.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="Start">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+    <!--
+        AvailableSourceTypes:
+
+        A bitmask of available source types. Currently defined types are:
+
+        <simplelist>
+          <member>1: MONITOR</member>
+          <member>2: WINDOW</member>
+        </simplelist>
+    -->
+    <property name="AvailableSourceTypes" type="u" access="read"/>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.impl.portal.Session.xml
+++ b/data/org.freedesktop.impl.portal.Session.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2017 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Jonas Ådahl <jadahl@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.impl.portal.Session:
+      @short_description: Shared session interface
+
+      The Session interface is shared by all portal interfaces that involve
+      long lived sessions.  When a method that creates a session is called, the
+      reply will include a session handle (i.e. object path) for a Session
+      object, which will stay alive for the duration of the session.
+
+      The portal can abort the interaction by calling
+      org.freedesktop.impl.portal.Session.Close() on the Session object.
+  -->
+  <interface name="org.freedesktop.impl.portal.Session">
+
+    <!--
+        Close:
+
+        Close the session.
+    -->
+    <method name="Close">
+    </method>
+
+    <!--
+        Closed:
+
+        The session was closed by the portal implementation.
+    -->
+    <signal name="Closed">
+    </signal>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2017-2018 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.ScreenCast:
+      @short_description: Screen cast portal
+  -->
+  <interface name="org.freedesktop.portal.ScreenCast">
+    <!--
+        CreateSession:
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Create a screen cast session. A successfully created session can at
+        any time be closed using org.freedesktop.portal.Session::Close, or may
+        at any time be closed by the portal implementation, which will be
+        signalled via org.freedesktop.portal.Session::Closed.
+
+        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>session_handle o</term>
+            <listitem><para>
+              The session handle. An object path for the
+              #org.freedesktop.portal.Session object representing the created
+              session.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="CreateSession">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+    <!--
+        SelectSources:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Configure what the screen cast session should record. This method must
+        be called before starting the session.
+
+        Passing invalid input to this method will cause the session to be
+        closed. An application may only attempt to select sources once per
+        session.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>type u</term>
+            <listitem><para>
+              Bitmask of what types of content to record. Default is MONITOR.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>multiple b</term>
+            <listitem><para>
+              Whether to allow selecting multiple sources. Default is no.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        For available source types, see the AvailableSourceTypes property.
+    -->
+    <method name="SelectSources">
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+    <!--
+        Start:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @parent_window: Identifier for the application window
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Start the screen cast session. This will typically result the portal
+        presenting a dialog letting the user do the selection set up by
+        SelectSources. An application can only attempt start a session once.
+
+        A screen cast session may only be started after having selected sources
+        using org.freedesktop.portal.ScreenCast::SelectSources.
+
+        The @parent_window identifier must be of the form "x11:$XID" for an X11
+        window. Support for other window systems may be added in the future.
+
+        The following results get returned via the
+        #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>streams a(ua{sv})</term>
+            <listitem><para>
+              An array of PipeWire streams. Each stream consists of a PipeWire
+              node ID (the first element in the tuple, and a Vardict of
+              properties.
+
+              The array will contain a single stream if 'multiple' (see
+              SelectSources) was set to 'false', or at least one stream if
+              'multiple' was set to 'true' as part of the SelectSources method.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        Stream properties include:
+        <variablelist>
+          <varlistentry>
+            <term>position (ii)</term>
+            <listitem><para>
+              A tuple consisting of the position (x, y) in the compositor
+              coordinate space. Note that the position may not be equivalent to a
+              position in a pixel coordinate space. Only available for monitor
+              streams.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>size (ii)</term>
+            <listitem><para>
+              A tuple consisting of (width, height). The size represents the size
+              of the stream as it is displayed in the compositor coordinate
+              space. Note that this size may not be equivalent to a size in a
+              pixel coordinate space. The size may differ from the size of the
+              stream.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="Start">
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+    <!--
+        OpenPipeWireRemote:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @options: Vardict with optional further information
+        @fd: File descriptor of an open PipeWire remote.
+
+        Open a file descriptor to the PipeWire remote where the screen cast
+        streams are available. The file descriptor should be used to create a
+        <classname>pw_remote</classname> object, by using
+        <function>pw_remote_connect_fd</function>. Only the screen cast stream
+        nodes will be available from this PipeWire node.
+    -->
+    <method name="OpenPipeWireRemote">
+      <annotation name="org.gtk.GDBus.C.Name" value="open_pipewire_remote"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="h" name="fd" direction="out"/>
+    </method>
+    <!--
+        AvailableSourceTypes:
+
+        A bitmask of available source types. Currently defined types are:
+
+        <simplelist>
+          <member>1: MONITOR</member>
+          <member>2: WINDOW</member>
+        </simplelist>
+    -->
+    <property name="AvailableSourceTypes" type="u" access="read"/>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.Session.xml
+++ b/data/org.freedesktop.portal.Session.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2017 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Jonas Ådahl <jadahl@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Session:
+      @short_description: Shared session interface
+
+      The Session interface is shared by all portal interfaces that involve
+      long lived sessions.  When a method that creates a session is called, if
+      succesful, the reply will include a session handle (i.e. object path) for
+      a Session object, which will stay alive for the duration of the session.
+
+      The duration of the session is defined by the interface that creates it.
+      For convenience, the interface contains a method
+      org.freedesktop.portal.Session.Close(), and a signal
+      org.freedesktop.portal.Session::Closed. Whether it is allowed to directly
+      call Close() depends on the interface.
+
+      The handle of a session will be of the form
+      /org/freedesktop/portal/desktop/session/SENDER/TOKEN, where SENDER is the
+      callers unique name, with the initial ':' removed and all '.' replaced by
+      '_', and TOKEN is a unique token that the caller provided with the
+      session_handle_token key in the options vardict of the method creating
+      the session.
+
+      The token that the caller provides should be unique and not guessable. To
+      avoid clashes with calls made from unrelated libraries, it is a good idea
+      to use a per-library prefix combined with a random number.
+
+      A client who started a session vanishing from the D-Bus is equivalent to
+      closing all active sessions made by said client.
+  -->
+  <interface name="org.freedesktop.portal.Session">
+
+    <!--
+        Close:
+
+        Closes the portal session to which this object refers and ends all
+        related user interaction (dialogs, etc).
+    -->
+    <method name="Close">
+    </method>
+
+    <!--
+        Closed:
+        @details: A key value Vardict with details about the closed session.
+
+        Emitted when a session is closed.
+
+        The content of @details is specified by the interface creating the session.
+    -->
+    <signal name="Closed">
+      <arg type="a{sv}" name="details"/>
+    </signal>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -24,6 +24,7 @@ FLATPAK_IMPL_IFACE_FILES =\
 
 PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.Request.xml \
+	data/org.freedesktop.portal.Session.xml \
 	data/org.freedesktop.portal.FileChooser.xml \
 	data/org.freedesktop.portal.OpenURI.xml \
 	data/org.freedesktop.portal.Print.xml \
@@ -39,6 +40,7 @@ PORTAL_IFACE_FILES =\
 
 PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.Request.xml \
+	data/org.freedesktop.impl.portal.Session.xml \
 	data/org.freedesktop.impl.portal.FileChooser.xml \
 	data/org.freedesktop.impl.portal.AppChooser.xml \
 	data/org.freedesktop.impl.portal.Print.xml \
@@ -120,6 +122,8 @@ xdg_desktop_portal_SOURCES = \
         src/permissions.h               \
         src/email.c                     \
         src/email.h                     \
+	src/session.c			\
+	src/session.h			\
 	src/xdp-utils.c			\
 	src/xdp-utils.h			\
 	$(NULL)

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -36,6 +36,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.Device.xml \
 	data/org.freedesktop.portal.Account.xml \
 	data/org.freedesktop.portal.Email.xml \
+	data/org.freedesktop.portal.ScreenCast.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -50,6 +51,7 @@ PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.Access.xml \
 	data/org.freedesktop.impl.portal.Account.xml \
 	data/org.freedesktop.impl.portal.Email.xml \
+	data/org.freedesktop.impl.portal.ScreenCast.xml \
 	$(NULL)
 
 $(xdp_dbus_built_sources) : $(FLATPAK_IFACE_FILES) $(PORTAL_IFACE_FILES)
@@ -130,9 +132,16 @@ xdg_desktop_portal_SOURCES = \
 	src/xdp-utils.h			\
 	$(NULL)
 
-xdg_desktop_portal_LDADD = $(BASE_LIBS)
+if HAVE_PIPEWIRE
+xdg_desktop_portal_SOURCES += \
+	src/screen-cast.c		\
+	src/screen-cast.h		\
+	$(NULL)
+endif
+
+xdg_desktop_portal_LDADD = $(BASE_LIBS) $(PIPEWIRE_LIBS)
 xdg_desktop_portal_CFLAGS = \
-	-DPKGDATADIR=\"$(pkgdatadir)\" $(BASE_CFLAGS) \
+	-DPKGDATADIR=\"$(pkgdatadir)\" $(BASE_CFLAGS) $(PIPEWIRE_CFLAGS) \
 	-I$(srcdir)/src -I$(builddir)/src \
 	$(NULL)
 xdg_desktop_portal_CPPFLAGS = \

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -116,6 +116,8 @@ xdg_desktop_portal_SOURCES = \
         src/account.h                   \
 	src/request.c			\
 	src/request.h			\
+	src/call.c			\
+	src/call.h			\
         src/documents.c                 \
         src/documents.h                 \
         src/permissions.c               \

--- a/src/call.c
+++ b/src/call.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "call.h"
+
+static void
+call_free (Call *call)
+{
+  g_free (call->app_id);
+  g_free (call->sender);
+  g_free (call);
+}
+
+void
+call_init_invocation (GDBusMethodInvocation *invocation,
+                      const char *app_id)
+{
+  Call *call;
+
+  call = g_new0 (Call, 1);
+  call->app_id = g_strdup (app_id);
+  call->sender = g_strdup (g_dbus_method_invocation_get_sender (invocation));
+
+  g_object_set_data_full (G_OBJECT (invocation), "call",
+                          call, (GDestroyNotify) call_free);
+}
+
+Call *
+call_from_invocation (GDBusMethodInvocation *invocation)
+{
+  return g_object_get_data (G_OBJECT (invocation), "call");
+}

--- a/src/call.h
+++ b/src/call.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+typedef struct _Call
+{
+  char *app_id;
+  char *sender;
+  GKeyFile *app_info;
+} Call;
+
+void call_init_invocation (GDBusMethodInvocation *invocation,
+                           const char *app_id);
+
+Call *call_from_invocation (GDBusMethodInvocation *invocation);

--- a/src/request.c
+++ b/src/request.c
@@ -225,6 +225,26 @@ get_token (GDBusMethodInvocation *invocation)
     {
       options = g_variant_get_child_value (parameters, 1);
     }
+  else if (strcmp (interface, "org.freedesktop.portal.ScreenCast") == 0)
+    {
+      if (strcmp (method, "CreateSession") == 0 )
+        {
+          options = g_variant_get_child_value (parameters, 0);
+        }
+      else if (strcmp (method, "SelectSources") == 0)
+        {
+          options = g_variant_get_child_value (parameters, 1);
+        }
+      else if (strcmp (method, "Start") == 0)
+        {
+          options = g_variant_get_child_value (parameters, 2);
+        }
+      else
+        {
+          g_warning ("Support for %s::%s missing in %s",
+                     interface, method, G_STRLOC);
+        }
+    }
   else
     {
       g_print ("Support for %s missing in " G_STRLOC, interface);

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -1,0 +1,1120 @@
+/*
+ * Copyright © 2017-2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <stdint.h>
+#include <pipewire/pipewire.h>
+#include <gio/gunixfdlist.h>
+
+#include "session.h"
+#include "screen-cast.h"
+#include "request.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+#include "xdp-utils.h"
+
+typedef struct _PipeWireRemote
+{
+  struct pw_main_loop *loop;
+  struct pw_core *core;
+  struct pw_remote *remote;
+  struct spa_hook remote_listener;
+
+  uint32_t registry_sync_seq;
+  uint32_t node_factory_id;
+
+  GError *error;
+} PipeWireRemote;
+
+typedef struct _ScreenCast ScreenCast;
+typedef struct _ScreenCastClass ScreenCastClass;
+
+struct _ScreenCast
+{
+  XdpScreenCastSkeleton parent_instance;
+};
+
+struct _ScreenCastClass
+{
+  XdpScreenCastSkeletonClass parent_class;
+};
+
+static XdpImplScreenCast *impl;
+static ScreenCast *screen_cast;
+static gboolean is_pipewire_initialized = FALSE;
+
+GType screen_cast_get_type (void);
+static void screen_cast_iface_init (XdpScreenCastIface *iface);
+
+static GQuark quark_request_session;
+
+typedef struct _ScreenCastStream
+{
+  uint32_t id;
+} ScreenCastStream;
+
+G_DEFINE_TYPE_WITH_CODE (ScreenCast, screen_cast, XDP_TYPE_SCREEN_CAST_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_SCREEN_CAST,
+                                                screen_cast_iface_init))
+
+typedef enum _ScreenCastSessionState
+{
+  SCREEN_CAST_SESSION_STATE_INIT,
+  SCREEN_CAST_SESSION_STATE_SELECTING_SOURCES,
+  SCREEN_CAST_SESSION_STATE_SOURCES_SELECTED,
+  SCREEN_CAST_SESSION_STATE_STARTING,
+  SCREEN_CAST_SESSION_STATE_STARTED,
+  SCREEN_CAST_SESSION_STATE_CLOSED
+} ScreenCastSessionState;
+
+typedef struct _ScreenCastSession
+{
+  Session parent;
+
+  ScreenCastSessionState state;
+
+  GList *streams;
+} ScreenCastSession;
+
+typedef struct _ScreenCastSessionClass
+{
+  SessionClass parent_class;
+} ScreenCastSessionClass;
+
+GType screen_cast_session_get_type (void);
+
+G_DEFINE_TYPE (ScreenCastSession, screen_cast_session, session_get_type ())
+
+static gboolean
+is_screen_cast_session (Session *session)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (session, screen_cast_session_get_type ());
+}
+
+static ScreenCastSession *
+screen_cast_session_new (GVariant *options,
+                         Request *request,
+                         GError **error)
+{
+  Session *session;
+  GDBusInterfaceSkeleton *interface_skeleton =
+    G_DBUS_INTERFACE_SKELETON (request);
+  const char *session_token;
+  GDBusConnection *connection =
+    g_dbus_interface_skeleton_get_connection (interface_skeleton);
+  GDBusConnection *impl_connection =
+    g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
+  const char *impl_dbus_name = g_dbus_proxy_get_name (G_DBUS_PROXY (impl));
+
+  session_token = lookup_session_token (options);
+  session = g_initable_new (screen_cast_session_get_type (), NULL, error,
+                            "sender", request->sender,
+                            "app-id", request->app_id,
+                            "token", session_token,
+                            "connection", connection,
+                            "impl-connection", impl_connection,
+                            "impl-dbus-name", impl_dbus_name,
+                            NULL);
+
+  g_debug ("screen cast session owned by '%s' created",
+           session->sender);
+
+  return (ScreenCastSession*)session;
+}
+
+static void
+create_session_done (GObject *source_object,
+                     GAsyncResult *res,
+                     gpointer data)
+{
+  g_autoptr(Request) request = data;
+  Session *session;
+  guint response = 2;
+  gboolean should_close_session;
+  g_autofree char *session_id = NULL;
+  GVariantBuilder results_builder;
+  g_autoptr(GError) error = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
+  SESSION_AUTOLOCK_UNREF (g_object_ref (session));
+  g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+
+  if (!xdp_impl_screen_cast_call_create_session_finish (impl,
+                                                        &response,
+                                                        NULL,
+                                                        res,
+                                                        &error))
+    {
+      g_warning ("A backend call failed: %s", error->message);
+      should_close_session = TRUE;
+      goto out;
+    }
+
+  if (request->exported && response == 0)
+    {
+      if (!session_export (session, &error))
+        {
+          g_warning ("Failed to export session: %s", error->message);
+          response = 2;
+          should_close_session = TRUE;
+          goto out;
+        }
+
+      should_close_session = FALSE;
+      session_register (session);
+    }
+  else
+    {
+      should_close_session = TRUE;
+    }
+
+  g_variant_builder_add (&results_builder, "{sv}",
+                         "session_handle", g_variant_new ("s", session->id));
+
+out:
+  if (request->exported)
+    {
+      xdp_request_emit_response (XDP_REQUEST (request),
+                                 response,
+                                 g_variant_builder_end (&results_builder));
+      request_unexport (request);
+    }
+  else
+    {
+      g_variant_builder_clear (&results_builder);
+    }
+
+  if (should_close_session)
+    session_close (session, FALSE);
+}
+
+static gboolean
+handle_create_session (XdpScreenCast *object,
+                       GDBusMethodInvocation *invocation,
+                       GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpImplRequest) impl_request = NULL;
+  Session *session;
+  GVariantBuilder options_builder;
+  GVariant *options;
+
+  REQUEST_AUTOLOCK (request);
+
+  impl_request =
+    xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                     G_DBUS_PROXY_FLAGS_NONE,
+                                     g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                     request->id,
+                                     NULL, &error);
+  if (!impl_request)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  request_set_impl_request (request, impl_request);
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  session = (Session *)screen_cast_session_new (arg_options, request, &error);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  options = g_variant_builder_end (&options_builder);
+
+  g_object_set_qdata_full (G_OBJECT (request),
+                           quark_request_session,
+                           g_object_ref (session),
+                           g_object_unref);
+
+  xdp_impl_screen_cast_call_create_session (impl,
+                                            request->id,
+                                            session->id,
+                                            request->app_id,
+                                            options,
+                                            NULL,
+                                            create_session_done,
+                                            g_object_ref (request));
+
+  xdp_screen_cast_complete_create_session (object, invocation, request->id);
+
+  return TRUE;
+}
+
+static void
+select_sources_done (GObject *source_object,
+                     GAsyncResult *res,
+                     gpointer data)
+{
+  g_autoptr(Request) request = data;
+  Session *session;
+  guint response = 2;
+  gboolean should_close_session;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GVariant) results = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
+  SESSION_AUTOLOCK_UNREF (g_object_ref (session));
+  g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
+
+  if (!xdp_impl_screen_cast_call_select_sources_finish (impl,
+                                                        &response,
+                                                        &results,
+                                                        res,
+                                                        &error))
+    g_warning ("A backend call failed: %s", error->message);
+
+  should_close_session = !request->exported || response != 0;
+
+  if (request->exported)
+    {
+      if (!results)
+        {
+          GVariantBuilder results_builder;
+
+          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+          results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
+        }
+
+      xdp_request_emit_response (XDP_REQUEST (request), response, results);
+      request_unexport (request);
+    }
+
+  if (should_close_session)
+    {
+      session_close (session, TRUE);
+    }
+  else if (!session->closed)
+    {
+      ScreenCastSession *screen_cast_session = (ScreenCastSession *)session;
+
+      g_assert_cmpint (screen_cast_session->state,
+                       ==,
+                       SCREEN_CAST_SESSION_STATE_SELECTING_SOURCES);
+      screen_cast_session->state = SCREEN_CAST_SESSION_STATE_SOURCES_SELECTED;
+    }
+}
+
+static XdpOptionKey screen_cast_select_sources_options[] = {
+  { "types", G_VARIANT_TYPE_UINT32 },
+  { "multiple", G_VARIANT_TYPE_BOOLEAN },
+};
+
+static gboolean
+handle_select_sources (XdpScreenCast *object,
+                       GDBusMethodInvocation *invocation,
+                       const char *arg_session_handle,
+                       GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  Session *session;
+  ScreenCastSession *screen_cast_session;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpImplRequest) impl_request = NULL;
+  GVariantBuilder options_builder;
+
+  REQUEST_AUTOLOCK (request);
+
+  session = acquire_session (arg_session_handle, request);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  SESSION_AUTOLOCK_UNREF (session);
+
+  if (is_screen_cast_session (session))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  screen_cast_session = (ScreenCastSession *)session;
+  switch (screen_cast_session->state)
+    {
+    case SCREEN_CAST_SESSION_STATE_INIT:
+      break;
+    case SCREEN_CAST_SESSION_STATE_SELECTING_SOURCES:
+    case SCREEN_CAST_SESSION_STATE_SOURCES_SELECTED:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Sources already selected");
+      return TRUE;
+    case SCREEN_CAST_SESSION_STATE_STARTING:
+    case SCREEN_CAST_SESSION_STATE_STARTED:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Can only select sources before starting");
+      return TRUE;
+    case SCREEN_CAST_SESSION_STATE_CLOSED:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  impl_request =
+    xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                     G_DBUS_PROXY_FLAGS_NONE,
+                                     g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                     request->id,
+                                     NULL, &error);
+  if (!impl_request)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  request_set_impl_request (request, impl_request);
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_filter_options (arg_options, &options_builder,
+                      screen_cast_select_sources_options,
+                      G_N_ELEMENTS (screen_cast_select_sources_options));
+
+  g_object_set_qdata_full (G_OBJECT (request),
+                           quark_request_session,
+                           g_object_ref (session),
+                           g_object_unref);
+  screen_cast_session->state = SCREEN_CAST_SESSION_STATE_SELECTING_SOURCES;
+
+  xdp_impl_screen_cast_call_select_sources (impl,
+                                            request->id,
+                                            arg_session_handle,
+                                            request->app_id,
+                                            g_variant_builder_end (&options_builder),
+                                            NULL,
+                                            select_sources_done,
+                                            g_object_ref (request));
+
+  xdp_screen_cast_complete_select_sources (object, invocation, request->id);
+
+  return TRUE;
+}
+
+static void
+registry_event_global (void *user_data,
+                       uint32_t id,
+                       uint32_t parent_id,
+                       uint32_t permissions,
+                       uint32_t type,
+                       uint32_t version,
+                       const struct spa_dict *props)
+{
+  PipeWireRemote *remote = user_data;
+  struct pw_type *core_type = pw_core_get_type (remote->core);
+  const struct spa_dict_item *factory_object_type;
+
+  if (type != core_type->factory)
+    return;
+
+  factory_object_type = spa_dict_lookup_item (props, "factory.type.name");
+  if (!factory_object_type)
+    return;
+
+  if (strcmp (factory_object_type->value, "PipeWire:Interface:ClientNode") == 0)
+    {
+      remote->node_factory_id = id;
+      pw_main_loop_quit (remote->loop);
+    }
+}
+
+static const struct pw_registry_proxy_events registry_events = {
+  PW_VERSION_REGISTRY_PROXY_EVENTS,
+  .global = registry_event_global,
+};
+
+static void
+core_event_done (void *user_data,
+                 uint32_t seq)
+{
+  PipeWireRemote *remote = user_data;
+
+  if (remote->registry_sync_seq == seq)
+    pw_main_loop_quit (remote->loop);
+}
+
+static const struct pw_core_proxy_events core_events = {
+  PW_VERSION_CORE_PROXY_EVENTS,
+  .done = core_event_done,
+};
+
+static gboolean
+discover_node_factory_sync (PipeWireRemote *remote,
+                            GError **error)
+{
+  struct pw_type *core_type = pw_core_get_type (remote->core);
+  struct pw_core_proxy *core_proxy;
+  struct spa_hook core_listener;
+  struct pw_registry_proxy *registry_proxy;
+  struct spa_hook registry_listener;
+
+  core_proxy = pw_remote_get_core_proxy (remote->remote);
+  pw_core_proxy_add_listener (core_proxy,
+                              &core_listener,
+                              &core_events,
+                              remote);
+
+  registry_proxy = pw_core_proxy_get_registry (core_proxy,
+                                               core_type->registry,
+                                               PW_VERSION_REGISTRY, 0);
+  pw_registry_proxy_add_listener (registry_proxy,
+                                  &registry_listener,
+                                  &registry_events,
+                                  remote);
+
+  pw_main_loop_run (remote->loop);
+
+  if (remote->node_factory_id == 0)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "No node factory discovered");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+on_state_changed (void *user_data,
+                  enum pw_remote_state old,
+                  enum pw_remote_state state,
+                  const char *error)
+{
+  PipeWireRemote *remote = user_data;
+
+  switch (state)
+    {
+    case PW_REMOTE_STATE_ERROR:
+      g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "%s", error);
+      pw_main_loop_quit (remote->loop);
+      break;
+    case PW_REMOTE_STATE_UNCONNECTED:
+      g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Disconnected");
+      pw_main_loop_quit (remote->loop);
+      break;
+    case PW_REMOTE_STATE_CONNECTING:
+      break;
+    case PW_REMOTE_STATE_CONNECTED:
+      pw_main_loop_quit (remote->loop);
+      break;
+    default:
+      g_warning ("Unknown PipeWire state");
+      break;
+    }
+}
+
+static const struct pw_remote_events remote_events = {
+  PW_VERSION_REMOTE_EVENTS,
+  .state_changed = on_state_changed,
+};
+
+static void
+pipewire_remote_destroy (PipeWireRemote *remote)
+{
+  g_clear_pointer (&remote->remote, (GDestroyNotify)pw_remote_destroy);
+  g_clear_pointer (&remote->core, (GDestroyNotify)pw_core_destroy);
+  g_clear_pointer (&remote->loop, (GDestroyNotify)pw_main_loop_destroy);
+  g_clear_error (&remote->error);
+
+  g_free (remote);
+}
+
+static void
+ensure_pipewire_is_initialized (void)
+{
+  if (is_pipewire_initialized)
+    return;
+
+  pw_init (NULL, NULL);
+
+  is_pipewire_initialized = TRUE;
+}
+
+static PipeWireRemote *
+connect_pipewire_sync (GError **error)
+{
+  PipeWireRemote *remote;
+
+  ensure_pipewire_is_initialized ();
+
+  remote = g_new0 (PipeWireRemote, 1);
+
+  remote->loop = pw_main_loop_new (NULL);
+  if (!remote->loop)
+    {
+      pipewire_remote_destroy (remote);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Couldn't create PipeWire main loop");
+      return NULL;
+    }
+
+  remote->core = pw_core_new (pw_main_loop_get_loop (remote->loop), NULL);
+  if (!remote->core)
+    {
+      pipewire_remote_destroy (remote);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Couldn't create PipeWire core");
+      return NULL;
+    }
+
+  remote->remote = pw_remote_new (remote->core, NULL, 0);
+  if (!remote->remote)
+    {
+      pipewire_remote_destroy (remote);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Couldn't create PipeWire remote");
+      return NULL;
+    }
+
+  pw_remote_add_listener (remote->remote,
+                          &remote->remote_listener,
+                          &remote_events,
+                          remote);
+
+  if (pw_remote_connect (remote->remote) != 0)
+    {
+      pipewire_remote_destroy (remote);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Couldn't connect PipeWire remote");
+      return NULL;
+    }
+
+  pw_main_loop_run (remote->loop);
+
+  switch (pw_remote_get_state (remote->remote, NULL))
+    {
+    case PW_REMOTE_STATE_ERROR:
+    case PW_REMOTE_STATE_UNCONNECTED:
+      *error = g_steal_pointer (&remote->error);
+      pipewire_remote_destroy (remote);
+      return FALSE;
+    case PW_REMOTE_STATE_CONNECTING:
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "PipeWire loop stopped unexpectedly");
+      pipewire_remote_destroy (remote);
+      return FALSE;
+    case PW_REMOTE_STATE_CONNECTED:
+      return remote;
+    default:
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Unexpected PipeWire state");
+      pipewire_remote_destroy (remote);
+      return FALSE;
+    }
+}
+
+static uint32_t
+screen_cast_stream_get_pipewire_node_id (ScreenCastStream *stream)
+{
+  return stream->id;
+}
+
+static PipeWireRemote *
+open_pipewire_screen_cast_remote (GList *streams,
+                                  GError **error)
+{
+  PipeWireRemote *remote;
+  GList *l;
+  unsigned int n_streams, i;
+  struct spa_dict_item *permission_items;
+  unsigned int n_permission_items;
+  g_autofree char *node_factory_permission_string = NULL;
+  char **stream_permission_values;
+
+  remote = connect_pipewire_sync (error);
+  if (!remote)
+    return FALSE;
+
+  if (!discover_node_factory_sync (remote, error))
+    {
+      pipewire_remote_destroy (remote);
+      return NULL;
+    }
+
+  n_streams = g_list_length (streams);
+  n_permission_items = n_streams + 4;
+  permission_items = g_new0 (struct spa_dict_item, n_permission_items);
+
+  /*
+   * Hide all existing and future nodes (except the ones we explicitly list below.
+   */
+  permission_items[0].key = PW_CORE_PROXY_PERMISSIONS_EXISTING;
+  permission_items[0].value = "---";
+  permission_items[1].key = PW_CORE_PROXY_PERMISSIONS_DEFAULT;
+  permission_items[1].value = "---";
+
+  /*
+   * PipeWire:Interface:Core
+   * Needs rwx to be able create the sink node using the create-object method
+   */
+  permission_items[2].key = PW_CORE_PROXY_PERMISSIONS_GLOBAL;
+  permission_items[2].value = "0:rwx";
+
+  /*
+   * PipeWire:Interface:NodeFactory
+   * Needs r-- so it can be passed to create-object when creating the sink node.
+   */
+  node_factory_permission_string = g_strdup_printf ("%d:r--",
+                                                    remote->node_factory_id);
+  permission_items[3].key = PW_CORE_PROXY_PERMISSIONS_GLOBAL;
+  permission_items[3].value = node_factory_permission_string;
+
+  i = 4;
+  stream_permission_values = g_new0 (char *, n_streams + 1);
+  for (l = streams; l; l = l->next)
+    {
+      ScreenCastStream *stream = l->data;
+      uint32_t stream_id;
+      char *permission_value;
+
+      stream_id = screen_cast_stream_get_pipewire_node_id (stream);
+      permission_value = g_strdup_printf ("%u:rwx", stream_id);
+      stream_permission_values[i - 3] = permission_value;
+
+      permission_items[i].key = PW_CORE_PROXY_PERMISSIONS_GLOBAL;
+      permission_items[i].value = permission_value;
+    }
+
+  pw_core_proxy_permissions(pw_remote_get_core_proxy (remote->remote),
+                            &SPA_DICT_INIT (permission_items,
+                                            n_permission_items));
+
+  g_strfreev (stream_permission_values);
+
+  return remote;
+}
+
+static void
+screen_cast_stream_free (ScreenCastStream *stream)
+{
+  g_free (stream);
+}
+
+static GList *
+collect_screen_cast_stream_data (GVariantIter *streams_iter)
+{
+  GList *streams = NULL;
+  uint32_t stream_id;
+  g_autoptr(GVariant) stream_options = NULL;
+
+  while (g_variant_iter_next (streams_iter, "(u@a{sv})",
+                              &stream_id, &stream_options))
+    {
+      ScreenCastStream *stream;
+
+      stream = g_new0 (ScreenCastStream, 1);
+      stream->id = stream_id;
+
+      streams = g_list_prepend (streams, stream);
+    }
+
+  return streams;
+}
+
+static gboolean
+process_results (ScreenCastSession *screen_cast_session,
+                 GVariant *results,
+                 GError **error)
+{
+  g_autoptr(GVariantIter) streams_iter = NULL;
+
+  if (!g_variant_lookup (results, "streams", "a(ua{sv})", &streams_iter))
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "No streams");
+      return FALSE;
+    }
+
+  screen_cast_session->streams = collect_screen_cast_stream_data (streams_iter);
+  return TRUE;
+}
+
+static void
+start_done (GObject *source_object,
+            GAsyncResult *res,
+            gpointer data)
+{
+  g_autoptr(Request) request = data;
+  Session *session;
+  ScreenCastSession *screen_cast_session;
+
+  guint response = 2;
+  gboolean should_close_session;
+  GVariant *results = NULL;
+  g_autoptr(GError) error = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
+  SESSION_AUTOLOCK_UNREF (g_object_ref (session));
+  g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
+
+  if (!xdp_impl_screen_cast_call_start_finish (impl,
+                                               &response,
+                                               &results,
+                                               res,
+                                               &error))
+    g_warning ("A backend call failed: %s", error->message);
+
+  should_close_session = !request->exported || response != 0;
+
+  screen_cast_session = (ScreenCastSession *)session;
+
+  if (request->exported)
+    {
+      if (response == 0)
+        {
+          if (!process_results (screen_cast_session, results, &error))
+            {
+              g_warning ("Failed to process results: %s", error->message);
+              g_clear_error (&error);
+              g_clear_pointer (&results, (GDestroyNotify)g_variant_unref);
+              response = 2;
+              should_close_session = TRUE;
+            }
+        }
+
+      if (!results)
+        {
+          GVariantBuilder results_builder;
+
+          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+          results = g_variant_builder_end (&results_builder);
+        }
+
+      xdp_request_emit_response (XDP_REQUEST (request), response, results);
+      request_unexport (request);
+    }
+
+  if (should_close_session)
+    {
+      session_close (session, TRUE);
+    }
+  else if (!session->closed)
+    {
+      g_assert (screen_cast_session->state ==
+                SCREEN_CAST_SESSION_STATE_STARTING);
+      g_debug ("screen cast session owned by '%s' started", session->sender);
+      screen_cast_session->state = SCREEN_CAST_SESSION_STATE_STARTED;
+    }
+}
+
+static gboolean
+handle_start (XdpScreenCast *object,
+              GDBusMethodInvocation *invocation,
+              const char *arg_session_handle,
+              const char *arg_parent_window,
+              GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  Session *session;
+  ScreenCastSession *screen_cast_session;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpImplRequest) impl_request = NULL;
+  GVariantBuilder options_builder;
+  GVariant *options;
+
+  REQUEST_AUTOLOCK (request);
+
+  session = acquire_session (arg_session_handle, request);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  SESSION_AUTOLOCK_UNREF (session);
+
+  screen_cast_session = (ScreenCastSession *)session;
+  switch (screen_cast_session->state)
+    {
+    case SCREEN_CAST_SESSION_STATE_SOURCES_SELECTED:
+      break;
+    case SCREEN_CAST_SESSION_STATE_INIT:
+    case SCREEN_CAST_SESSION_STATE_SELECTING_SOURCES:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Sources not selected");
+      return TRUE;
+    case SCREEN_CAST_SESSION_STATE_STARTING:
+    case SCREEN_CAST_SESSION_STATE_STARTED:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Can only start once");
+      return TRUE;
+    case SCREEN_CAST_SESSION_STATE_CLOSED:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  g_object_set_data_full (G_OBJECT (request),
+                          "window", g_strdup (arg_parent_window), g_free);
+
+  impl_request =
+    xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                     G_DBUS_PROXY_FLAGS_NONE,
+                                     g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                     request->id,
+                                     NULL, &error);
+  if (!impl_request)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  request_set_impl_request (request, impl_request);
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  options = g_variant_builder_end (&options_builder);
+
+  g_object_set_qdata_full (G_OBJECT (request),
+                           quark_request_session,
+                           g_object_ref (session),
+                           g_object_unref);
+  screen_cast_session->state = SCREEN_CAST_SESSION_STATE_STARTING;
+
+  xdp_impl_screen_cast_call_start (impl,
+                                   request->id,
+                                   arg_session_handle,
+                                   request->app_id,
+                                   arg_parent_window,
+                                   options,
+                                   NULL,
+                                   start_done,
+                                   g_object_ref (request));
+
+  xdp_screen_cast_complete_start (object, invocation, request->id);
+
+  return TRUE;
+}
+
+static gboolean
+handle_open_pipewire_remote (XdpScreenCast *object,
+                             GDBusMethodInvocation *invocation,
+                             GUnixFDList *in_fd_list,
+                             const char *arg_session_handle,
+                             GVariant *arg_options)
+{
+  Call *call = call_from_invocation (invocation);
+  Session *session;
+  ScreenCastSession *screen_cast_session;
+  GList *streams;
+  PipeWireRemote *remote;
+  GUnixFDList *out_fd_list;
+  int fd;
+  int fd_id;
+  g_autoptr(GError) error = NULL;
+
+  session = acquire_session_from_call (arg_session_handle, call);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  SESSION_AUTOLOCK_UNREF (session);
+
+  screen_cast_session = (ScreenCastSession *)session;
+  streams = screen_cast_session->streams;
+  if (!streams)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "No streams available");
+      return TRUE;
+    }
+
+  remote = open_pipewire_screen_cast_remote (streams, &error);
+  if (!remote)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "%s", error->message);
+      return TRUE;
+    }
+
+  out_fd_list = g_unix_fd_list_new ();
+  fd = pw_remote_steal_fd (remote->remote);
+  fd_id = g_unix_fd_list_append (out_fd_list, fd, &error);
+  close (fd);
+  pipewire_remote_destroy (remote);
+
+  if (fd_id == -1)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Failed to append fd: %s",
+                                             error->message);
+      return TRUE;
+    }
+
+  xdp_screen_cast_complete_open_pipewire_remote (object, invocation,
+                                                 out_fd_list,
+                                                 g_variant_new_handle (fd_id));
+  return TRUE;
+}
+
+static void
+screen_cast_iface_init (XdpScreenCastIface *iface)
+{
+  iface->handle_create_session = handle_create_session;
+  iface->handle_select_sources = handle_select_sources;
+  iface->handle_start = handle_start;
+  iface->handle_open_pipewire_remote = handle_open_pipewire_remote;
+}
+
+static void
+sync_supported_source_types (ScreenCast *screen_cast)
+{
+  unsigned int available_source_types;
+
+  available_source_types = xdp_impl_screen_cast_get_available_source_types (impl);
+  xdp_screen_cast_set_available_source_types (XDP_SCREEN_CAST (screen_cast),
+                                              available_source_types);
+}
+
+static void
+on_supported_source_types_changed (GObject *gobject,
+                                   GParamSpec *pspec,
+                                   ScreenCast *screen_cast)
+{
+  sync_supported_source_types (screen_cast);
+}
+
+static void
+screen_cast_init (ScreenCast *screen_cast)
+{
+  xdp_screen_cast_set_version (XDP_SCREEN_CAST (screen_cast), 1);
+
+  g_signal_connect (impl, "notify::supported-source-types",
+                    G_CALLBACK (on_supported_source_types_changed),
+                    screen_cast);
+  sync_supported_source_types (screen_cast);
+}
+
+static void
+screen_cast_class_init (ScreenCastClass *klass)
+{
+}
+
+GDBusInterfaceSkeleton *
+screen_cast_create (GDBusConnection *connection,
+                    const char *dbus_name)
+{
+  g_autoptr(GError) error = NULL;
+
+  impl = xdp_impl_screen_cast_proxy_new_sync (connection,
+                                              G_DBUS_PROXY_FLAGS_NONE,
+                                              dbus_name,
+                                              DESKTOP_PORTAL_OBJECT_PATH,
+                                              NULL,
+                                              &error);
+  if (impl == NULL)
+    {
+      g_warning ("Failed to create screen cast proxy: %s", error->message);
+      return NULL;
+    }
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl), G_MAXINT);
+
+  screen_cast = g_object_new (screen_cast_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (screen_cast);
+}
+
+static void
+screen_cast_session_close (Session *session)
+{
+  ScreenCastSession *screen_cast_session = (ScreenCastSession *)session;
+
+  screen_cast_session->state = SCREEN_CAST_SESSION_STATE_CLOSED;
+
+  g_debug ("screen cast session owned by '%s' closed", session->sender);
+}
+
+static void
+screen_cast_session_finalize (GObject *object)
+{
+  ScreenCastSession *screen_cast_session = (ScreenCastSession *)object;
+
+  g_list_free_full (screen_cast_session->streams,
+                    (GDestroyNotify)screen_cast_stream_free);
+
+  G_OBJECT_CLASS (screen_cast_session_parent_class)->finalize (object);
+}
+
+static void
+screen_cast_session_init (ScreenCastSession *screen_cast_session)
+{
+}
+
+static void
+screen_cast_session_class_init (ScreenCastSessionClass *klass)
+{
+  GObjectClass *object_class;
+  SessionClass *session_class;
+
+  object_class = G_OBJECT_CLASS (klass);
+  object_class->finalize = screen_cast_session_finalize;
+
+  session_class = (SessionClass *)klass;
+  session_class->close = screen_cast_session_close;
+
+  quark_request_session =
+    g_quark_from_static_string ("-xdp-request-screen-cast-session");
+}

--- a/src/screen-cast.h
+++ b/src/screen-cast.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017-2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * screen_cast_create (GDBusConnection *connection,
+                                             const char      *dbus_name);

--- a/src/session.c
+++ b/src/session.c
@@ -18,6 +18,7 @@
 
 #include "session.h"
 #include "request.h"
+#include "call.h"
 
 #include <string.h>
 
@@ -81,6 +82,30 @@ acquire_session (const char *session_handle,
     return NULL;
 
   if (g_strcmp0 (session->app_id, request->app_id) != 0)
+    return NULL;
+
+  return g_steal_pointer (&session);
+}
+
+Session *
+acquire_session_from_call (const char *session_handle,
+                           Call *call)
+{
+  g_autoptr(Session) session = NULL;
+
+  G_LOCK (sessions);
+  session = g_hash_table_lookup (sessions, session_handle);
+  if (session)
+    g_object_ref (session);
+  G_UNLOCK (sessions);
+
+  if (!session)
+    return NULL;
+
+  if (g_strcmp0 (session->sender, call->sender) != 0)
+    return NULL;
+
+  if (g_strcmp0 (session->app_id, call->app_id) != 0)
     return NULL;
 
   return g_steal_pointer (&session);

--- a/src/session.c
+++ b/src/session.c
@@ -1,0 +1,486 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "session.h"
+#include "request.h"
+
+#include <string.h>
+
+enum
+{
+  PROP_0,
+
+  PROP_SENDER,
+  PROP_APP_ID,
+  PROP_TOKEN,
+  PROP_CONNECTION,
+  PROP_IMPL_CONNECTION,
+  PROP_IMPL_DBUS_NAME,
+
+  PROP_LAST
+};
+
+static GParamSpec *obj_props[PROP_LAST];
+
+G_LOCK_DEFINE (sessions);
+static GHashTable *sessions;
+
+static void g_initable_iface_init (GInitableIface *iface);
+static void session_skeleton_iface_init (XdpSessionIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Session, session, XDP_TYPE_SESSION_SKELETON,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE,
+                                                g_initable_iface_init)
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_SESSION,
+                                                session_skeleton_iface_init))
+
+#define SESSION_GET_CLASS(o) \
+  (G_TYPE_INSTANCE_GET_CLASS ((o), session_get_type (), SessionClass))
+
+const char *
+lookup_session_token (GVariant *options)
+{
+  const char *token = NULL;
+
+  g_variant_lookup (options, "session_handle_token", "&s", &token);
+
+  return token;
+}
+
+Session *
+acquire_session (const char *session_handle,
+                 Request *request)
+{
+  g_autoptr(Session) session = NULL;
+
+  G_LOCK (sessions);
+  session = g_hash_table_lookup (sessions, session_handle);
+  if (session)
+    g_object_ref (session);
+  G_UNLOCK (sessions);
+
+  if (!session)
+    return NULL;
+
+  if (g_strcmp0 (session->sender, request->sender) != 0)
+    return NULL;
+
+  if (g_strcmp0 (session->app_id, request->app_id) != 0)
+    return NULL;
+
+  return g_steal_pointer (&session);
+}
+
+gboolean
+session_export (Session *session,
+                GError **error)
+{
+  if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (session),
+                                         session->connection,
+                                         session->id,
+                                         error))
+    return FALSE;
+
+  g_object_ref (session);
+  session->exported = TRUE;
+
+  return TRUE;
+}
+
+static void
+session_unexport (Session *session)
+{
+  session->exported = FALSE;
+  g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (session));
+  g_object_unref (session);
+}
+
+void
+session_register (Session *session)
+{
+  G_LOCK (sessions);
+  g_hash_table_insert (sessions, session->id, session);
+  G_UNLOCK (sessions);
+}
+
+static void
+session_unregister (Session *session)
+{
+  G_LOCK (sessions);
+  g_hash_table_remove (sessions, session->id);
+  G_UNLOCK (sessions);
+}
+
+void
+session_close (Session *session,
+               gboolean notify_closed)
+{
+  if (session->closed)
+    return;
+
+  SESSION_GET_CLASS (session)->close (session);
+
+  if (session->exported)
+    session_unexport (session);
+
+  session_unregister (session);
+
+  if (session->impl_session)
+    {
+      g_autoptr(GError) error = NULL;
+
+      if (!xdp_impl_session_call_close_sync (session->impl_session,
+                                             NULL, &error))
+        g_warning ("Failed to close session implementation: %s",
+                   error->message);
+
+      g_clear_object (&session->impl_session);
+    }
+
+  session->closed = TRUE;
+
+  if (notify_closed)
+    {
+      GVariantBuilder details_builder;
+
+      g_variant_builder_init (&details_builder, G_VARIANT_TYPE_VARDICT);
+      g_signal_emit_by_name (session, "closed",
+                             g_variant_builder_end (&details_builder));
+    }
+
+  g_object_unref (session);
+}
+
+static gboolean
+handle_close (XdpSession *object,
+              GDBusMethodInvocation *invocation)
+{
+  Session *session = (Session *)object;
+
+  SESSION_AUTOLOCK_UNREF (g_object_ref (session));
+
+  session_close (session, FALSE);
+
+  xdp_session_complete_close (object, invocation);
+
+  return TRUE;
+}
+
+static void
+session_skeleton_iface_init (XdpSessionIface *iface)
+{
+  iface->handle_close = handle_close;
+}
+
+static void
+close_sessions_in_thread_func (GTask *task,
+                               gpointer source_object,
+                               gpointer task_data,
+                               GCancellable *cancellable)
+{
+  const char *sender = (const char *)task_data;
+  GSList *list = NULL;
+  GSList *l;
+  GHashTableIter iter;
+  Session *session;
+
+  G_LOCK (sessions);
+  if (sessions)
+    {
+      g_hash_table_iter_init (&iter, sessions);
+      while (g_hash_table_iter_next (&iter, NULL, (gpointer *)&session))
+        {
+          if (strcmp (sender, session->sender) == 0)
+            list = g_slist_prepend (list, g_object_ref (session));
+        }
+    }
+  G_UNLOCK (sessions);
+
+  for (l = list; l; l = l->next)
+    {
+      Session *session = l->data;
+
+      SESSION_AUTOLOCK (session);
+      session_close (session, FALSE);
+    }
+
+  g_slist_free_full (list, g_object_unref);
+}
+
+void
+close_sessions_for_sender (const char *sender)
+{
+  g_autoptr(GTask) task = NULL;
+
+  task = g_task_new (NULL, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_strdup (sender), g_free);
+  g_task_run_in_thread (task, close_sessions_in_thread_func);
+}
+
+static void
+on_closed (XdpImplSession *object)
+{
+  Session *session = (Session *)object;
+
+  SESSION_AUTOLOCK_UNREF (g_object_ref (session));
+
+  g_clear_object (&session->impl_session);
+  session_close (session, TRUE);
+}
+
+static gboolean
+session_authorize_callback (GDBusInterfaceSkeleton *interface,
+                            GDBusMethodInvocation  *invocation,
+                            gpointer                user_data)
+{
+  const gchar *session_owner = user_data;
+  const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
+
+  if (strcmp (sender, session_owner) != 0)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Portal operation not allowed, Unmatched caller");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+session_initable_init (GInitable *initable,
+                       GCancellable *cancellable,
+                       GError **error)
+{
+  Session *session = (Session *)initable;
+  g_autofree char *sender_escaped = NULL;
+  g_autofree char *id = NULL;
+  g_autoptr(XdpImplSession) impl_session = NULL;
+  int i;
+
+  sender_escaped = g_strdup (session->sender + 1);
+  for (i = 0; sender_escaped[i]; i++)
+    {
+      if (sender_escaped[i] == '.')
+        sender_escaped[i] = '_';
+    }
+
+  if (!session->token)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Missing token");
+      return FALSE;
+    }
+
+  id = g_strdup_printf ("/org/freedesktop/portal/desktop/session/%s/%s",
+                        sender_escaped, session->token);
+
+  impl_session = xdp_impl_session_proxy_new_sync (session->impl_connection,
+                                                  G_DBUS_PROXY_FLAGS_NONE,
+                                                  session->impl_dbus_name,
+                                                  id,
+                                                  NULL, error);
+  if (!impl_session)
+    return FALSE;
+
+  g_signal_connect (impl_session, "closed", G_CALLBACK (on_closed), NULL);
+
+  session->id = g_steal_pointer (&id);
+  session->impl_session = g_steal_pointer (&impl_session);
+
+  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (session),
+                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
+  g_signal_connect (session, "g-authorize-method",
+                    G_CALLBACK (session_authorize_callback),
+                    session->sender);
+
+  return TRUE;
+}
+
+static void
+g_initable_iface_init (GInitableIface *iface)
+{
+  iface->init = session_initable_init;
+}
+
+static void
+session_set_property (GObject *object,
+                      guint prop_id,
+                      const GValue *value,
+                      GParamSpec *pspec)
+{
+  Session *session = (Session *)object;
+
+  switch (prop_id)
+    {
+    case PROP_SENDER:
+      session->sender = g_strdup (g_value_get_string (value));
+      break;
+
+    case PROP_APP_ID:
+      session->app_id = g_strdup (g_value_get_string (value));
+      break;
+
+    case PROP_TOKEN:
+      session->token = g_strdup (g_value_get_string (value));
+      break;
+
+    case PROP_CONNECTION:
+      g_set_object (&session->connection, g_value_get_object (value));
+      break;
+
+    case PROP_IMPL_CONNECTION:
+      g_set_object (&session->impl_connection, g_value_get_object (value));
+      break;
+
+    case PROP_IMPL_DBUS_NAME:
+      session->impl_dbus_name = g_strdup (g_value_get_string (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+session_get_property (GObject *object,
+                      guint prop_id,
+                      GValue *value,
+                      GParamSpec *pspec)
+{
+  Session *session = (Session *)object;
+
+  switch (prop_id)
+    {
+    case PROP_SENDER:
+      g_value_set_string (value, session->sender);
+      break;
+
+    case PROP_APP_ID:
+      g_value_set_string (value, session->app_id);
+      break;
+
+    case PROP_TOKEN:
+      g_value_set_string (value, session->token);
+      break;
+
+    case PROP_CONNECTION:
+      g_value_set_object (value, session->connection);
+      break;
+
+    case PROP_IMPL_CONNECTION:
+      g_value_set_object (value, session->impl_connection);
+      break;
+
+    case PROP_IMPL_DBUS_NAME:
+      g_value_set_string (value, session->impl_dbus_name);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+session_finalize (GObject *object)
+{
+  Session *session = (Session *)object;
+
+  g_assert (!g_hash_table_lookup (sessions, session->id));
+
+  g_free (session->sender);
+  g_clear_object (&session->connection);
+
+  g_clear_object (&session->impl_connection);
+  g_free (session->impl_dbus_name);
+  g_clear_object (&session->impl_session);
+
+  g_free (session->app_id);
+  g_free (session->id);
+
+  g_mutex_clear (&session->mutex);
+
+  G_OBJECT_CLASS (session_parent_class)->finalize (object);
+}
+
+static void
+session_init (Session *session)
+{
+  g_mutex_init (&session->mutex);
+}
+
+static void
+session_class_init (SessionClass *klass)
+{
+  GObjectClass *gobject_class;
+
+  sessions = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                    NULL, NULL);
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  gobject_class->finalize = session_finalize;
+  gobject_class->set_property = session_set_property;
+  gobject_class->get_property = session_get_property;
+
+  obj_props[PROP_SENDER] =
+    g_param_spec_string ("sender", "Sender", "Sender",
+                         NULL,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_APP_ID] =
+    g_param_spec_string ("app-id", "app-id", "App ID",
+                         NULL,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_TOKEN] =
+    g_param_spec_string ("token", "token", "Token",
+                         NULL,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_CONNECTION] =
+    g_param_spec_object ("connection", "connection",
+                         "DBus connection",
+                         G_TYPE_DBUS_CONNECTION,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_IMPL_CONNECTION] =
+    g_param_spec_object ("impl-connection", "impl-connection",
+                         "impl DBus connection",
+                         G_TYPE_DBUS_CONNECTION,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_IMPL_DBUS_NAME] =
+    g_param_spec_string ("impl-dbus-name", "impl-dbus-name",
+                         "impl DBus name",
+                         NULL,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
+}

--- a/src/session.h
+++ b/src/session.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "request.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+
+typedef struct _Session Session;
+typedef struct _SessionClass SessionClass;
+
+struct _Session
+{
+  XdpSessionSkeleton parent;
+
+  GMutex mutex;
+
+  gboolean exported;
+  gboolean closed;
+
+  char *app_id;
+  char *id;
+  char *token;
+
+  char *sender;
+  GDBusConnection *connection;
+
+  char *impl_dbus_name;
+  GDBusConnection *impl_connection;
+  XdpImplSession *impl_session;
+};
+
+struct _SessionClass
+{
+  XdpSessionSkeletonClass parent_class;
+
+  void (*close) (Session *session);
+};
+
+GType session_get_type (void);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Session, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpImplSession, g_object_unref)
+
+const char * lookup_session_token (GVariant *options);
+
+Session * acquire_session (const char *session_handle,
+                           Request *request);
+
+void session_register (Session *session);
+
+gboolean session_export (Session *session,
+                         GError **error);
+
+void close_sessions_for_sender (const char *sender);
+
+void session_close (Session *session,
+                    gboolean notify_close);
+
+static inline void
+auto_session_unlock_unref_helper (Session **session)
+{
+  if (!*session)
+    return;
+
+  g_mutex_unlock (&(*session)->mutex);
+  g_object_unref (*session);
+}
+
+static inline Session *
+auto_session_lock_helper (Session *session)
+{
+  if (session)
+    g_mutex_lock (&session->mutex);
+  return session;
+}
+
+#define SESSION_AUTOLOCK(session) \
+  G_GNUC_UNUSED __attribute__((cleanup (auto_unlock_helper))) \
+  GMutex * G_PASTE (session_auto_unlock, __LINE__) = \
+    auto_lock_helper (&session->mutex);
+
+#define SESSION_AUTOLOCK_UNREF(session) \
+  G_GNUC_UNUSED __attribute__((cleanup (auto_session_unlock_unref_helper))) \
+  Session * G_PASTE (session_auto_unlock_unref, __LINE__) = \
+    auto_session_lock_helper (session);

--- a/src/session.h
+++ b/src/session.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "request.h"
+#include "call.h"
 #include "xdp-dbus.h"
 #include "xdp-impl-dbus.h"
 
@@ -62,6 +63,9 @@ const char * lookup_session_token (GVariant *options);
 
 Session * acquire_session (const char *session_handle,
                            Request *request);
+
+Session * acquire_session_from_call (const char *session_handle,
+                                     Call *call);
 
 void session_register (Session *session);
 

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -30,6 +30,7 @@
 #include "xdp-utils.h"
 #include "xdp-dbus.h"
 #include "request.h"
+#include "call.h"
 #include "documents.h"
 #include "permissions.h"
 #include "file-chooser.h"
@@ -274,6 +275,12 @@ find_portal_implementation (const char *interface)
 }
 
 static gboolean
+method_needs_request (GDBusMethodInvocation *invocation)
+{
+  return TRUE;
+}
+
+static gboolean
 authorize_callback (GDBusInterfaceSkeleton *interface,
                     GDBusMethodInvocation  *invocation,
                     gpointer                user_data)
@@ -292,7 +299,10 @@ authorize_callback (GDBusInterfaceSkeleton *interface,
       return FALSE;
     }
 
-  request_init_invocation (invocation, app_id);
+  if (method_needs_request (invocation))
+    request_init_invocation (invocation, app_id);
+  else
+    call_init_invocation (invocation, app_id);
 
   return TRUE;
 }

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -28,6 +28,7 @@
 
 #include "xdp-utils.h"
 #include "request.h"
+#include "session.h"
 
 G_LOCK_DEFINE (app_infos);
 static GHashTable *app_infos;
@@ -259,6 +260,7 @@ name_owner_changed (GDBusConnection *connection,
       G_UNLOCK (app_infos);
 
       close_requests_for_sender (name);
+      close_sessions_for_sender (name);
     }
 }
 


### PR DESCRIPTION
This adds a screen cast portal, provided via org.freedesktop.portal.ScreenCast. A sample user illustrating how its used can be found here: https://gitlab.gnome.org/snippets/19 . A xdg-desktop-portal-gtk implementation (needing mutter 3.26 + https://bugzilla.gnome.org/show_bug.cgi?id=787715 ): https://github.com/jadahl/xdg-desktop-portal-gtk/commits/wip/screen-cast .

There are some things to note about it, and as is, it is not ready to be merged. More on that below.

1.

This is, as far as I can tell, the first portal API that introduces long lived sessions. I need this so that I can later couple a screen cast session with a remote desktop session. To summarize, doing remote desktop might (most likely) involve screen casting, but we should not pop up two portal dialogs; thus we need a combined "Start" switch.

Sessions here are currently associated by passing a session ID that the application retrieves from the Result vardict from a "CreateSession" method. This is then passed to every method that depend on a given session (SelectSources, Start, Stop).

The "combined" sessions will be done by having the application first create a org.freedesktop.portal.RemoteDesktop session (in the same way as is done in the commit introducing the ScreenCast in this PR). The session ID is then passed as an option when creating the org.freedesktop.portal.ScreenCast session. This will mean that the screen cast session is controlled by the remote desktop session, which in practice means that the application Starts/Stops both sessions atomically using the remote desktop session. Vardict entries from the screen cast Start method will instead be passed via the Result object of the remote desktop Start method.

2.

This requires PipeWire, which is not yet possible to be used from inside a flatpak sandbox. As the idea is to have the portal pass the PipeWire remote file descriptor to the client, this portal API naturally must be changed to also do this. The intention here is to first get feedback on the portal API itself, then make the needed adaptations for passing a file descriptor.