### PR TITLE
build: Run install-test-data-hook as intended

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,4 +44,7 @@ EXTRA_DIST += xdg-desktop-portal.pc.in
 
 EXTRA_DIST += README.md
 
+install-data-hook:
+	$(MAKE) $(AM_MAKEFLAGS) install-test-data-hook
+
 AM_DISTCHECK_CONFIGURE_FLAGS =


### PR DESCRIPTION
This wasn't set up when it was copied from Flatpak.