### PR TITLE
Don't register http: uris

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -178,6 +178,19 @@ is_sandboxed (GDesktopAppInfo *info)
 }
 
 static gboolean
+is_file_uri (const char *uri)
+{
+  g_autofree char *scheme = NULL;
+
+  scheme = g_uri_parse_scheme (uri);
+
+  if (g_strcmp0 (scheme, "file") == 0)
+    return TRUE;
+
+  return FALSE;
+}
+
+static gboolean
 launch_application_with_uri (const char *choice_id,
                              const char *uri,
                              const char *parent_window,
@@ -189,7 +202,7 @@ launch_application_with_uri (const char *choice_id,
   g_autofree char *ruri = NULL;
   GList uris;
 
-  if (is_sandboxed (info))
+  if (is_sandboxed (info) && is_file_uri (uri))
     {
       g_autoptr(GError) error = NULL;
 


### PR DESCRIPTION
When we have a sandboxed handler, we try to register
the uri with the document portal to ensure that the
handler can access it. But this only makes sense if
the uri is a file: one.

This was causing failures when opening http: uris
via the portal with a sandboxed epiphany.

See https://github.com/flatpak/xdg-desktop-portal/issues/173