### PR TITLE
remote-desktop: Add 'finish' option to axis events

### DIFF
--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -167,6 +167,18 @@
 
         May only be called if POINTER access was provided after starting the
         session.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>finish b</term>
+            <listitem><para>
+              If set to true, this is the last axis event in a series, for
+              example as a result of the fingers being lifted from a touchpad
+              after a two-finger scroll.  Default is false.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="NotifyPointerAxis">
       <arg type="o" name="session_handle" direction="in"/>

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -190,6 +190,18 @@
 
         May only be called if POINTER access was provided after starting the
         session.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>finish b</term>
+            <listitem><para>
+              If set to true, this is the last axis event in a series, for
+              example as a result of the fingers being lifted from a touchpad
+              after a two-finger scroll.  Default is false.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="NotifyPointerAxis">
       <arg type="o" name="session_handle" direction="in"/>

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -866,6 +866,10 @@ handle_notify_pointer_button (XdpRemoteDesktop *object,
   return TRUE;
 }
 
+static XdpOptionKey remote_desktop_notify_pointer_axis_options[] = {
+  { "finish", G_VARIANT_TYPE_BOOLEAN },
+};
+
 static gboolean
 handle_notify_pointer_axis (XdpRemoteDesktop *object,
                             GDBusMethodInvocation *invocation,
@@ -902,8 +906,8 @@ handle_notify_pointer_axis (XdpRemoteDesktop *object,
 
   g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &options_builder,
-                      remote_desktop_notify_options,
-                      G_N_ELEMENTS (remote_desktop_notify_options));
+                      remote_desktop_notify_pointer_axis_options,
+                      G_N_ELEMENTS (remote_desktop_notify_pointer_axis_options));
   options = g_variant_builder_end (&options_builder);
 
   xdp_impl_remote_desktop_call_notify_pointer_axis (impl,


### PR DESCRIPTION
This is so that an end to a continuous axis motion can be reported
(equivalent of lifting a finger) meaning clients can turn this into a
kinetic scroll.