### PR TITLE
screencast: Document correct vardict option

### DIFF
--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -64,7 +64,7 @@
         Supported keys in the @options vardict include:
         <variablelist>
           <varlistentry>
-            <term>type u</term>
+            <term>types u</term>
             <listitem><para>
               Bitmask of what types of content to record. Default is MONITOR.
             </para></listitem>


### PR DESCRIPTION
SelectSources() actually looks for the key "types", not "type".

As pointed out by @grulja 