### PR TITLE
Return real path when saving files we have access to

### DIFF
--- a/src/documents.c
+++ b/src/documents.c
@@ -106,16 +106,35 @@ register_document (const char *uri,
   version = xdp_documents_get_version (documents);
 
   if (for_save)
-    ret = xdp_documents_call_add_named_sync (documents,
-                                             g_variant_new_handle (fd_in),
-                                             basename,
-                                             TRUE,
-                                             TRUE,
-                                             fd_list,
-                                             &doc_id,
-                                             NULL,
-                                             NULL,
-                                             error);
+    {
+      if (version >= 3)
+        {
+          ret = xdp_documents_call_add_named_full_sync (documents,
+                                                        g_variant_new_handle (fd_in),
+                                                        basename,
+                                                        7,
+                                                        app_id,
+                                                        permissions,
+                                                        fd_list,
+                                                        &doc_id,
+                                                        NULL,
+                                                        NULL,
+                                                        NULL,
+                                                        error);
+          handled_permissions = TRUE;
+        }
+      else
+        ret = xdp_documents_call_add_named_sync (documents,
+                                                 g_variant_new_handle (fd_in),
+                                                 basename,
+                                                 TRUE,
+                                                 TRUE,
+                                                 fd_list,
+                                                 &doc_id,
+                                                 NULL,
+                                                 NULL,
+                                                 error);
+    }
   else
     {
       if (version >= 2)


### PR DESCRIPTION
Make use of new add_named_full() function where we can specify with flags whether
the document portal should return real path to file we have access to or if it
should return path to fuse mountpoint