### PR TITLE
Handle incomplete create session gracefully

### DIFF
--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -165,8 +165,8 @@ remote_desktop_session_new (GVariant *options,
                             "impl-dbus-name", impl_dbus_name,
                             NULL);
 
-  g_debug ("remote desktop session owned by '%s' created",
-           session->sender);
+  if (session)
+    g_debug ("remote desktop session owned by '%s' created", session->sender);
 
   return (RemoteDesktopSession *)session;
 }

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -155,7 +155,6 @@ remote_desktop_session_new (GVariant *options,
     g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   const char *impl_dbus_name = g_dbus_proxy_get_name (G_DBUS_PROXY (impl));
 
-
   session_token = lookup_session_token (options);
   session = g_initable_new (remote_desktop_session_get_type (), NULL, error,
                             "sender", request->sender,

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -135,8 +135,8 @@ screen_cast_session_new (GVariant *options,
                             "impl-dbus-name", impl_dbus_name,
                             NULL);
 
-  g_debug ("screen cast session owned by '%s' created",
-           session->sender);
+  if (session)
+    g_debug ("screen cast session owned by '%s' created", session->sender);
 
   return (ScreenCastSession*)session;
 }

--- a/src/session.c
+++ b/src/session.c
@@ -426,7 +426,7 @@ session_finalize (GObject *object)
 {
   Session *session = (Session *)object;
 
-  g_assert (!g_hash_table_lookup (sessions, session->id));
+  g_assert (!session->id || !g_hash_table_lookup (sessions, session->id));
 
   g_free (session->sender);
   g_clear_object (&session->connection);


### PR DESCRIPTION
Sending bogus arguments to org.freedesktop.portal.ScreenCast.CreateSession (and probably org.freedesktop.portal.RemoteDesktop.CreateSession) caused xdg-desktop-portal to crash.

See https://github.com/flatpak/xdg-desktop-portal/issues/186