### PR TITLE
remote-desktop: Correct device type values

### DIFF
--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -326,7 +326,7 @@
         <simplelist>
           <member>1: KEYBOARD</member>
           <member>2: POINTER</member>
-          <member>3: TOUCHSCREEN</member>
+          <member>4: TOUCHSCREEN</member>
         </simplelist>
     -->
     <property name="AvailableDeviceTypes" type="u" access="read"/>

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -349,7 +349,7 @@
         <simplelist>
           <member>1: KEYBOARD</member>
           <member>2: POINTER</member>
-          <member>3: TOUCHSCREEN</member>
+          <member>4: TOUCHSCREEN</member>
         </simplelist>
     -->
     <property name="AvailableDeviceTypes" type="u" access="read"/>

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -69,9 +69,9 @@ typedef enum _RemoteDesktopSessionState
 typedef enum _DeviceType
 {
   DEVICE_TYPE_NONE = 0,
-  DEVICE_TYPE_POINTER,
-  DEVICE_TYPE_KEYBOARD,
-  DEVICE_TYPE_TOUCHSCREEN,
+  DEVICE_TYPE_KEYBOARD = 1 << 0,
+  DEVICE_TYPE_POINTER = 1 << 1,
+  DEVICE_TYPE_TOUCHSCREEN = 1 << 2,
 } DeviceType;
 
 typedef struct _RemoteDesktopSession


### PR DESCRIPTION
The devices are bits in a bitmask, but were numbered 1, 2 and 3, both
in the API documentation and in the implementation. The order in the
implementation was also incorrect.