### PR TITLE
screen-cast: add missing sync request

### DIFF
--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -538,6 +538,8 @@ discover_node_factory_sync (PipeWireRemote *remote,
                                   &registry_events,
                                   remote);
 
+  pw_core_proxy_sync(core_proxy, ++remote->registry_sync_seq);
+
   pw_main_loop_run (remote->loop);
 
   if (remote->node_factory_id == 0)


### PR DESCRIPTION
We wait until we get the last object from the registry by looking at
a sync reply with the sequence number in registry_sync_seq. Add the
missing sync request to make this work.