### PR TITLE
Add Settings portal

### DIFF
--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2018 Igalia S.L.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Patrick Griffis <pgriffis@igalia.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+    org.freedesktop.portal.Settings:
+    @short_description: Settings interface
+
+    This interface provides read-only access to a small number
+    of host settings required for toolkits similar to XSettings.
+    It is not for general purpose settings.
+
+    Currently the valid keys are entirely implementation details
+    that are undocumented. If you are a toolkit and want to use
+    this please open an issue.
+  -->
+  <interface name="org.freedesktop.portal.Settings">
+
+    <!--
+      ReadAll:
+      @namespace: Namespace to filter results by, supports simple globbing explained below.
+      @value: Dictionary of namespaces to its keys and values.
+
+      If @namespace is an empty string matches all. Globbing is supported but only for
+      trailing sections, e.g. "org.example.*".
+    -->
+    <method name='ReadAll'>
+      <arg name='namespace' type='s'/>
+      <arg name='value' direction='out' type='a{sa{sv}}'/>
+    </method>
+
+    <!--
+      Read:
+      @namespace: Namespace to look up @key in.
+      @key: The key to get.
+      @value: The value @key is set to.
+
+      Reads a single value. Returns an error on any unknown namespace or key.
+    -->
+    <method name='Read'>
+      <arg name='namespace' type='s'/>
+      <arg name='key' type='s'/>
+      <arg name='value' direction='out' type='v'/>
+    </method>
+
+    <!--
+      SettingChanged:
+      @namespace: Namespace of changed setting.
+      @key: The key of changed setting.
+      @value: The new value.
+
+      Emitted when a setting changes.
+    -->
+    <signal name='SettingChanged'>
+      <arg name='namespace' direction='out' type='s'/>
+      <arg name='key' direction='out' type='s'/>
+      <arg name='value' direction='out' type='v'/>
+    </signal>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -34,6 +34,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.ScreenCast.xml \
 	data/org.freedesktop.portal.RemoteDesktop.xml \
 	data/org.freedesktop.portal.Location.xml \
+	data/org.freedesktop.portal.Settings.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -132,6 +133,8 @@ xdg_desktop_portal_SOURCES = \
         src/permissions.h               \
         src/email.c                     \
         src/email.h                     \
+	src/settings.c			\
+	src/settings.h			\
 	src/session.c			\
 	src/session.h			\
 	src/trash.c			\

--- a/src/request.c
+++ b/src/request.c
@@ -286,6 +286,10 @@ get_token (GDBusMethodInvocation *invocation)
                      interface, method, G_STRLOC);
         }
     }
+  else if (strcmp (interface, "org.freedesktop.portal.Settings") == 0)
+    {
+      // no request objects
+    }
   else
     {
       g_print ("Support for %s missing in " G_STRLOC, interface);

--- a/src/settings.c
+++ b/src/settings.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2018 Igalia S.L.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Patrick Griffis <pgriffis@igalia.com>
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+
+#include "settings.h"
+#include "xdp-dbus.h"
+#include "xdp-utils.h"
+
+typedef struct _Settings Settings;
+typedef struct _SettingsClass SettingsClass;
+
+struct _Settings
+{
+  XdpSettingsSkeleton parent_instance;
+
+  GHashTable *settings;
+};
+
+struct _SettingsClass
+{
+  XdpSettingsSkeletonClass parent_class;
+};
+
+static Settings *settings;
+
+GType settings_get_type (void) G_GNUC_CONST;
+static void settings_iface_init (XdpSettingsIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Settings, settings, XDP_TYPE_SETTINGS_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_SETTINGS, settings_iface_init));
+
+typedef struct {
+  GSettingsSchema *schema;
+  GSettings *settings;
+} SettingsBundle;
+
+static SettingsBundle *
+settings_bundle_new (GSettingsSchema *schema,
+                     GSettings       *settings)
+{
+  SettingsBundle *bundle = g_new (SettingsBundle, 1);
+  bundle->schema = schema;
+  bundle->settings = settings;
+  return bundle;
+}
+
+static void
+settings_bundle_free (SettingsBundle *bundle)
+{
+  g_object_unref (bundle->schema);
+  g_object_unref (bundle->settings);
+  g_free (bundle);
+}
+
+static gboolean
+namespace_matches (const char *namespace,
+                   const char *pattern)
+{
+  size_t pattern_len;
+
+  if (pattern[0] == '\0')
+    return TRUE;
+  if (strcmp (namespace, pattern) == 0)
+    return TRUE;
+
+  pattern_len = strlen (pattern);
+  if (pattern[pattern_len - 1] == '*' && strncmp (namespace, pattern, pattern_len - 1) == 0)
+    return TRUE;
+
+  return FALSE;
+}
+
+static gboolean
+settings_handle_read_all (XdpSettings           *object,
+                          GDBusMethodInvocation *invocation,
+                          const char            *arg_namespace)
+{
+  Settings *self = (Settings *)object;
+  GVariantBuilder builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("(a{sa{sv}})"));
+  GHashTableIter iter;
+  char *key;
+  SettingsBundle *value;
+
+  g_variant_builder_open (&builder, G_VARIANT_TYPE ("a{sa{sv}}"));
+  g_hash_table_iter_init (&iter, self->settings);
+  while (g_hash_table_iter_next (&iter, (gpointer *)&key, (gpointer *)&value))
+    {
+      g_auto (GStrv) keys = NULL;
+      GVariantDict dict;
+      gsize i;
+
+      if (!namespace_matches (key, arg_namespace))
+        continue;
+
+      keys = g_settings_schema_list_keys (value->schema);
+      g_variant_dict_init (&dict, NULL);
+      for (i = 0; keys[i]; ++i)
+        g_variant_dict_insert_value (&dict, keys[i], g_settings_get_value (value->settings, keys[i]));
+
+      g_variant_builder_add (&builder, "{s@a{sv}}", key, g_variant_dict_end (&dict));
+    }
+  g_variant_builder_close (&builder);
+
+  g_dbus_method_invocation_return_value (invocation, g_variant_builder_end (&builder));
+  return TRUE;
+}
+
+static gboolean
+settings_handle_read (XdpSettings           *object,
+                      GDBusMethodInvocation *invocation,
+                      const char            *arg_namespace,
+                      const char            *arg_key)
+{
+  Settings *self = (Settings *)object;
+
+  g_debug ("Read %s %s", arg_namespace, arg_key);
+
+  // TODO: Handle kdeglobals via same interface
+  if (!g_hash_table_contains (self->settings, arg_namespace))
+    {
+      g_debug ("Attempted to read from unknown namespace %s", arg_namespace);
+      g_dbus_method_invocation_return_error_literal (invocation, XDG_DESKTOP_PORTAL_ERROR,
+                                                     XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND,
+                                                     _("Requested setting not found"));
+    }
+  else
+    {
+      SettingsBundle *bundle = g_hash_table_lookup (self->settings, arg_namespace);
+      if (g_settings_schema_has_key (bundle->schema, arg_key))
+        {
+          g_autoptr (GVariant) variant = NULL;
+          variant = g_settings_get_value (bundle->settings, arg_key);
+          g_dbus_method_invocation_return_value (invocation, g_variant_new("(v)", variant));
+        }
+      else
+        {
+          g_debug ("Attempted to read unknown key %s", arg_key);
+          g_dbus_method_invocation_return_error_literal (invocation, XDG_DESKTOP_PORTAL_ERROR,
+                                                         XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND,
+                                                         _("Requested setting not found"));
+        }
+    }
+
+  return TRUE;
+}
+
+typedef struct {
+  Settings *self;
+  const char *namespace;
+} ChangedSignalUserData;
+
+static ChangedSignalUserData *
+changed_signal_user_data_new (Settings   *settings,
+                              const char *namespace)
+{
+  ChangedSignalUserData *data = g_new (ChangedSignalUserData, 1);
+  data->self = settings;
+  data->namespace = namespace;
+  return data;
+}
+
+static void
+changed_signal_user_data_destroy (gpointer  data,
+                                  GClosure *closure)
+{
+  g_free (data);
+}
+
+static void
+on_settings_changed (GSettings             *settings,
+                     const char            *key,
+                     ChangedSignalUserData *user_data)
+{
+  g_autoptr (GVariant) new_value = g_settings_get_value (settings, key);
+
+  g_debug ("Emitting changed for %s %s", user_data->namespace, key);
+  xdp_settings_emit_setting_changed (XDP_SETTINGS (user_data->self), user_data->namespace, key, g_variant_new ("v", new_value));
+}
+
+static void
+init_settings_table (Settings   *self,
+                     GHashTable *table)
+{
+  static const char * const schemas[] = {
+    "org.gnome.desktop.interface",
+    "org.gnome.settings-daemon.peripherals.mouse",
+    "org.gnome.desktop.sound",
+    "org.gnome.desktop.privacy",
+    "org.gnome.desktop.wm.preferences",
+    "org.gnome.settings-daemon.plugins.xsettings",
+    "org.gnome.desktop.a11y",
+  };
+  size_t i;
+  GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
+
+  for (i = 0; i < G_N_ELEMENTS(schemas); ++i)
+    {
+      GSettings *setting;
+      GSettingsSchema *schema;
+      SettingsBundle *bundle;
+      const char *schema_name = schemas[i];
+      
+      schema = g_settings_schema_source_lookup (source, schema_name, TRUE);
+      if (!schema)
+        {
+          g_debug ("%s schema not found", schema_name);
+          continue;
+        }
+
+      setting = g_settings_new (schema_name);
+      bundle = settings_bundle_new (schema, setting);
+      g_signal_connect_data (setting, "changed", G_CALLBACK(on_settings_changed),
+                             changed_signal_user_data_new (self, schema_name),
+                             changed_signal_user_data_destroy, 0);
+      g_hash_table_insert (table, (char*)schema_name, bundle);
+    }
+}
+
+static void
+settings_iface_init (XdpSettingsIface *iface)
+{
+  iface->handle_read = settings_handle_read;
+  iface->handle_read_all = settings_handle_read_all;
+}
+
+static void
+settings_init (Settings *self)
+{
+  self->settings = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, (GDestroyNotify)settings_bundle_free);
+  init_settings_table (self, self->settings);
+
+  xdp_settings_set_version (XDP_SETTINGS (self), 1);
+}
+
+static void
+settings_finalize (GObject *object)
+{
+  Settings *self = (Settings*)object;
+  g_hash_table_destroy (self->settings);
+
+  G_OBJECT_CLASS (settings_parent_class)->finalize (object);
+}
+
+static void
+settings_class_init (SettingsClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = settings_finalize;
+}
+
+GDBusInterfaceSkeleton *
+settings_create (GDBusConnection *connection)
+{
+  settings = g_object_new (settings_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (settings);
+}

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2018 Igalia S.L.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Patrick Griffis <pgriffis@igalia.com>
+ */
+
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * settings_create (GDBusConnection *connection);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -48,6 +48,7 @@
 #include "remote-desktop.h"
 #include "trash.h"
 #include "location.h"
+#include "settings.h"
 
 static GMainLoop *loop = NULL;
 
@@ -385,6 +386,7 @@ on_bus_acquired (GDBusConnection *connection,
   export_portal_implementation (connection, network_monitor_create (connection));
   export_portal_implementation (connection, proxy_resolver_create (connection));
   export_portal_implementation (connection, trash_create (connection));
+  export_portal_implementation (connection, settings_create (connection));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.FileChooser");
   if (implementation != NULL)


### PR DESCRIPTION
This is a minimal portal that effectively just replaces XSettings on Wayland without requring DConf access.

@grulja @aleixpol - I'd like your input on if you can use this to replace your `--filesystem=xdg-config/kdeglobals:ro` permission also.