### PR TITLE
Do not assume when file doesn't exist that we don't have access to it

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -680,8 +680,6 @@ app_has_file_access (const char *target_app_id,
       if (strcmp (res, "read-only") == 0 &&
           ((target_perms & DOCUMENT_PERMISSION_FLAGS_WRITE) == 0))
         return TRUE;
-
-      return FALSE;
     }
 
   /* Secondly we fall back to a simple check that will not be perfect but should not


### PR DESCRIPTION
In scenario when we use --filesystem=host and trying to save a file which doesn't exist yet, then e.g. "flatpak info --file-access=/home/usr/foo org.kde.kate" call will return "hidden", but that's just because this file doesn't exist and we actually have access to it. We shouldn't in this case return false immediately, but call app_has_file_access_fallback() to verify it further.