### PR TITLE
open-uri: Don't crash when opening files skipping the app chooser

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -512,7 +512,8 @@ handle_open_in_thread_func (GTask *task,
       basename = g_path_get_basename (path);
 
       scheme = g_strdup ("file");
-      g_object_set_data_full (G_OBJECT (request), "uri", g_filename_to_uri (path, NULL, NULL), g_free);
+      uri = g_filename_to_uri (path, NULL, NULL);
+      g_object_set_data_full (G_OBJECT (request), "uri", g_strdup (uri), g_free);
     }
 
   find_recommended_choices (scheme, content_type, &choices, &skip_app_chooser);


### PR DESCRIPTION
When OpenFile is used to open a directory and either there's a default
application to handle file:// URIs, or only one appropriate application
is installed (e.g. Nautilus), we would hit a crash with the current code
since launch_default_for_uri() will be passed a NULL uri parameter.

This fixes that by ensuring that uri is always properly set at that point.

https://github.com/flatpak/xdg-desktop-portal/issues/129