### PR TITLE
README: Fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The portal interfaces include APIs for file access, opening URIs, printing
 and others.
 
 Documentation for the available D-Bus interfaces can be found	
-[here](http://flatpak.org/xdg-desktop-portal/portal-docs.html).
+[here](https://flatpak.github.io/xdg-desktop-portal/portal-docs.html).
 
 ## Building xdg-desktop-portal
 


### PR DESCRIPTION
Use the new docs URL as mentioned in
https://github.com/flatpak/xdg-desktop-portal/issues/138#issuecomment-376379696