### PR TITLE
network-monitor: Use ::network-changed for change notifications

### DIFF
--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -211,9 +211,9 @@ network_monitor_iface_init (XdpNetworkMonitorIface *iface)
 }
 
 static void
-notify (GObject *object,
-        GParamSpec *pspec,
-        NetworkMonitor *nm)
+network_changed (GObject *object,
+                 gboolean network_available,
+                 NetworkMonitor *nm)
 {
   xdp_network_monitor_emit_changed (XDP_NETWORK_MONITOR (nm));
 }
@@ -223,7 +223,7 @@ network_monitor_init (NetworkMonitor *nm)
 {
   nm->monitor = g_network_monitor_get_default ();
 
-  g_signal_connect (nm->monitor, "notify", G_CALLBACK (notify), nm);
+  g_signal_connect (nm->monitor, "network-changed", G_CALLBACK (network_changed), nm);
 
   xdp_network_monitor_set_version (XDP_NETWORK_MONITOR (nm), 3);
 }


### PR DESCRIPTION
The ::network-changed signal is emitted when the network configuration
changes, which doesn't necessarily mean a change of network availability
or connectivity. For example connecting to a VPN doesn't usually change
the general online state, but as additional services become available,
clients may want to retry previously failed connection attempts.

To support this use case in the portal implementation, simply relay
the "native" network monitor's ::network-changed signal instead of
listening for property changes.