### PR TITLE
network monitor: Add GetStatus and CanReach methods

### DIFF
--- a/data/org.freedesktop.portal.NetworkMonitor.xml
+++ b/data/org.freedesktop.portal.NetworkMonitor.xml
@@ -119,6 +119,21 @@
       <arg type='a{sv}' name='status' direction='out'/>
     </method>
 
+    <!--
+        CanReach:
+        @hostname: the hostname to reach
+        @port: the port to reach
+        @reachable: Whether the hostname:port was reachable
+
+        Returns whether the given hostname is believed to be reachable.
+        This method was added in version 3.
+    -->
+    <method name="CanReach">
+      <arg type='s' name='hostname' direction='in'/>
+      <arg type='u' name='port' direction='in'/>
+      <arg type='b' name='reachable' direction='out'/>
+    </method>
+
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.NetworkMonitor.xml
+++ b/data/org.freedesktop.portal.NetworkMonitor.xml
@@ -28,7 +28,7 @@
       expected to use this interface indirectly, via a library API
       such as the GLib GNetworkMonitor interface.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes version 3 of this interface.
   -->
   <interface name="org.freedesktop.portal.NetworkMonitor">
     <!--
@@ -70,7 +70,7 @@
         GetConnectivity:
         @connectivity: the level of connectivity
 
-        Returs more detailed information about the host's network
+        Returns more detailed information about the host's network
         connectivity. The meaning of the value is:
         <simplelist>
           <member>1: Local only. The host is not configured with a route to the internet.</member>
@@ -85,6 +85,40 @@
     <method name="GetConnectivity">
       <arg type='u' name='connectivity' direction='out'/>
     </method>
+    <!--
+        GetStatus:
+        @status: a dictionary with the current values
+
+        Returns the three values all at once.
+
+        The following results get returned via @status:
+        <variablelist>
+          <varlistentry>
+            <term>available b</term>
+            <listitem><para>
+              Whether the network is available.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>metered b</term>
+            <listitem><para>
+              Whether the network is metered.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>connectivity u</term>
+            <listitem><para>
+              The level of connectivity.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        This method was added in version 3 to avoid multiple round-trips.
+    -->
+    <method name="GetStatus">
+      <arg type='a{sv}' name='status' direction='out'/>
+    </method>
+
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -155,12 +155,54 @@ handle_get_status (XdpNetworkMonitor     *object,
 }
 
 static void
+can_reach_done (GObject      *source,
+                GAsyncResult *result,
+                gpointer      data)
+{
+  GNetworkMonitor *monitor = G_NETWORK_MONITOR (source);
+  g_autoptr(GDBusMethodInvocation) invocation = data;
+  gboolean reachable;
+
+  reachable = g_network_monitor_can_reach_finish (monitor, result, NULL);
+
+  g_dbus_method_invocation_return_value (invocation, g_variant_new ("(b)", reachable));
+}
+
+static gboolean
+handle_can_reach (XdpNetworkMonitor     *object,
+                  GDBusMethodInvocation *invocation,
+                  const char            *hostname,
+                  guint                  port)
+{
+  Request *request = request_from_invocation (invocation);
+
+  if (!xdp_app_info_has_network (request->app_info))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "This call is not available inside the sandbox");
+    }
+  else
+    {
+      NetworkMonitor *nm = (NetworkMonitor *)object;
+      g_autoptr(GSocketConnectable) address = NULL;
+
+      address = g_network_address_new (hostname, port);
+      g_network_monitor_can_reach_async (nm->monitor, address, NULL, can_reach_done, g_object_ref (invocation)); 
+    }
+
+  return TRUE;
+}
+
+static void
 network_monitor_iface_init (XdpNetworkMonitorIface *iface)
 {
   iface->handle_get_available = handle_get_available;
   iface->handle_get_metered = handle_get_metered;
   iface->handle_get_connectivity = handle_get_connectivity;
-  iface->handle_get_status= handle_get_status;
+  iface->handle_get_status = handle_get_status;
+  iface->handle_can_reach = handle_can_reach;
 }
 
 static void


### PR DESCRIPTION
GetStatus lets us avoid multiple roundtrips to get all the values.
CanReach lets us implement g_network_monitor_can_reach().