### PR TITLE
Depend on current PipeWire library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ AC_ARG_ENABLE(pipewire,
 	      [AS_HELP_STRING([--enable-pipewire],[Enable PipeWire support. Needed for screen cast portal])],
 	      enable_pipewire=$enableval, enable_pipewire=yes)
 if test x$enable_pipewire = xyes ; then
-	PKG_CHECK_MODULES(PIPEWIRE, [libpipewire-0.1 >= 0.1.8])
+	PKG_CHECK_MODULES(PIPEWIRE, [libpipewire-0.2 >= 0.2.2])
 	AC_DEFINE([HAVE_PIPEWIRE],[1], [Define to enable PipeWire support])
 fi
 AM_CONDITIONAL([HAVE_PIPEWIRE],[test "$enable_pipewire" = "yes"])


### PR DESCRIPTION
PipeWire 0.2.x changed API and is not ABI compatible with 0.1.x versions. We should require latest one as it's probably the one used at this moment and in near future. Also minor problem is that PW 0.2.0 and 0.2.1 were missing to bump version in library name, thus libpipewire-0.2 exists with PW 0.2.2 and newer.