### PR TITLE
open-uri: Don't ever pass a list of NULLs to g_app_info_launch_uris()

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -267,7 +267,7 @@ handle_access_microphone_in_thread (GTask *task,
 
       g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
       xdp_request_emit_response (XDP_REQUEST (request),
-                                 allowed ? 0 : 1,
+                                 allowed ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED,
                                  g_variant_builder_end (&results));
       request_unexport (request);
     }

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -485,7 +485,9 @@ handle_open_in_thread_func (GTask *task,
           if (request->exported)
             {
               g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
-              xdp_request_emit_response (XDP_REQUEST (request), 2, g_variant_builder_end (&opts_builder));
+              xdp_request_emit_response (XDP_REQUEST (request),
+                                         XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
+                                         g_variant_builder_end (&opts_builder));
               request_unexport (request);
             }
           return;
@@ -502,7 +504,9 @@ handle_open_in_thread_func (GTask *task,
           if (request->exported)
             {
               g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
-              xdp_request_emit_response (XDP_REQUEST (request), 2, g_variant_builder_end (&opts_builder));
+              xdp_request_emit_response (XDP_REQUEST (request),
+                                         XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
+                                         g_variant_builder_end (&opts_builder));
               request_unexport (request);
             }
           return;

--- a/src/request.h
+++ b/src/request.h
@@ -24,6 +24,12 @@
 #include "xdp-dbus.h"
 #include "xdp-impl-dbus.h"
 
+typedef enum {
+  XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS = 0,
+  XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED,
+  XDG_DESKTOP_PORTAL_RESPONSE_OTHER
+} XdgDesktopPortalResponseEnum;
+
 typedef struct _Request Request;
 typedef struct _RequestClass RequestClass;
 


### PR DESCRIPTION
Add extra checks to never do this when registering the URI with the
documents portal (for sandboxed handler) fails for any reason, and
report to the sandboxed caller accordingly when that happens.

https://github.com/flatpak/xdg-desktop-portal/issues/134