### PR TITLE
Refactor in preparation for using org.freedesktop.DBus.Containers1

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -28,6 +28,10 @@
 
 #include "xdp-utils.h"
 
+#define DBUS_NAME_DBUS "org.freedesktop.DBus"
+#define DBUS_INTERFACE_DBUS DBUS_NAME_DBUS
+#define DBUS_PATH_DBUS "/org/freedesktop/DBus"
+
 G_LOCK_DEFINE (app_infos);
 static GHashTable *app_infos;
 
@@ -345,9 +349,9 @@ xdp_connection_lookup_app_info_sync (GDBusConnection       *connection,
   if (app_info)
     return g_steal_pointer (&app_info);
 
-  msg = g_dbus_message_new_method_call ("org.freedesktop.DBus",
-                                        "/org/freedesktop/DBus",
-                                        "org.freedesktop.DBus",
+  msg = g_dbus_message_new_method_call (DBUS_NAME_DBUS,
+                                        DBUS_PATH_DBUS,
+                                        DBUS_INTERFACE_DBUS,
                                         "GetConnectionCredentials");
   g_dbus_message_set_body (msg, g_variant_new ("(s)", sender));
 
@@ -431,10 +435,10 @@ xdp_connection_track_name_owners (GDBusConnection *connection,
                                   XdpPeerDiedCallback peer_died_cb)
 {
   g_dbus_connection_signal_subscribe (connection,
-                                      "org.freedesktop.DBus",
-                                      "org.freedesktop.DBus",
+                                      DBUS_NAME_DBUS,
+                                      DBUS_INTERFACE_DBUS,
                                       "NameOwnerChanged",
-                                      "/org/freedesktop/DBus",
+                                      DBUS_PATH_DBUS,
                                       NULL,
                                       G_DBUS_SIGNAL_FLAGS_NONE,
                                       name_owner_changed,

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -410,7 +410,7 @@ name_owner_changed (GDBusConnection *connection,
   const char *name, *from, *to;
   XdpPeerDiedCallback peer_died_cb = user_data;
 
-  g_variant_get (parameters, "(sss)", &name, &from, &to);
+  g_variant_get (parameters, "(&s&s&s)", &name, &from, &to);
 
   if (name[0] == ':' &&
       strcmp (name, from) == 0 &&


### PR DESCRIPTION
I've been working on [improving containers support in the reference implementation of D-Bus](https://bugs.freedesktop.org/show_bug.cgi?id=100344).

This branch contains some refactoring on the way to that:
* Make more use of constants
* Make it clearer that the hash table currently named app_infos is indexed by the unique name of a D-Bus peer (because I'm going to add a parallel hash table indexed by the fd.o#100344 container ID)
* Use a tagged union to distinguish between Flatpak and other container technologies, and generalize the storage of technology-specific metadata a bit (this might be useful for #155 and #136)

It also includes #162.