### PR TITLE
screenshot: Add an 'interactive' option

### DIFF
--- a/data/org.freedesktop.impl.portal.Screenshot.xml
+++ b/data/org.freedesktop.impl.portal.Screenshot.xml
@@ -48,6 +48,13 @@
               Whether the dialog should be modal. Defaults to yes.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>interactive b</term>
+            <listitem><para>
+              Hint whether the dialog should offer customization before taking a screenshot.
+              Defaults to no.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned via the @results vardict:

--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -29,7 +29,7 @@
       via the document portal, and the returned URI will point
       into the document portal fuse filesystem in /run/user/$UID/doc/.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Screenshot">
     <!--
@@ -57,6 +57,13 @@
             <term>modal b</term>
             <listitem><para>
               Whether the dialog should be modal. Default is yes.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>interactive b</term>
+            <listitem><para>
+              Hint shether the dialog should offer customization before taking a screenshot.
+              Default is no. Since version 2.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -136,7 +136,8 @@ screenshot_done (GObject *source,
 }
 
 static XdpOptionKey screenshot_options[] = {
-  { "modal", G_VARIANT_TYPE_BOOLEAN }
+  { "modal", G_VARIANT_TYPE_BOOLEAN },
+  { "interactive", G_VARIANT_TYPE_BOOLEAN }
 };
 
 static gboolean


### PR DESCRIPTION
This option indicates to the backend that it would
be useful to offer customization before taking a screenshot.
This is just a hint, backends may not have options or may
ignore the interactive option.