### PR TITLE
[WIP, don't merge yet] Use o.fd.DBus.Containers1 to identify D-Bus peers

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -28,6 +28,10 @@
 
 #include "xdp-utils.h"
 
+#define DBUS_NAME_DBUS "org.freedesktop.DBus"
+#define DBUS_INTERFACE_DBUS DBUS_NAME_DBUS
+#define DBUS_PATH_DBUS "/org/freedesktop/DBus"
+
 G_LOCK_DEFINE (app_infos);
 static GHashTable *app_infos;
 
@@ -345,9 +349,9 @@ xdp_connection_lookup_app_info_sync (GDBusConnection       *connection,
   if (app_info)
     return g_steal_pointer (&app_info);
 
-  msg = g_dbus_message_new_method_call ("org.freedesktop.DBus",
-                                        "/org/freedesktop/DBus",
-                                        "org.freedesktop.DBus",
+  msg = g_dbus_message_new_method_call (DBUS_NAME_DBUS,
+                                        DBUS_PATH_DBUS,
+                                        DBUS_INTERFACE_DBUS,
                                         "GetConnectionCredentials");
   g_dbus_message_set_body (msg, g_variant_new ("(s)", sender));
 
@@ -431,10 +435,10 @@ xdp_connection_track_name_owners (GDBusConnection *connection,
                                   XdpPeerDiedCallback peer_died_cb)
 {
   g_dbus_connection_signal_subscribe (connection,
-                                      "org.freedesktop.DBus",
-                                      "org.freedesktop.DBus",
+                                      DBUS_NAME_DBUS,
+                                      DBUS_INTERFACE_DBUS,
                                       "NameOwnerChanged",
-                                      "/org/freedesktop/DBus",
+                                      DBUS_PATH_DBUS,
                                       NULL,
                                       G_DBUS_SIGNAL_FLAGS_NONE,
                                       name_owner_changed,

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -410,7 +410,7 @@ name_owner_changed (GDBusConnection *connection,
   const char *name, *from, *to;
   XdpPeerDiedCallback peer_died_cb = user_data;
 
-  g_variant_get (parameters, "(sss)", &name, &from, &to);
+  g_variant_get (parameters, "(&s&s&s)", &name, &from, &to);
 
   if (name[0] == ':' &&
       strcmp (name, from) == 0 &&


### PR DESCRIPTION
This branch follows on from #163 to make use of fd.o#100344 to identify D-Bus peers. If the result of `GetConnectionCredentials()` contains the *container instance ID* from fd.o#100344, then we fetch the rest of the metadata from the dbus-daemon instead of reading `/.flatpak-info`.

In principle this should work for Snap too (see also #155, #136), but it would need to be wired up in the same way as the current Flatpak support (by looking for the well-known string identifying the container type, which I assume might be `io.snapcraft` or something, and storing whatever is needed in the data structure).

I haven't yet tried [reading the container ID from the message header](https://bugs.freedesktop.org/show_bug.cgi?id=101899) via the GDBusMethodInvocation (which will need either minor GDBus enhancements, or a hack). When implemented, that will enable us to avoid calling `GetConnectionCredentials()` at all, if we have access to a `GDBusMethodInvocation` and not just a sender name.