### PR TITLE
inhibit: Add session state monitoring

### DIFF
--- a/data/org.freedesktop.impl.portal.Inhibit.xml
+++ b/data/org.freedesktop.impl.portal.Inhibit.xml
@@ -64,5 +64,48 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
+
+    <!--
+        CreateMonitor:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @session_handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @app_id: App id of the application
+        @window: the parent window
+
+        Creates a monitoring session. While this session is
+        active, the caller will receive StateChanged signals
+        with updates on the session state.
+    -->
+    <method name="CreateMonitor">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="window" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+    </method>
+
+    <!--
+        StateChanged:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @state: Vardict with information about the session state
+
+        The StateChanged signal is sent to active monitoring sessions when
+        the session state changes.
+
+        The following information may get returned in the @state vardict:
+        <variablelist>
+           <varlistentry>
+            <term>screensaver-active b</term>
+            <listitem><para>
+              Whether the screensaver is active.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <signal name="StateChanged">
+      <arg type="o" name="session_handle" direction="out"/>
+      <arg type="a{sv}" name="state" direction="out"/>
+    </signal>
+
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -26,7 +26,7 @@
       This simple interface lets sandboxed applications inhibit the user
       session from ending, suspending, idling or getting switched away.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Inhibit">
     <!--
@@ -70,6 +70,85 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+
+    <!--
+        CreateMonitor:
+        @window: the parent window
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Creates a monitoring session. While this session is
+        active, the caller will receive StateChanged signals
+        with updates on the session state.
+
+        A successfully created session can at any time be closed using
+        org.freedesktop.portal.Session::Close, or may at any time be closed
+        by the portal implementation, which will be signalled via
+        org.freedesktop.portal.Session::Closed.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the @handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Request documentation for
+              more information about the @handle.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>session_handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the session handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Session documentation for
+              more information about the session handle.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>session_handle o</term>
+            <listitem><para>
+              The session handle. An object path for the
+              #org.freedesktop.portal.Session object representing the created
+              session.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        This method was added in version 2 of this interface.
+    -->
+    <method name="CreateMonitor">
+      <arg type="s" name="window" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+        StateChanged:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @state: Vardict with information about the session state
+
+        The StateChanged signal is sent to active monitoring sessions when
+        the session state changes.
+
+        The following information may get returned in the @state vardict:
+        <variablelist>
+          <varlistentry>
+            <term>screensaver-active b</term>
+            <listitem><para>
+              Whether the screensaver is active.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <signal name="StateChanged">
+      <arg type="o" name="session_handle" direction="out"/>
+      <arg type="a{sv}" name="state" direction="out"/>
+    </signal>
+
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/request.c
+++ b/src/request.c
@@ -194,7 +194,10 @@ get_token (GDBusMethodInvocation *invocation)
     }
   else if (strcmp (interface, "org.freedesktop.portal.Inhibit") == 0)
     {
-      options = g_variant_get_child_value (parameters, 2);
+      if (strcmp (method, "Inhibit") == 0)
+        options = g_variant_get_child_value (parameters, 2);
+      else if (strcmp (method, "CreateMonitor") == 0)
+        options = g_variant_get_child_value (parameters, 1);
     }
   else if (strcmp (interface, "org.freedesktop.portal.NetworkMonitor") == 0)
     {

--- a/src/session.c
+++ b/src/session.c
@@ -111,6 +111,20 @@ acquire_session_from_call (const char *session_handle,
   return g_steal_pointer (&session);
 }
 
+Session *
+lookup_session (const char *session_handle)
+{
+  g_autoptr(Session) session = NULL;
+
+  G_LOCK (sessions);
+  session = g_hash_table_lookup (sessions, session_handle);
+  if (session)
+    g_object_ref (session);
+  G_UNLOCK (sessions);
+
+  return g_steal_pointer (&session);
+}
+
 gboolean
 session_export (Session *session,
                 GError **error)

--- a/src/session.h
+++ b/src/session.h
@@ -67,6 +67,8 @@ Session * acquire_session (const char *session_handle,
 Session * acquire_session_from_call (const char *session_handle,
                                      Call *call);
 
+Session * lookup_session (const char *session_handle);
+
 void session_register (Session *session);
 
 gboolean session_export (Session *session,


### PR DESCRIPTION
For now, this just includes the screensaver-active
state, since several applications are using this.
More can be added.

We can avoid leaking this information to everybody
by putting a CreateMonitor request in front of it.