### PR TITLE
File transfer

### DIFF
--- a/data/org.freedesktop.portal.FileTransfer.xml
+++ b/data/org.freedesktop.portal.FileTransfer.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2018 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+       org.freedesktop.portal.FileTransfer:
+       @short_description: Portal for transferring files between apps
+
+       The FileTransfer portal operates as a middle-man between apps
+       when transferring files via drag-and-drop or copy-paste, taking
+       care of the necessary exporting of files in the document portal.
+
+       Toolkits are expected to use the application/vnd.portal.filetransfer
+       mimetype when using this mechanism for file exchange via copy-paste
+       or drag-and-drop.
+
+       The data that is transmitted with this mimetype should be the key
+       returned by the StartTransfer method. Upon receiving this mimetype,
+       the target should call RetrieveFiles with the key, to obtain the
+       list of files. The portal will take care of exporting files in
+       the document store as necessary to make them accessible to the
+       target.
+
+       The D-Bus interface for the this portal is available under the
+       bus name org.freedesktop.portal.Documents and the object path
+       /org/freedesktop/portal/documents.
+
+       This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.FileTransfer">
+    <!--
+        StartTransfer:
+        @options: Vardict with optional further onformation
+        @key: a key that needs to be passed to RetrieveFiles to obtain the files
+
+	Starts a session for a file transfer.
+        The caller should call AddFiles at least once, to add files to this session.
+
+        Another application can then call RetrieveFiles to obtain them, if it has
+        the @session and @secret.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>writable b</term>
+            <listitem><para>
+              Whether to allow the chosen application to write to the files.
+              Default: False
+            </para><para>
+              This key only takes effect for files that need to be exported
+              in the document portal for the receiving app. But it does require
+              the passed-in file descriptors to be writable.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>autostop b</term>
+            <listitem><para>
+              Whether to stop the transfer automatically after the first
+              RetrieveFiles call. Default: True
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="StartTransfer">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="s" name="key" direction="out"/>
+    </method>
+
+    <!--
+        AddFiles:
+        @key: A key returned by StartTransfer
+        @fds: File descriptors for the files to register
+
+        Adds files to a session. This method can be called multiple times on
+        a given session. Note that only regular files (not directories) can
+        be added.
+
+        Note that the session bus often has a low limit of file descriptors per
+        message (typically, 16), so you may have to send large file lists with
+        multiple AddFiles calls.
+    -->
+    <method name="AddFiles">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="s" name="key" direction="in"/>
+      <arg type="ah" name="fds" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+    </method>
+
+    <!--
+        RetrieveFiles:
+        @key: A key returned by StartTransfer
+        @options: Vardict with optional further onformation
+        @files: list of paths
+
+        Retrieves files that were previously added to the session with
+        AddFiles. The files will be exported in the document portal
+        as-needed for the caller, and they will be writable if the
+        owner of the session allowed it.
+
+        After the first RetrieveFiles call, the session will be closed
+        by the portal, unless autostop has been set to False.
+    -->
+    <method name="RetrieveFiles">
+      <arg type="s" name="key" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="as" name="files" direction="out"/>
+    </method>
+
+    <!--
+        StopTransfer:
+        @key: A key returned by StartTransfer
+
+        Ends the transfer. Further calls to AddFiles or RetrieveFiles
+        for this key will return an error.
+    -->
+    <method name="StopTransfer">
+      <arg type="s" name="key" direction="in"/>
+    </method>
+
+    <!--
+        TransferClosed:
+        @key: key returned by StartTransfer
+
+        The TransferClosed signal is emitted to the caller of StartTransfer
+        when the transfer is closed.
+    -->
+    <signal name="TransferClosed">
+      <arg type="s" name="key"/>
+    </signal>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -27,6 +27,7 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.portal.Camera.xml		\
 	$(top_srcdir)/data/org.freedesktop.portal.Wallpaper.xml		\
 	$(top_srcdir)/data/org.freedesktop.portal.MemoryMonitor.xml 	\
+	$(top_srcdir)/data/org.freedesktop.portal.FileTransfer.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Request.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Session.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.FileChooser.xml 	\
@@ -74,6 +75,7 @@ xml_files = 								\
 	portal-org.freedesktop.portal.Camera.xml			\
 	portal-org.freedesktop.portal.MemoryMonitor.xml		\
 	portal-org.freedesktop.impl.portal.Background.xml 			\
+	portal-org.freedesktop.portal.FileTransfer.xml			\
 	portal-org.freedesktop.impl.portal.Request.xml 			\
 	portal-org.freedesktop.impl.portal.Session.xml 			\
 	portal-org.freedesktop.impl.portal.FileChooser.xml		\

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -113,6 +113,7 @@
     <xi:include href="portal-org.freedesktop.portal.Documents.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Wallpaper.xml"/>
     <xi:include href="portal-org.freedesktop.portal.MemoryMonitor.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.FileTransfer.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Flatpak.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Flatpak.UpdateMonitor.xml"/>
   </reference>

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -40,13 +40,14 @@ document-portal/permission-store-dbus.c: data/org.freedesktop.impl.portal.Permis
 		$(srcdir)/data/org.freedesktop.impl.portal.PermissionStore.xml	\
 		$(NULL)
 
-document-portal/document-portal-dbus.c: data/org.freedesktop.portal.Documents.xml Makefile
+document-portal/document-portal-dbus.c: data/org.freedesktop.portal.Documents.xml data/org.freedesktop.portal.FileTransfer.xml Makefile
 	mkdir -p $(builddir)/document-portal
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.portal.	\
 		--c-namespace XdpDbus				\
 		--generate-c-code $(builddir)/document-portal/document-portal-dbus	\
 		$(srcdir)/data/org.freedesktop.portal.Documents.xml	\
+		$(srcdir)/data/org.freedesktop.portal.FileTransfer.xml	\
 		$(NULL)
 
 document-portal/%-dbus.h: document-portal/%-dbus.c
@@ -88,6 +89,7 @@ xdg_document_portal_SOURCES = \
 	src/xdp-utils.c	\
 	src/xdp-utils.h	\
 	document-portal/document-portal.c		\
+	document-portal/file-transfer.c			\
 	document-portal/document-enums.h		\
 	document-portal/document-store.h		\
 	document-portal/document-store.c		\

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -18,6 +18,8 @@
 #include "permission-db.h"
 #include "permission-store-dbus.h"
 #include "document-portal-fuse.h"
+#include "file-transfer.h"
+#include "document-portal.h"
 
 #include <sys/eventfd.h>
 
@@ -430,85 +432,43 @@ portal_add (GDBusMethodInvocation *invocation,
             GVariant              *parameters,
             XdpAppInfo            *app_info)
 {
+  int fd_id;
+  gboolean reuse_existing, persistent;
+  DocumentAddFullFlags flags = 0;
   GDBusMessage *message;
   GUnixFDList *fd_list;
-  g_autofree char *id = NULL;
-  int fd_id, fd, fds_len;
-  g_autofree char *path = NULL;
-  gboolean writable;
-  const int *fds;
-  struct stat st_buf, real_parent_st_buf;
-  gboolean reuse_existing, persistent;
   GError *error = NULL;
-  const char *app_id = xdp_app_info_get_id (app_info);
+  g_auto(GStrv) ids = NULL;
 
   g_variant_get (parameters, "(hbb)", &fd_id, &reuse_existing, &persistent);
 
+  if (reuse_existing)
+    flags |= DOCUMENT_ADD_FLAGS_REUSE_EXISTING;
+  if (persistent)
+    flags |= DOCUMENT_ADD_FLAGS_PERSISTENT;
+ 
   message = g_dbus_method_invocation_get_message (invocation);
   fd_list = g_dbus_message_get_unix_fd_list (message);
 
-  fd = -1;
   if (fd_list != NULL)
     {
-      fds = g_unix_fd_list_peek_fds (fd_list, &fds_len);
+      int fds_len;
+      const int *fds = g_unix_fd_list_peek_fds (fd_list, &fds_len);
       if (fd_id < fds_len)
-        fd = fds[fd_id];
+        {
+          int fd = fds[fd_id];
+
+          ids = document_add_full (&fd, 1, flags, app_info, "", 0, &error);
+        }
     }
 
-  if (!validate_fd (fd, app_info, &st_buf, &real_parent_st_buf, &path, &writable, &error))
+  if (ids == NULL)
     {
       g_dbus_method_invocation_take_error (invocation, error);
       return;
     }
 
-  if (st_buf.st_dev == fuse_dev)
-    {
-      /* The passed in fd is on the fuse filesystem itself */
-      id = verify_existing_document (&st_buf, reuse_existing);
-      if (id == NULL)
-        {
-          g_dbus_method_invocation_return_error (invocation,
-                                                 XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                                                 "Invalid fd passed");
-          return;
-        }
-    }
-  else
-    {
-      {
-        XDP_AUTOLOCK (db);
-
-        id = do_create_doc (&real_parent_st_buf, path, reuse_existing, persistent);
-
-        if (app_id[0] != '\0')
-          {
-            g_autoptr(PermissionDbEntry) entry = permission_db_lookup (db, id);
-            DocumentPermissionFlags perms =
-              DOCUMENT_PERMISSION_FLAGS_GRANT_PERMISSIONS |
-              DOCUMENT_PERMISSION_FLAGS_READ;
-
-            if (writable)
-              {
-                perms |= DOCUMENT_PERMISSION_FLAGS_WRITE;
-
-                /* If its a unique one its safe for the creator to
-                   delete it at will */
-                if (!reuse_existing)
-                  perms |= DOCUMENT_PERMISSION_FLAGS_DELETE;
-              }
-
-            do_set_permissions (entry, id, app_id, perms);
-          }
-      }
-
-      /* Invalidate with lock dropped to avoid deadlock */
-      xdp_fuse_invalidate_doc_app (id, NULL);
-      if (app_id[0] != '\0')
-        xdp_fuse_invalidate_doc_app (id, app_id);
-    }
-
-  g_dbus_method_invocation_return_value (invocation,
-                                         g_variant_new ("(s)", id));
+  g_dbus_method_invocation_return_value (invocation, g_variant_new ("(s)", ids[0]));
 }
 
 static char *
@@ -671,29 +631,20 @@ portal_add_full (GDBusMethodInvocation *invocation,
                  GVariant              *parameters,
                  XdpAppInfo            *app_info)
 {
-  const char *app_id = xdp_app_info_get_id (app_info);
+  g_autoptr(GVariant) array = NULL;
+  guint32 flags;
+  const char *target_app_id;
+  const char **permissions = NULL;
+  DocumentPermissionFlags target_perms;
+  gsize n_args;
   GDBusMessage *message;
   GUnixFDList *fd_list;
-  char *id;
-  int fd_id, fd, fds_len;
-  const int *fds = NULL;
-  struct stat st_buf;
-  gboolean reuse_existing, persistent, as_needed_by_app;
+  g_autofree int *fd = NULL;
+  g_auto(GStrv) ids = NULL;
   GError *error = NULL;
-  guint32 flags = 0;
-  g_autoptr(GVariant) array = NULL;
-  const char *target_app_id;
-  g_autofree const char **permissions = NULL;
-  g_autoptr(GPtrArray) ids = g_ptr_array_new_with_free_func (g_free);
-  g_autoptr(GPtrArray) paths = g_ptr_array_new_with_free_func (g_free);
-  g_autofree gboolean *writable = NULL;
-  g_autofree struct stat *real_parent_st_bufs = NULL;
-  int i;
-  gsize n_args;
-  DocumentPermissionFlags target_perms;
   GVariantBuilder builder;
 
-  g_variant_get (parameters, "(@ahus^a&s)",
+  g_variant_get (parameters, "(@ahu&s^a&s)",
                  &array, &flags, &target_app_id, &permissions);
 
   if ((flags & ~DOCUMENT_ADD_FLAGS_FLAGS_ALL) != 0)
@@ -704,10 +655,6 @@ portal_add_full (GDBusMethodInvocation *invocation,
       return;
     }
 
-  reuse_existing = (flags & DOCUMENT_ADD_FLAGS_REUSE_EXISTING) != 0;
-  persistent = (flags & DOCUMENT_ADD_FLAGS_PERSISTENT) != 0;
-  as_needed_by_app = (flags & DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP) != 0;
-
   target_perms = xdp_parse_permissions (permissions, &error);
   if (error)
     {
@@ -716,38 +663,86 @@ portal_add_full (GDBusMethodInvocation *invocation,
     }
 
   n_args = g_variant_n_children (array);
-  g_ptr_array_set_size (ids, n_args + 1);
-  g_ptr_array_set_size (paths, n_args + 1);
-  real_parent_st_bufs = g_new0 (struct stat, n_args);
-  writable = g_new0 (gboolean, n_args);
-
+  fd = g_new (int, n_args);
   message = g_dbus_method_invocation_get_message (invocation);
   fd_list = g_dbus_message_get_unix_fd_list (message);
+
   if (fd_list != NULL)
-    fds = g_unix_fd_list_peek_fds (fd_list, &fds_len);
+    {
+      int fds_len = 0;
+      int i;
+      const int *fds = g_unix_fd_list_peek_fds (fd_list, &fds_len);
+      for (i = 0; i < n_args; i++)
+        {
+          int fd_id;
+          g_variant_get_child (array, i, "h", &fd_id);
+          if (fd_id < fds_len)
+            fd[i] = fds[fd_id];
+          else
+            fd[i] = -1;
+        }
+
+      ids = document_add_full (fd, n_args, flags, app_info, target_app_id, target_perms, &error);
+    } 
+
+  if (ids == NULL)
+    {
+      g_dbus_method_invocation_take_error (invocation, error);
+      return;
+    }
+
+  g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&builder, "{sv}", "mountpoint",
+                         g_variant_new_bytestring (xdp_fuse_get_mountpoint ()));
+
+  g_dbus_method_invocation_return_value (invocation,
+                                         g_variant_new ("(^as@a{sv})",
+                                                        (char **)ids,
+                                                        g_variant_builder_end (&builder)));
+}
+
+char **
+document_add_full (int                      *fd,
+                   int                       n_args,
+                   DocumentAddFullFlags      flags,
+                   XdpAppInfo               *app_info,
+                   const char               *target_app_id,
+                   DocumentPermissionFlags   target_perms,
+                   GError                  **error)
+{
+  const char *app_id = xdp_app_info_get_id (app_info);
+  g_autoptr(GPtrArray) ids = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GPtrArray) paths = g_ptr_array_new_with_free_func (g_free);
+  gboolean reuse_existing, persistent, as_needed_by_app, allow_write;
+  g_autofree struct stat *real_parent_st_bufs = NULL;
+  struct stat st_buf;
+  g_autofree gboolean *writable = NULL;
+  int i;
+  char *id;
+
+  reuse_existing = (flags & DOCUMENT_ADD_FLAGS_REUSE_EXISTING) != 0;
+  persistent = (flags & DOCUMENT_ADD_FLAGS_PERSISTENT) != 0;
+  as_needed_by_app = (flags & DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP) != 0;
+  allow_write = (target_perms & DOCUMENT_PERMISSION_FLAGS_WRITE) != 0;
+
+  g_ptr_array_set_size (paths, n_args + 1);
+  g_ptr_array_set_size (ids, n_args + 1);
+  real_parent_st_bufs = g_new0 (struct stat, n_args);
+  writable = g_new0 (gboolean, n_args);
 
   for (i = 0; i < n_args; i++)
     {
       g_autofree char *path = NULL;
 
-      g_variant_get_child (array, i, "h", &fd_id);
+      if (!validate_fd (fd[i], app_info, &st_buf, &real_parent_st_bufs[i], &path, &writable[i], error))
+        return NULL;
 
-      fd = -1;
-      if (fds != NULL && fd_id < fds_len)
-        fd = fds[fd_id];
-
-      if (!validate_fd (fd, app_info, &st_buf, &real_parent_st_bufs[i], &path, &writable[i], &error))
+      if (allow_write && !writable[i])
         {
-          g_dbus_method_invocation_take_error (invocation, error);
-          return;
-        }
-
-      if ((target_perms & DOCUMENT_PERMISSION_FLAGS_WRITE) && !writable[i])
-        {
-          g_dbus_method_invocation_return_error (invocation,
-                                                 XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
-                                                 "Not enough permissions");
-          return;
+          g_set_error (error,
+                       XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                       "Not enough permissions");
+          return NULL;
         }
 
       g_ptr_array_index(paths,i) = g_steal_pointer (&path);
@@ -758,24 +753,21 @@ portal_add_full (GDBusMethodInvocation *invocation,
           id = verify_existing_document (&st_buf, reuse_existing);
           if (id == NULL)
             {
-              g_dbus_method_invocation_return_error (invocation,
-                                                     XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                                                     "Invalid fd passed");
-              return;
+              g_set_error (error,
+                           XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                           "Invalid fd passed");
+              return NULL;
             }
           g_ptr_array_index(ids,i) = id;
         }
     }
 
   {
-    DocumentPermissionFlags caller_base_perms =
-      DOCUMENT_PERMISSION_FLAGS_GRANT_PERMISSIONS |
-      DOCUMENT_PERMISSION_FLAGS_READ;
-    DocumentPermissionFlags caller_write_perms =
-      DOCUMENT_PERMISSION_FLAGS_WRITE;
+    DocumentPermissionFlags caller_base_perms = DOCUMENT_PERMISSION_FLAGS_GRANT_PERMISSIONS |
+                                                DOCUMENT_PERMISSION_FLAGS_READ;
+    DocumentPermissionFlags caller_write_perms = DOCUMENT_PERMISSION_FLAGS_WRITE;
 
-    /* If its a unique one its safe for the creator to
-       delete it at will */
+    /* If its a unique one its safe for the creator to delete it at will */
     if (!reuse_existing)
       caller_write_perms |= DOCUMENT_PERMISSION_FLAGS_DELETE;
 
@@ -835,14 +827,9 @@ portal_add_full (GDBusMethodInvocation *invocation,
         xdp_fuse_invalidate_doc_app (id, target_app_id);
     }
 
-  g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
-  g_variant_builder_add (&builder, "{sv}", "mountpoint",
-                         g_variant_new_bytestring (xdp_fuse_get_mountpoint ()));
+  g_ptr_array_index(ids,n_args) = NULL;
 
-  g_dbus_method_invocation_return_value (invocation,
-                                         g_variant_new ("(^as@a{sv})",
-                                                        (char **)ids->pdata,
-                                                        g_variant_builder_end (&builder)));
+  return g_strdupv ((char**)ids->pdata);
 }
 
 static void

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1332,6 +1332,8 @@ on_bus_acquired (GDBusConnection *connection,
       g_error_free (error);
     }
 
+  g_debug ("Providing portal %s", g_dbus_interface_skeleton_get_info (G_DBUS_INTERFACE_SKELETON (dbus_api))->name);
+
   if (!g_dbus_interface_skeleton_export (file_transfer,
                                          connection,
                                          "/org/freedesktop/portal/documents",
@@ -1340,6 +1342,8 @@ on_bus_acquired (GDBusConnection *connection,
       g_warning ("error: %s", error->message);
       g_error_free (error);
     }
+
+  g_debug ("Providing portal %s", g_dbus_interface_skeleton_get_info (G_DBUS_INTERFACE_SKELETON (file_transfer))->name);
 }
 
 static void

--- a/document-portal/document-portal.h
+++ b/document-portal/document-portal.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include "document-enums.h"
+
+char ** document_add_full (int                      *fd,
+                           int                       n_args,
+                           DocumentAddFullFlags      flags,
+                           XdpAppInfo               *app_info,
+                           const char               *target_app_id,
+                           DocumentPermissionFlags   target_perms,
+                           GError                  **error);

--- a/document-portal/document-portal.h
+++ b/document-portal/document-portal.h
@@ -23,7 +23,17 @@
 #include <gio/gio.h>
 #include "document-enums.h"
 
+gboolean validate_fd (int           fd,
+                      XdpAppInfo   *app_info,
+                      struct stat  *st_buf,
+                      struct stat  *real_parent_st_buf,
+                      char        **path_out,
+                      gboolean     *writable_out,
+                      GError      **error);
+
 char ** document_add_full (int                      *fd,
+                           int                      *parent_dev,
+                           int                      *parent_ino,
                            int                       n_args,
                            DocumentAddFullFlags      flags,
                            XdpAppInfo               *app_info,

--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -1,0 +1,571 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+#include "file-transfer.h"
+#include "src/xdp-utils.h"
+#include "document-portal-dbus.h"
+#include "document-enums.h"
+#include "document-portal.h"
+#include "document-portal-fuse.h"
+
+static XdpDbusFileTransfer *file_transfer;
+
+typedef struct
+{
+  char *path;
+  int parent_dev;
+  int parent_ino;
+} ExportedFile;
+
+static void
+exported_file_free (gpointer data)
+{
+  ExportedFile *file = data;
+
+  g_free (file->path);
+  g_free (file);
+}
+
+typedef struct
+{
+  GObject object;
+  GMutex mutex;
+
+  GPtrArray *files;
+  gboolean writable;
+  gboolean autostop;
+  char *key;
+  char *sender;
+  XdpAppInfo *app_info;
+} FileTransfer;
+
+typedef struct
+{
+  GObjectClass parent_class;
+} FileTransferClass;
+
+static GType file_transfer_get_type (void);
+
+G_DEFINE_TYPE (FileTransfer, file_transfer, G_TYPE_OBJECT)
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FileTransfer, g_object_unref);
+
+static void
+file_transfer_init (FileTransfer *transfer)
+{
+  g_mutex_init (&transfer->mutex);
+}
+
+static void
+file_transfer_finalize (GObject *object)
+{
+  FileTransfer *transfer = (FileTransfer *)object;
+
+  g_mutex_clear (&transfer->mutex);
+  xdp_app_info_unref (transfer->app_info);
+  g_ptr_array_unref (transfer->files);
+  g_free (transfer->key);
+  g_free (transfer->sender);
+
+  G_OBJECT_CLASS (file_transfer_parent_class)->finalize (object);
+}
+
+static void
+file_transfer_class_init (FileTransferClass *class)
+{
+  G_OBJECT_CLASS (class)->finalize = file_transfer_finalize;
+}
+
+static inline void
+auto_unlock_unref_helper (FileTransfer **transfer)
+{
+  if (!*transfer)
+    return;
+
+  g_mutex_unlock (&(*transfer)->mutex);
+  g_object_unref (*transfer);
+}
+
+static inline FileTransfer *
+auto_lock_helper (FileTransfer *transfer)
+{
+  if (transfer)
+    g_mutex_lock (&transfer->mutex);
+  return transfer;
+}
+
+#define TRANSFER_AUTOLOCK_UNREF(transfer) \
+  G_GNUC_UNUSED __attribute__((cleanup (auto_unlock_unref_helper))) \
+  FileTransfer * G_PASTE (auto_unlock_unref, __LINE__) = \
+    auto_lock_helper (transfer);
+
+G_LOCK_DEFINE (transfers);
+static GHashTable *transfers;
+
+static FileTransfer *
+lookup_transfer (const char *key)
+{
+  FileTransfer *transfer;
+
+  G_LOCK (transfers);
+  transfer = (FileTransfer *)g_hash_table_lookup (transfers, key);
+  if (transfer)
+    g_object_ref (transfer);
+  G_UNLOCK (transfers);
+
+  return transfer;
+}
+
+static FileTransfer *
+file_transfer_start (XdpAppInfo *app_info,
+                     const char *sender,
+                     gboolean    writable,
+                     gboolean    autostop)
+{
+  FileTransfer *transfer;
+
+  transfer = g_object_new (file_transfer_get_type (), NULL);
+
+  transfer->app_info = xdp_app_info_ref (app_info);
+  transfer->sender = g_strdup (sender);
+  transfer->writable = writable;
+  transfer->autostop = autostop;
+  transfer->files = g_ptr_array_new_with_free_func (exported_file_free);
+
+  G_LOCK (transfers);
+  do {
+    guint64 key;
+    g_free (transfer->key);
+    key = g_random_int ();
+    key = (key << 32) | g_random_int ();
+    transfer->key = g_strdup_printf ("%lu", key);
+  }
+  while (g_hash_table_contains (transfers, transfer->key));
+  g_hash_table_insert (transfers, transfer->key, g_object_ref (transfer));
+  G_UNLOCK (transfers);
+
+  g_debug ("start file transfer owned by '%s' (%s)",
+           xdp_app_info_get_id (transfer->app_info),
+           transfer->sender);
+
+  return transfer;
+}
+
+static gboolean
+stop (gpointer data)
+{
+  FileTransfer *transfer = data;
+
+  g_object_unref (transfer);
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+file_transfer_stop (FileTransfer *transfer)
+{
+  GDBusConnection *bus;
+
+  g_debug ("stop file transfer owned by '%s' (%s)",
+           xdp_app_info_get_id (transfer->app_info),
+           transfer->sender);
+
+  bus = g_dbus_interface_skeleton_get_connection (G_DBUS_INTERFACE_SKELETON (file_transfer));
+  g_dbus_connection_emit_signal (bus,
+                                 transfer->sender,
+                                 "/org/freedesktop/portal/documents",
+                                 "org.freedesktop.portal.FileTransfer",
+                                 "TransferClosed",
+                                 g_variant_new ("(s)", transfer->key),
+                                 NULL);
+
+  G_LOCK (transfers);
+  g_hash_table_steal (transfers, transfer->key);
+  G_UNLOCK (transfers);
+
+  g_idle_add (stop, transfer);
+}
+
+static void
+file_transfer_add_file (FileTransfer *transfer,
+                        const char *path,
+                        struct stat *parent_st_buf)
+{
+  ExportedFile *file;
+
+  file = g_new (ExportedFile, 1);
+  file->path = g_strdup (path);
+  file->parent_dev = parent_st_buf->st_dev;
+  file->parent_ino = parent_st_buf->st_ino;
+
+  g_ptr_array_add (transfer->files, file);
+}
+
+static char **
+file_transfer_execute (FileTransfer *transfer,
+                       XdpAppInfo *target_app_info,
+                       GError **error)
+{
+  guint32 flags;
+  DocumentPermissionFlags perms;
+  const char *target_app_id;
+  int n_fds;
+  g_autofree int *fds = NULL;
+  g_autofree int *parent_devs = NULL;
+  g_autofree int *parent_inos = NULL;
+  int i;
+  g_auto(GStrv) ids = NULL;
+  char **files = NULL;
+
+  g_debug ("retrieve %d files for %s from file transfer owned by '%s' (%s)",
+           transfer->files->len,
+           xdp_app_info_get_id (target_app_info),
+           xdp_app_info_get_id (transfer->app_info),
+           transfer->sender);
+
+  /* if the target is unsandboxed, just return the files as-is */
+  if (xdp_app_info_is_host (target_app_info))
+    {
+      files = g_new (char *, transfer->files->len + 1);
+      for (i = 0; i < transfer->files->len; i++)
+        {
+          ExportedFile *file = (ExportedFile*)g_ptr_array_index (transfer->files, i);
+          files[i] = g_strdup (file->path);
+        }
+      files[i] = NULL;
+      return files;
+    }
+
+  flags = DOCUMENT_ADD_FLAGS_REUSE_EXISTING | DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP;
+
+  perms = DOCUMENT_PERMISSION_FLAGS_READ;
+  if (transfer->writable)
+    perms |= DOCUMENT_PERMISSION_FLAGS_WRITE;
+
+  target_app_id = xdp_app_info_get_id (target_app_info);
+
+  n_fds = transfer->files->len;
+  fds = g_new (int, n_fds);
+  parent_devs = g_new (int, n_fds);
+  parent_inos = g_new (int, n_fds);
+  for (i = 0; i < n_fds; i++)
+    {
+      ExportedFile *file = (ExportedFile*)g_ptr_array_index (transfer->files, i);
+
+      fds[i] = open (file->path, O_PATH | O_CLOEXEC);
+      if (fds[i] == -1)
+        {
+          g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno), "File transfer %s failed", transfer->key);
+          for (; i > 0; i--)
+            close (fds[i - 1]);
+          return NULL;
+        }
+
+      parent_devs[i] = file->parent_dev;
+      parent_inos[i] = file->parent_ino;
+    }
+
+  ids = document_add_full (fds, parent_devs, parent_inos, n_fds, flags, transfer->app_info, target_app_id, perms, error);
+
+  for (i = 0; i < n_fds; i++)
+    close (fds[i]);
+
+  if (ids)
+    {
+      const char *mountpoint = xdp_fuse_get_mountpoint ();
+      files = g_new (char *, n_fds + 1);
+      for (i = 0; i < n_fds; i++)
+        {
+          ExportedFile *file = (ExportedFile *) g_ptr_array_index (transfer->files, i);
+
+          if (ids[i][0] == '\0')
+            files[i] = g_strdup (file->path);
+          else
+            {
+              g_autofree char *name = g_path_get_basename (file->path);
+              files[i] = g_build_filename (mountpoint, ids[i], name, NULL);
+            }
+        }
+      files[n_fds] = NULL;
+    }
+
+  return files;
+}
+
+static void
+start_transfer (GDBusMethodInvocation *invocation,
+                GVariant *parameters,
+                XdpAppInfo *app_info)
+{
+  g_autoptr(GVariant) options = NULL;
+  g_autoptr(FileTransfer) transfer = NULL;
+  gboolean writable;
+  gboolean autostop;
+  const char *sender;
+
+  g_variant_get (parameters, "(@a{sv})", &options);
+  if (!g_variant_lookup (options, "writable", "b", &writable))
+    writable = FALSE;
+
+  if (!g_variant_lookup (options, "autostop", "b", &autostop))
+    autostop = TRUE;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+
+  transfer = file_transfer_start (app_info, sender, writable, autostop);
+
+  g_dbus_method_invocation_return_value (invocation, g_variant_new ("(s)", transfer->key));
+}
+
+static void
+add_files (GDBusMethodInvocation *invocation,
+           GVariant *parameters,
+           XdpAppInfo *app_info)
+{
+  FileTransfer *transfer;
+  const char *key;
+  g_autoptr(GVariant) options = NULL;
+  GDBusMessage *message;
+  GUnixFDList *fd_list;
+  g_autoptr(GVariantIter) iter = NULL;
+  int fd_id;
+  const int *fds;
+  int n_fds;
+
+  g_variant_get (parameters, "(&sah@a{sv})", &key, &iter, &options);
+
+  transfer = lookup_transfer (key);
+  if (transfer == NULL)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid transfer");
+      return;
+    }
+
+  TRANSFER_AUTOLOCK_UNREF (transfer);
+
+  if (strcmp (transfer->sender, g_dbus_method_invocation_get_sender (invocation)) != 0)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid transfer");
+      return;
+    }
+
+  message = g_dbus_method_invocation_get_message (invocation);
+  fd_list = g_dbus_message_get_unix_fd_list (message);
+
+  fds = g_unix_fd_list_peek_fds (fd_list, &n_fds);
+
+  g_debug ("add %d files to file transfer owned by '%s' (%s)", n_fds,
+           xdp_app_info_get_id (transfer->app_info),
+           transfer->sender);
+
+  while (g_variant_iter_next (iter, "h", &fd_id))
+    {
+      int fd = -1;
+      g_autofree char *path = NULL;
+      gboolean fd_is_writable;
+      struct stat st_buf;
+      struct stat parent_st_buf;
+
+      if (fd_id < n_fds)
+        fd = fds[fd_id];
+
+      if (fd == -1)
+        {
+          g_dbus_method_invocation_return_error (invocation,
+                                                 G_DBUS_ERROR,
+                                                 G_DBUS_ERROR_ACCESS_DENIED,
+                                                 "Invalid transfer");
+          return;
+        }
+
+      if (!validate_fd (fd, app_info, &st_buf, &parent_st_buf, &path, &fd_is_writable, NULL) ||
+          (transfer->writable && !fd_is_writable))
+        {
+          g_dbus_method_invocation_return_error (invocation,
+                                                 XDG_DESKTOP_PORTAL_ERROR,
+                                                 XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                                 "Can't export file");
+          return;
+        }
+
+      file_transfer_add_file (transfer, path, &parent_st_buf);
+    }
+
+  g_dbus_method_invocation_return_value (invocation, NULL);
+}
+
+
+static void
+retrieve_files (GDBusMethodInvocation *invocation,
+                GVariant *parameters,
+                XdpAppInfo *app_info)
+{
+  const char *key;
+  FileTransfer *transfer;
+  g_auto(GStrv) files = NULL;
+  GError *error = NULL;
+
+  g_variant_get (parameters, "(&s@a{sv})", &key, NULL);
+
+  transfer = lookup_transfer (key);
+  if (transfer == NULL)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid transfer");
+      return;
+    }
+
+  TRANSFER_AUTOLOCK_UNREF (transfer);
+
+  files = file_transfer_execute (transfer, app_info, &error);
+  if (files == NULL)
+    g_dbus_method_invocation_return_gerror (invocation, error);
+  else
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(^as)", files));
+
+  if (transfer->autostop)
+    file_transfer_stop (transfer);
+}
+
+static void
+stop_transfer (GDBusMethodInvocation *invocation,
+                GVariant *parameters,
+                XdpAppInfo *app_info)
+{
+  const char *key;
+  FileTransfer *transfer;
+
+  g_variant_get (parameters, "(&s)", &key);
+
+  transfer = lookup_transfer (key);
+  if (transfer == NULL)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid transfer");
+      return;
+    }
+
+  TRANSFER_AUTOLOCK_UNREF (transfer);
+
+  file_transfer_stop (transfer);
+
+  g_dbus_method_invocation_return_value (invocation, NULL);
+}
+
+typedef void (*PortalMethod) (GDBusMethodInvocation *invocation,
+                              GVariant              *parameters,
+                              XdpAppInfo            *app_info);
+
+static gboolean
+handle_method (GCallback              method_callback,
+               GDBusMethodInvocation *invocation)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpAppInfo) app_info = NULL;
+  PortalMethod portal_method = (PortalMethod)method_callback;
+
+  app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, &error);
+  if (app_info == NULL)
+    g_dbus_method_invocation_return_gerror (invocation, error);
+  else
+    portal_method (invocation, g_dbus_method_invocation_get_parameters (invocation), app_info);
+
+  return TRUE;
+}
+
+GDBusInterfaceSkeleton *
+file_transfer_create (void)
+{
+  file_transfer = xdp_dbus_file_transfer_skeleton_new ();
+
+  g_signal_connect_swapped (file_transfer, "handle-start-transfer", G_CALLBACK (handle_method), start_transfer);
+  g_signal_connect_swapped (file_transfer, "handle-add-files", G_CALLBACK (handle_method), add_files);
+  g_signal_connect_swapped (file_transfer, "handle-retrieve-files", G_CALLBACK (handle_method), retrieve_files);
+  g_signal_connect_swapped (file_transfer, "handle-stop-transfer", G_CALLBACK (handle_method), stop_transfer);
+
+  xdp_dbus_file_transfer_set_version (XDP_DBUS_FILE_TRANSFER (file_transfer), 1);
+
+  transfers = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_object_unref);
+
+  return G_DBUS_INTERFACE_SKELETON (file_transfer);
+}
+
+void
+stop_file_transfers_in_thread_func (GTask        *task,
+                                    gpointer      source_object,
+                                    gpointer      task_data,
+                                    GCancellable *cancellable)
+{
+  const char *sender = (const char *)task_data;
+  GHashTableIter iter;
+  FileTransfer *transfer;
+
+  G_LOCK (transfers);
+  if (transfers)
+    {
+      g_hash_table_iter_init (&iter, transfers);
+      while (g_hash_table_iter_next (&iter, NULL, (gpointer *)&transfer))
+        {
+          if (strcmp (sender, transfer->sender) == 0)
+            {
+              g_print ("removing transfer %s for dead peer %s\n", transfer->key, transfer->sender);
+              g_hash_table_iter_remove (&iter);
+            }
+        }
+    }
+  G_UNLOCK (transfers);
+}
+
+void
+stop_file_transfers_for_sender (const char *sender)
+{
+  GTask *task;
+
+  task = g_task_new (NULL, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_strdup (sender), g_free);
+  g_task_run_in_thread (task, stop_file_transfers_in_thread_func);
+  g_object_unref (task);
+}

--- a/document-portal/file-transfer.h
+++ b/document-portal/file-transfer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton *file_transfer_create (void);
+
+void stop_file_transfers_for_sender (const char *name);

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -43,11 +43,24 @@ set_openuri_permissions (const char *type,
 static void
 unset_openuri_permissions (const char *type)
 {
+  GVariantBuilder data_builder;
+
   xdp_impl_permission_store_call_delete_sync (permission_store,
                                               "desktop-used-apps",
                                               type,
                                               NULL,
                                               NULL);
+
+  /* turn on paranoid mode to ensure we get a backend call */
+  g_variant_builder_init (&data_builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&data_builder, "{sv}", "always-ask", g_variant_new_boolean (TRUE));
+  xdp_impl_permission_store_call_set_value_sync (permission_store,
+                                                 "desktop-used-apps",
+                                                 TRUE,
+                                                 type,
+                                                 g_variant_new_variant (g_variant_builder_end (&data_builder)),
+                                                 NULL,
+                                                 NULL);
   /* Ignore the error here, since this fails if the table doesn't exist */
 }
 


### PR DESCRIPTION
This branch adds a "FileTransfer" portal to the document portal binary. It can be used to implement dnd and copy/paste. By using the portal as a side-channel to transfer the files (while exporting them as-needed).

This works, and https://gitlab.gnome.org/GNOME/gtk/merge_requests/321 has corresponding gtk changes. Future todo: better handling for directories.