### PR TITLE
utils: Don't leak names whose ownership changed

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -410,7 +410,7 @@ name_owner_changed (GDBusConnection *connection,
   const char *name, *from, *to;
   XdpPeerDiedCallback peer_died_cb = user_data;
 
-  g_variant_get (parameters, "(sss)", &name, &from, &to);
+  g_variant_get (parameters, "(&s&s&s)", &name, &from, &to);
 
   if (name[0] == ':' &&
       strcmp (name, from) == 0 &&


### PR DESCRIPTION
g_variant_get (..., "s", ...) copies the string out of the variant.
g_variant_get (..., "&s", ...) borrows it from the variant, which is
what we want here.

Signed-off-by: Simon McVittie <smcv@collabora.com>