### PR TITLE
xdp-utils: Also resolve file descriptors to paths for directories

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -337,7 +337,7 @@ xdp_get_path_for_fd (GKeyFile *app_info,
       ((fd_flags & O_PATH) != O_PATH) ||
       ((fd_flags & O_NOFOLLOW) == O_NOFOLLOW) ||
       fstat (fd, &st_buf) < 0 ||
-      (st_buf.st_mode & S_IFMT) != S_IFREG ||
+      ((st_buf.st_mode & S_IFMT) != S_IFREG && (st_buf.st_mode & S_IFMT) != S_IFDIR) ||
       (symlink_size = readlink (proc_path, path_buffer, PATH_MAX)) < 0)
     {
       return NULL;


### PR DESCRIPTION
This won't be useful if the path passed points to a directory not
reachable inside the sandbox, but it will at least allow opening
them in other cases where that might be the case.

https://github.com/flatpak/xdg-desktop-portal/issues/128