### PR TITLE
Support non-O_PATH fds for adding existing files

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -605,12 +605,14 @@ portal_add (GDBusMethodInvocation *invocation,
               DOCUMENT_PERMISSION_FLAGS_READ;
 
             if (access_mode & W_OK)
-              perms |= DOCUMENT_PERMISSION_FLAGS_WRITE;
+              {
+                perms |= DOCUMENT_PERMISSION_FLAGS_WRITE;
 
-            /* If its a unique one its safe for the creator to
-               delete it at will */
-            if (!reuse_existing)
-              perms |= DOCUMENT_PERMISSION_FLAGS_DELETE;
+                /* If its a unique one its safe for the creator to
+                   delete it at will */
+                if (!reuse_existing)
+                  perms |= DOCUMENT_PERMISSION_FLAGS_DELETE;
+              }
 
             do_set_permissions (entry, id, app_id, perms);
           }
@@ -882,11 +884,13 @@ portal_add_full (GDBusMethodInvocation *invocation,
     DocumentPermissionFlags caller_base_perms =
       DOCUMENT_PERMISSION_FLAGS_GRANT_PERMISSIONS |
       DOCUMENT_PERMISSION_FLAGS_READ;
+    DocumentPermissionFlags caller_write_perms =
+      DOCUMENT_PERMISSION_FLAGS_WRITE;
 
     /* If its a unique one its safe for the creator to
        delete it at will */
     if (!reuse_existing)
-      caller_base_perms |= DOCUMENT_PERMISSION_FLAGS_DELETE;
+      caller_write_perms |= DOCUMENT_PERMISSION_FLAGS_DELETE;
 
     XDP_AUTOLOCK (db); /* Lock once for all ops */
 
@@ -913,7 +917,7 @@ portal_add_full (GDBusMethodInvocation *invocation,
                 DocumentPermissionFlags caller_perms = caller_base_perms;
 
                 if (access_modes[i] & W_OK)
-                  caller_perms |= DOCUMENT_PERMISSION_FLAGS_WRITE;
+                  caller_perms |= caller_write_perms;
 
                 g_autoptr(PermissionDbEntry) entry = permission_db_lookup (db, id);;
                 do_set_permissions (entry, id, app_id, caller_perms);

--- a/src/email.c
+++ b/src/email.c
@@ -170,7 +170,7 @@ handle_compose_email (XdpEmail *object,
               return TRUE;
             }
 
-          path = xdp_app_info_get_path_for_fd (request->app_info, fd);
+          path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, NULL);
           g_variant_builder_add (&attachments, "s", path);
         }
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -518,9 +518,11 @@ handle_open_in_thread_func (GTask *task,
   else
     {
       g_autofree char *path = NULL;
+      gboolean fd_is_writable;
 
-      path = xdp_app_info_get_path_for_fd (request->app_info, fd);
-      if (path == NULL)
+      path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, &fd_is_writable);
+      if (path == NULL ||
+          (writable && !fd_is_writable))
         {
           /* Reject the request */
           if (request->exported)

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -21,6 +21,10 @@
 
 #pragma once
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <gio/gio.h>
 #include <errno.h>
 
@@ -47,10 +51,14 @@ XdpAppInfo *xdp_app_info_ref             (XdpAppInfo  *app_info);
 void        xdp_app_info_unref           (XdpAppInfo  *app_info);
 const char *xdp_app_info_get_id          (XdpAppInfo  *app_info);
 gboolean    xdp_app_info_is_host         (XdpAppInfo  *app_info);
+gboolean    xdp_app_info_supports_opath  (XdpAppInfo  *app_info);
 char *      xdp_app_info_remap_path      (XdpAppInfo  *app_info,
                                           const char  *path);
 char *      xdp_app_info_get_path_for_fd (XdpAppInfo  *app_info,
-                                          int          fd);
+                                          int          fd,
+                                          int          require_st_mode,
+                                          struct stat *st_buf,
+                                          gboolean    *writable_out);
 XdpAppInfo *xdp_get_app_info_from_pid    (pid_t        pid,
                                           GError     **error);
 


### PR DESCRIPTION
As discussed in https://github.com/flatpak/xdg-desktop-portal/issues/167 using O_PATH to pass proof of access to a file is not good enough for e.g. snap, as it only means the sandbox can see the pathname, not that it can e.g. open it. So, if the fd is not O_PATH we use the open flags to detect if the file should be writable or not.

For directories we still use O_PATH because there is no way to prove writability to a directory. However, AddNamed*() is only callable from the host, so that is not really a problem.

We still support O_PATH for host and flatpak callers, because those  are safe and there are still code out there using this.
