### PR TITLE
desktop-portal: don't attempt to export NULL GDBusInterfaceSkeletons

### DIFF
--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -339,6 +339,12 @@ export_portal_implementation (GDBusConnection *connection,
 {
   g_autoptr(GError) error = NULL;
 
+  if (skeleton == NULL)
+    {
+      g_warning ("No skeleton to export");
+      return;
+    }
+
   g_dbus_interface_skeleton_set_flags (skeleton,
                                        G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
   g_signal_connect (skeleton, "g-authorize-method",


### PR DESCRIPTION
This PR is related to some crash reports we've been seeing on Ubuntu where xdg-desktop-portal segfaults during start-up.  In short, there is a timeout trying to activate xdg-desktop-portal-gtk that leads to export_portal_implementation() being called with a NULL skeleton argument.  Here are the logs from one occurrence of the crash:

    xdg-desktop-por[3113]: Failed to create file chooser proxy: Error calling StartServiceByName for org.freedesktop.impl.portal.desktop.gtk: Timeout was reached
    xdg-desktop-por[3113]: g_dbus_interface_skeleton_set_flags: assertion 'G_IS_DBUS_INTERFACE_SKELETON (interface_)' failed
    xdg-desktop-por[3113]: invalid (NULL) pointer instance
    xdg-desktop-por[3113]: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
    xdg-desktop-por[3113]: g_dbus_interface_skeleton_export: assertion 'G_IS_DBUS_INTERFACE_SKELETON (interface_)' failed
    systemd[2919]: xdg-desktop-portal.service: Main process exited, code=dumped, status=11/SEGV
    systemd[2919]: xdg-desktop-portal.service: Failed with result 'core-dump'.
    systemd[2919]: Failed to start Portal service.

To fix the crash, I decided to put the NULL check inside export_portal_implementation() since every call of this function has another function call as an argument.  This seemed the most reliable and least invasive fix.

My full analysis of the crash report can be found here:

https://bugs.launchpad.net/ubuntu/+source/xdg-desktop-portal/+bug/1691649/comments/7