### PR TITLE
network-monitor: Fix variant type

### DIFF
--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -140,14 +140,18 @@ handle_get_status (XdpNetworkMonitor     *object,
     {
       NetworkMonitor *nm = (NetworkMonitor *)object;
       GVariantBuilder status;
+      gboolean v;
 
       g_variant_builder_init (&status, G_VARIANT_TYPE_VARDICT);
+      v = g_network_monitor_get_network_available (nm->monitor);
       g_variant_builder_add (&status, "{sv}",
-                             "available", g_network_monitor_get_network_available (nm->monitor));
+                             "available", g_variant_new_boolean (v));
+      v = g_network_monitor_get_network_metered (nm->monitor);
       g_variant_builder_add (&status, "{sv}",
-                             "metered", g_network_monitor_get_network_metered (nm->monitor));
+                             "metered", g_variant_new_boolean (v));
+      v = g_network_monitor_get_connectivity (nm->monitor);
       g_variant_builder_add (&status, "{sv}",
-                             "connectivity", g_network_monitor_get_connectivity (nm->monitor));
+                             "connectivity", g_variant_new_boolean (v));
       g_dbus_method_invocation_return_value (invocation, g_variant_new ("(a{sv})", &status));
     }
 


### PR DESCRIPTION
Vardict entries are of type {sv}, so wrap the actual value in a variant.