### PR TITLE
file-chooser: Handle save-file backend failure

### DIFF
--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -478,8 +478,8 @@ save_file_done (GObject *source,
                 gpointer data)
 {
   g_autoptr(Request) request = data;
-  guint response;
-  GVariant *options;
+  guint response = 2;
+  g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GTask) task = NULL;
 


### PR DESCRIPTION
Don't crash when a save-file backend call fails. We'd do so because
we'd compare with and pass around uninitialized data if _finish() call
failed. Avoid this as done elsewhere by initializing the variables
passed to the _finish() function.