### PR TITLE
Clarify the docs on filters in the file chooser

### DIFF
--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -80,11 +80,18 @@
             <para>
               Each item in the array specifies a single filter to offer to the user.
               The first string is a user-visible name for the filter. The a(us)
-              specifies a list of filter strings, which can be either a glob pattern
-              (indicated by 0) or a mimetype (indicated by 1).
+              specifies a list of filter strings, which can be either a glob-style pattern
+              (indicated by 0) or a mimetype (indicated by 1). Patterns are case-sensitive.
+              To match different capitalizations of, e.g. '*.ico', use a pattern like
+              '*.[iI][cC][oO]'.
             </para>
             <para>
               Example: [('Images', [(0, '*.ico'), (1, 'image/png')]), ('Text', [(0, '*.txt')])]
+            </para>
+            <para>
+              Note that filters are purely there to aid the user in making a useful selection.
+              The portal may still allow the user to select files that don't match any filter
+              criteria, and applications must be prepared to handle that.
             </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
Make it explicit that patterns are case-sensitive.

Closes https://github.com/flatpak/xdg-desktop-portal/issues/225