### PR TITLE
Support snap

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -978,7 +978,7 @@ xdp_fuse_lookup (fuse_req_t  req,
 
     case XDP_INODE_BY_APP:
       /* This lazily creates the app dir */
-      if (xdp_is_valid_flatpak_name (name))
+      if (xdp_is_valid_app_id (name))
         child_inode = xdp_inode_get_dir (name, NULL, NULL);
       break;
 

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -130,7 +130,7 @@ portal_grant_permissions (GDBusMethodInvocation *invocation,
         return;
       }
 
-    if (!xdp_is_valid_flatpak_name (target_app_id))
+    if (!xdp_is_valid_app_id (target_app_id))
       {
         g_dbus_method_invocation_return_error (invocation,
                                                XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
@@ -187,7 +187,7 @@ portal_revoke_permissions (GDBusMethodInvocation *invocation,
         return;
       }
 
-    if (!xdp_is_valid_flatpak_name (target_app_id))
+    if (!xdp_is_valid_app_id (target_app_id))
       {
         g_dbus_method_invocation_return_error (invocation,
                                                XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -37,7 +37,7 @@ gint xdp_mkstempat (int    dir_fd,
                     int    flags,
                     int    mode);
 
-gboolean xdp_is_valid_flatpak_name (const char *string);
+gboolean xdp_is_valid_app_id (const char *string);
 
 typedef void (*XdpPeerDiedCallback) (const char *name);
 


### PR DESCRIPTION
This adds support for snaps, based on the code in https://github.com/flatpak/xdg-desktop-portal/pull/136 by @jhenstridge. I did not actually test this, so it needs testing before it can be commited.

This PR includes the changes from https://github.com/flatpak/xdg-desktop-portal/pull/154, but we should probably land those separately first.

This should handle the basics of portals, but there are two things still missing:
 * xdp_get_app_info_from_pid() needs support to look up a snap AppInfo from the pid
 * app_has_file_access() in document-portal.c currently only supports flatpak, it would be interesting to have a version of this for snaps too.