### PR TITLE
Trash

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -4,6 +4,7 @@ dist_introspection_DATA = \
 	data/org.freedesktop.portal.Request.xml \
 	data/org.freedesktop.portal.Session.xml \
 	data/org.freedesktop.portal.FileChooser.xml \
+	data/org.freedesktop.portal.Trash.xml \
 	data/org.freedesktop.portal.OpenURI.xml \
 	data/org.freedesktop.portal.Print.xml \
 	data/org.freedesktop.portal.NetworkMonitor.xml \

--- a/data/org.freedesktop.portal.Trash.xml
+++ b/data/org.freedesktop.portal.Trash.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2016 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Trash:
+      @short_description: Portal for trashing files
+
+      This simple interface lets sandboxed applications send files to
+      the trashcan.
+
+      This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.Trash">
+    <!--
+        TrashFile:
+	@fd: file descriptor for the file to trash
+        @result: the result. 0 if trashing failed, 1 if trashing succeeded, other values may be returned in the future
+
+        Sends a file to the trashcan. Applications are allowed to
+        trash a file if they can open it in r/w mode.
+    -->
+    <method name="TrashFile">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="h" name="fd" direction="in"/>
+      <arg type="u" name="result" direction="out"/>
+    </method>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -8,6 +8,7 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.portal.Request.xml 		\
 	$(top_srcdir)/data/org.freedesktop.portal.Session.xml 		\
 	$(top_srcdir)/data/org.freedesktop.portal.FileChooser.xml 	\
+	$(top_srcdir)/data/org.freedesktop.portal.Trash.xml 		\
 	$(top_srcdir)/data/org.freedesktop.portal.OpenURI.xml 		\
 	$(top_srcdir)/data/org.freedesktop.portal.Print.xml 		\
 	$(top_srcdir)/data/org.freedesktop.portal.Email.xml 		\
@@ -40,6 +41,7 @@ xml_files = 								\
 	portal-org.freedesktop.portal.Request.xml 			\
 	portal-org.freedesktop.portal.Session.xml 			\
 	portal-org.freedesktop.portal.FileChooser.xml 			\
+	portal-org.freedesktop.portal.Trash.xml 			\
 	portal-org.freedesktop.portal.OpenURI.xml 			\
 	portal-org.freedesktop.portal.Print.xml 			\
 	portal-org.freedesktop.portal.Email.xml 			\

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -92,6 +92,7 @@
     <xi:include href="portal-org.freedesktop.portal.Request.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Session.xml"/>
     <xi:include href="portal-org.freedesktop.portal.FileChooser.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.Trash.xml"/>
     <xi:include href="portal-org.freedesktop.portal.OpenURI.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Print.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Email.xml"/>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -19,6 +19,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.Request.xml \
 	data/org.freedesktop.portal.Session.xml \
 	data/org.freedesktop.portal.FileChooser.xml \
+	data/org.freedesktop.portal.Trash.xml \
 	data/org.freedesktop.portal.OpenURI.xml \
 	data/org.freedesktop.portal.Print.xml \
 	data/org.freedesktop.portal.NetworkMonitor.xml \
@@ -122,6 +123,8 @@ xdg_desktop_portal_SOURCES = \
         src/email.h                     \
 	src/session.c			\
 	src/session.h			\
+	src/trash.c			\
+	src/trash.h			\
 	src/xdp-utils.c			\
 	src/xdp-utils.h			\
 	$(NULL)

--- a/src/trash.c
+++ b/src/trash.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+
+#include <locale.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+#include "trash.h"
+#include "request.h"
+#include "documents.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+#include "xdp-utils.h"
+
+typedef struct _Trash Trash;
+typedef struct _TrashClass TrashClass;
+
+struct _Trash
+{
+  XdpTrashSkeleton parent_instance;
+};
+
+struct _TrashClass
+{
+  XdpTrashSkeletonClass parent_class;
+};
+
+static Trash *trash;
+
+GType trash_get_type (void) G_GNUC_CONST;
+static void trash_iface_init (XdpTrashIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Trash, trash, XDP_TYPE_TRASH_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_TRASH, trash_iface_init));
+
+static guint
+trash_file (XdpAppInfo *app_info,
+            const char *sender,
+            int fd)
+{
+  g_autofree char *path = NULL;
+  gboolean writable;
+  g_autoptr(GFile) file = NULL;
+
+  path = xdp_app_info_get_path_for_fd (app_info, fd, 0, NULL, &writable);
+
+  if (path == NULL || !writable)
+    return 0;
+
+  file = g_file_new_for_path (path);
+  if (!g_file_trash (file, NULL, NULL))
+    return 0;
+
+  return 1;
+}
+
+static gboolean
+handle_trash_file (XdpTrash *object,
+                   GDBusMethodInvocation *invocation,
+                   GUnixFDList *fd_list,
+                   GVariant *arg_fd)
+{
+  Request *request = request_from_invocation (invocation);
+  int idx, fd;
+  guint result;
+
+  REQUEST_AUTOLOCK (request);
+
+  g_variant_get (arg_fd, "h", &idx);
+  fd = g_unix_fd_list_get (fd_list, idx, NULL);
+
+  result = trash_file (request->app_info, request->sender, fd);
+
+  xdp_trash_complete_trash_file (object, invocation, NULL, result);
+
+  return TRUE;
+}
+
+static void
+trash_iface_init (XdpTrashIface *iface)
+{
+  iface->handle_trash_file = handle_trash_file;
+}
+
+static void
+trash_init (Trash *fc)
+{
+  xdp_trash_set_version (XDP_TRASH (fc), 1);
+}
+
+static void
+trash_class_init (TrashClass *klass)
+{
+}
+
+GDBusInterfaceSkeleton *
+trash_create (GDBusConnection *connection)
+{
+  trash = g_object_new (trash_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (trash);
+}

--- a/src/trash.h
+++ b/src/trash.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * trash_create (GDBusConnection *connection);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -46,6 +46,7 @@
 #include "email.h"
 #include "screen-cast.h"
 #include "remote-desktop.h"
+#include "trash.h"
 
 static GMainLoop *loop = NULL;
 
@@ -376,6 +377,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   export_portal_implementation (connection, network_monitor_create (connection));
   export_portal_implementation (connection, proxy_resolver_create (connection));
+  export_portal_implementation (connection, trash_create (connection));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.FileChooser");
   if (implementation != NULL)


### PR DESCRIPTION
Here is a minimal trash implementation. I looked briefly at adding a way to restore files, but we don't load gvfs in the portal frontend, so we can't operate on trash:///. Moving the trash implementation to the backend would be an option, but we currently don't load gvfs there either...