### PR TITLE
OpenURI: Don't skip the dialog based on content type if a threshold is set

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -547,7 +547,7 @@ handle_open_in_thread_func (GTask *task,
   find_recommended_choices (scheme, content_type, &choices, &skip_app_chooser);
   get_latest_choice_info (app_id, content_type, &latest_id, &latest_count, &latest_threshold, &always_ask);
 
-  if (skip_app_chooser || (!always_ask && (latest_count >= latest_threshold)))
+  if ((always_ask && skip_app_chooser) || (!always_ask && (latest_count >= latest_threshold)))
     {
       /* If a recommended choice is found, just use it and skip the chooser dialog */
       gboolean result = launch_application_with_uri (skip_app_chooser ? choices[0] : latest_id,


### PR DESCRIPTION
If a threshold is set for a given content-type/schema and app ID in the
permission store, we should make the decision on whether to show the
app chooser dialog or not based only on whether such threshold has been
reached by consistently selecting the same app a big enough amount of
consecutive times, not based on whether we're opening a directory or
a HTTP/HTTPs URI (only cases when we currently might skip the dialog).

If a threshold is not set (this is the default unless the permission store
has been altered with an external tool), the current behaviour is kept
and the dialog will still be skipped for those special cases.

https://github.com/flatpak/xdg-desktop-portal/issues/149