### PR TITLE
xdp-utils: inspect sender security label to detect snap packages.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_SUBST([systemduserunitdir], [$with_systemduserunitdir])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 
-PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0])
+PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0 libapparmor])
 AC_SUBST(BASE_CFLAGS)
 AC_SUBST(BASE_LIBS)
 


### PR DESCRIPTION
I've been working towards getting xdg-desktop-portal to work with snap packages (https://snapcraft.io/).  I don't yet have everything functioning, but thought I'd open a PR as a starting point to see if there is interest in accepting this upstream.  If there is interest in this, I've got a similar patch for xdg-document-portal.

It is possible to detect that we're talking to a snap confined application by checking that it's AppArmor security profile starts with "snap.".  I've switched over to using `GetConnectionCredentials`, which provides both the security label (for detecting snaps) and the process ID (for detecting flatpaks), so this doesn't impose additional round trips.

I am using libapparmor to parse the profile out of the security label, but the functions used are so trivial that we could reimplement them to avoid the dependency if desired.

There is a bit of an impedance mismatch because snap package names do not match Flatpak's application ID format.  As a work around, I am prepending "snap.pkg." to the snap package name to fulfil the requirement for three dot separated components.  This isn't perfect, since I think there are some valid snap package names that aren't valid for the last component of the application ID.  I think the idea of including some kind of prefix has merit though, since it should help avoid namespace conflicts.