### PR TITLE
Include the flatpak portal docs

### DIFF
--- a/data/org.freedesktop.portal.OpenURI.xml
+++ b/data/org.freedesktop.portal.OpenURI.xml
@@ -43,7 +43,7 @@
         window. Support for other window systems may be added in the future.
 
         Note that file:// uris are explicitly not supported by this method.
-        To request opening local files, use org.freedesktop.portal.OpenFile().
+        To request opening local files, use org.freedesktop.portal.OpenURI.OpenFile().
 
         Supported keys in the @options vardict include:
         <variablelist>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,6 +1,10 @@
 NULL =
 
+org.freedesktop.portal.Flatpak.xml :
+	cp $(datadir)/dbus-1/interfaces/org.freedesktop.portal.Flatpak.xml .
+
 portal_files = 								\
+	org.freedesktop.portal.Flatpak.xml		 		\
 	$(top_srcdir)/data/org.freedesktop.portal.Request.xml 		\
 	$(top_srcdir)/data/org.freedesktop.portal.Session.xml 		\
 	$(top_srcdir)/data/org.freedesktop.portal.FileChooser.xml 	\
@@ -32,6 +36,7 @@ portal_files = 								\
 	$(NULL)
 
 xml_files = 								\
+	portal-org.freedesktop.portal.Flatpak.xml 			\
 	portal-org.freedesktop.portal.Request.xml 			\
 	portal-org.freedesktop.portal.Session.xml 			\
 	portal-org.freedesktop.portal.FileChooser.xml 			\
@@ -63,6 +68,7 @@ xml_files = 								\
 	$(NULL)
 
 EXTRA_DIST = \
+	org.freedesktop.portal.Flatpak.xml \
 	docbook.css		\
 	portal-docs.xml.in	\
 	xmlto-config.xsl	\

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -45,6 +45,7 @@
     <xi:include href="portal-org.freedesktop.portal.NetworkMonitor.xml"/>
     <xi:include href="portal-org.freedesktop.portal.ProxyResolver.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Documents.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.Flatpak.xml"/>
   </reference>
   <reference>
     <title>Portal Backend API Reference</title>


### PR DESCRIPTION
This is a little different, since the flatpak portal actually lives in the flatpak repository, so we include it here from its installed location in /usr/share/dbus-1/interfaces/