### PR TITLE
settings: Support the fontconfig timestamp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_SUBST([systemduserunitdir], [$with_systemduserunitdir])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 
-PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0])
+PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0 fontconfig])
 AC_SUBST(BASE_CFLAGS)
 AC_SUBST(BASE_LIBS)
 

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -141,6 +141,8 @@ xdg_desktop_portal_SOURCES = \
 	src/trash.h			\
 	src/xdp-utils.c			\
 	src/xdp-utils.h			\
+	src/fc-monitor.c		\
+	src/fc-monitor.h		\
 	$(NULL)
 
 if HAVE_PIPEWIRE

--- a/src/fc-monitor.c
+++ b/src/fc-monitor.c
@@ -19,6 +19,8 @@
  * Author:  Behdad Esfahbod, Red Hat, Inc.
  */
 
+/* NOTE: This file is copied from gnome-settings-daemon, please keep it in sync */
+
 #include "fc-monitor.h"
 
 #include <gio/gio.h>

--- a/src/fc-monitor.c
+++ b/src/fc-monitor.c
@@ -1,0 +1,321 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2008 Red Hat, Inc.
+ * Copyright (C) 2017 Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author:  Behdad Esfahbod, Red Hat, Inc.
+ */
+
+#include "fc-monitor.h"
+
+#include <gio/gio.h>
+#include <fontconfig/fontconfig.h>
+
+#define TIMEOUT_MILLISECONDS 1000
+
+static void
+fontconfig_cache_update_thread (GTask *task,
+                                gpointer source_object G_GNUC_UNUSED,
+                                gpointer task_data G_GNUC_UNUSED,
+                                GCancellable *cancellable G_GNUC_UNUSED)
+{
+        if (FcConfigUptoDate (NULL)) {
+                g_task_return_boolean (task, FALSE);
+                return;
+        }
+
+        if (!FcInitReinitialize ()) {
+                g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_FAILED,
+                                         "FcInitReinitialize failed");
+                return;
+        }
+
+        g_task_return_boolean (task, TRUE);
+}
+
+static void
+fontconfig_cache_update_async (GAsyncReadyCallback callback,
+                               gpointer user_data)
+{
+        GTask *task = g_task_new (NULL, NULL, callback, user_data);
+        g_task_run_in_thread (task, fontconfig_cache_update_thread);
+        g_object_unref (task);
+}
+
+static gboolean
+fontconfig_cache_update_finish (GAsyncResult *result,
+                                GError **error)
+{
+        return g_task_propagate_boolean (G_TASK (result), error);
+}
+
+typedef enum {
+        UPDATE_IDLE,
+        UPDATE_PENDING,
+        UPDATE_RUNNING,
+        UPDATE_RESTART,
+} UpdateState;
+
+struct _FcMonitor {
+        GObject parent_instance;
+
+        GPtrArray *monitors;
+
+        guint timeout;
+        UpdateState state;
+        gboolean notify;
+};
+
+enum {
+        SIGNAL_UPDATED,
+
+        N_SIGNALS
+};
+
+static guint signals[N_SIGNALS] = { 0, };
+
+static void fc_monitor_finalize (GObject *object);
+static void monitor_files (FcMonitor *self, FcStrList *list);
+static void stuff_changed (GFileMonitor *monitor, GFile *file, GFile *other_file,
+                           GFileMonitorEvent event_type, gpointer data);
+static void start_timeout (FcMonitor *self);
+static gboolean start_update (gpointer data);
+static void update_done (GObject *source_object, GAsyncResult *result, gpointer user_data);
+
+G_DEFINE_TYPE (FcMonitor, fc_monitor, G_TYPE_OBJECT);
+
+static void
+fc_monitor_class_init (FcMonitorClass *klass)
+{
+        GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+        object_class->finalize = fc_monitor_finalize;
+
+        signals[SIGNAL_UPDATED] = g_signal_new ("updated",
+                                                G_TYPE_FROM_CLASS (klass),
+                                                G_SIGNAL_RUN_LAST,
+                                                0,
+                                                NULL,
+                                                NULL,
+                                                NULL,
+                                                G_TYPE_NONE,
+                                                0);
+}
+
+FcMonitor *
+fc_monitor_new (void)
+{
+        return g_object_new (FC_TYPE_MONITOR, NULL);
+}
+
+static void
+fc_monitor_init (FcMonitor *self G_GNUC_UNUSED)
+{
+        FcInit ();
+}
+
+static void
+fc_monitor_finalize (GObject *object)
+{
+        FcMonitor *self = FC_MONITOR (object);
+
+        if (self->timeout)
+                g_source_remove (self->timeout);
+        self->timeout = 0;
+
+        g_clear_pointer (&self->monitors, g_ptr_array_unref);
+
+        G_OBJECT_CLASS (fc_monitor_parent_class)->finalize (object);
+}
+
+void
+fc_monitor_start (FcMonitor *self)
+{
+        g_return_if_fail (FC_IS_MONITOR (self));
+        g_return_if_fail (self->monitors == NULL);
+
+        self->monitors = g_ptr_array_new_with_free_func (g_object_unref);
+
+        monitor_files (self, FcConfigGetConfigFiles (NULL));
+        monitor_files (self, FcConfigGetFontDirs (NULL));
+}
+
+void
+fc_monitor_stop (FcMonitor *self)
+{
+        g_return_if_fail (FC_IS_MONITOR (self));
+        g_clear_pointer (&self->monitors, g_ptr_array_unref);
+}
+
+static void
+monitor_files (FcMonitor *self,
+               FcStrList *list)
+{
+        const char *str;
+
+        while ((str = (const char *) FcStrListNext (list))) {
+                GFile *file;
+                GFileMonitor *monitor;
+
+                file = g_file_new_for_path (str);
+
+                g_debug ("Monitoring %s", str);
+                monitor = g_file_monitor (file, G_FILE_MONITOR_NONE, NULL, NULL);
+
+                g_object_unref (file);
+
+                if (!monitor)
+                        continue;
+
+                g_signal_connect (monitor, "changed", G_CALLBACK (stuff_changed), self);
+
+                g_ptr_array_add (self->monitors, monitor);
+        }
+
+        FcStrListDone (list);
+}
+
+static const gchar *
+get_name (GType enum_type,
+          gint enum_value)
+{
+        GEnumClass *klass = g_type_class_ref (enum_type);
+        GEnumValue *value = g_enum_get_value (klass, enum_value);
+        const gchar *name = value ? value->value_name : "(unknown)";
+        g_type_class_unref (klass);
+        return name;
+}
+
+static void
+stuff_changed (GFileMonitor *monitor G_GNUC_UNUSED,
+               GFile *file G_GNUC_UNUSED,
+               GFile *other_file G_GNUC_UNUSED,
+               GFileMonitorEvent event_type,
+               gpointer data)
+{
+        FcMonitor *self = FC_MONITOR (data);
+        const gchar *event_name = get_name (G_TYPE_FILE_MONITOR_EVENT, event_type);
+        char *path = g_file_get_path (file);
+
+        switch (self->state) {
+        case UPDATE_IDLE:
+                g_debug ("Got %-38s for %s: starting fontconfig update timeout", event_name, path);
+                start_timeout (self);
+                break;
+
+        case UPDATE_PENDING:
+                /* wait for quiescence */
+                g_debug ("Got %-38s for %s: restarting fontconfig update timeout", event_name, path);
+                g_source_remove (self->timeout);
+                start_timeout (self);
+                break;
+
+        case UPDATE_RUNNING:
+                g_debug ("Got %-38s for %s: restarting fontconfig update", event_name, path);
+                self->state = UPDATE_RESTART;
+                break;
+
+        case UPDATE_RESTART:
+                g_debug ("Got %-38s for %s: waiting on fontconfig update", event_name, path);
+                break;
+        }
+
+	g_free (path);
+}
+
+static void
+start_timeout (FcMonitor *self)
+{
+        self->state = UPDATE_PENDING;
+        self->timeout = g_timeout_add (TIMEOUT_MILLISECONDS, start_update, self);
+        g_source_set_name_by_id (self->timeout, "[gnome-settings-daemon] update");
+}
+
+static gboolean
+start_update (gpointer data)
+{
+        FcMonitor *self = FC_MONITOR (data);
+
+        self->state = UPDATE_RUNNING;
+        self->timeout = 0;
+
+        g_debug ("Timeout completed: starting fontconfig update");
+        fontconfig_cache_update_async (update_done, g_object_ref (self));
+
+        return G_SOURCE_REMOVE;
+}
+
+static void
+update_done (GObject *source_object G_GNUC_UNUSED,
+             GAsyncResult *result,
+             gpointer data)
+{
+        FcMonitor *self = FC_MONITOR (data);
+        gboolean restart = self->state == UPDATE_RESTART;
+        GError *error = NULL;
+
+        self->state = UPDATE_IDLE;
+
+        if (fontconfig_cache_update_finish (result, &error)) {
+                g_debug ("Fontconfig update successful");
+                /* Remember we had a successful update even if we have to restart it */
+                self->notify = TRUE;
+        } else if (error) {
+                g_warning ("Fontconfig update failed: %s", error->message);
+                g_error_free (error);
+        } else
+                g_debug ("Fontconfig update was unnecessary");
+
+        if (restart) {
+                g_debug ("Concurrent change: restarting fontconfig update timeout");
+                start_timeout (self);
+        } else if (self->notify) {
+                self->notify = FALSE;
+
+                if (self->monitors) {
+                        fc_monitor_stop (self);
+                        fc_monitor_start (self);
+                }
+
+                /* we finish modifying self before emitting the signal,
+                 * allowing the callback to stop us if it decides to. */
+                g_signal_emit (self, signals[SIGNAL_UPDATED], 0);
+        }
+
+        /* release ref taken in start_update */
+        g_object_unref (self);
+}
+
+#ifdef FONTCONFIG_MONITOR_TEST
+static void
+yay (void)
+{
+        g_message ("yay");
+}
+
+int
+main (void)
+{
+        GMainLoop *loop = g_main_loop_new (NULL, TRUE);
+        FcMonitor *monitor = fc_monitor_new ();
+
+        fc_monitor_start (monitor);
+        g_signal_connect (monitor, "updated", G_CALLBACK (yay), NULL);
+
+        g_main_loop_run (loop);
+        return 0;
+}
+#endif

--- a/src/fc-monitor.h
+++ b/src/fc-monitor.h
@@ -1,0 +1,36 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef FC_MONITOR_H
+#define FC_MONITOR_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FC_TYPE_MONITOR (fc_monitor_get_type ())
+G_DECLARE_FINAL_TYPE (FcMonitor, fc_monitor, FC, MONITOR, GObject)
+
+FcMonitor *fc_monitor_new (void);
+
+void fc_monitor_start (FcMonitor *monitor);
+void fc_monitor_stop  (FcMonitor *monitor);
+
+G_END_DECLS
+
+#endif /* FC_MONITOR_H */

--- a/src/fc-monitor.h
+++ b/src/fc-monitor.h
@@ -19,6 +19,8 @@
 #ifndef FC_MONITOR_H
 #define FC_MONITOR_H
 
+/* NOTE: this file is copied from gnome-settings-daemon, please keep it in sync */
+
 #include <glib-object.h>
 
 G_BEGIN_DECLS

--- a/src/settings.c
+++ b/src/settings.c
@@ -39,7 +39,7 @@ struct _Settings
 
   GHashTable *settings;
   FcMonitor *fontconfig_monitor;
-  int fontconfig_timestamp;
+  int fontconfig_serial;
 };
 
 struct _SettingsClass
@@ -131,7 +131,7 @@ settings_handle_read_all (XdpSettings           *object,
       GVariantDict dict;
 
       g_variant_dict_init (&dict, NULL);
-      g_variant_dict_insert_value (&dict, "timestamp", g_variant_new_int32 (self->fontconfig_timestamp));
+      g_variant_dict_insert_value (&dict, "serial", g_variant_new_int32 (self->fontconfig_serial));
       
       g_variant_builder_add (&builder, "{s@a{sv}}", "org.gnome.fontconfig", g_variant_dict_end (&dict));
     }
@@ -155,10 +155,10 @@ settings_handle_read (XdpSettings           *object,
   // TODO: Handle kdeglobals via same interface
   if (strcmp (arg_namespace, "org.gnome.fontconfig") == 0)
     {
-      if (strcmp (arg_key, "timestamp") == 0)
+      if (strcmp (arg_key, "serial") == 0)
         {
           g_dbus_method_invocation_return_value (invocation,
-                                                 g_variant_new ("(v)", g_variant_new_int32 (self->fontconfig_timestamp)));
+                                                 g_variant_new ("(v)", g_variant_new_int32 (self->fontconfig_serial)));
           return TRUE;
         }
     }
@@ -259,15 +259,15 @@ fontconfig_changed (FcMonitor *monitor,
                     Settings *self)
 {
   const char *namespace = "org.gnome.fontconfig";
-  const char *key = "timestamp";
+  const char *key = "serial";
   
   g_debug ("Emitting changed for %s %s", namespace, key);
 
-  self->fontconfig_timestamp = time (NULL);
+  self->fontconfig_serial++;
 
   xdp_settings_emit_setting_changed (XDP_SETTINGS (self),
                                      namespace, key,
-                                     g_variant_new ("v", g_variant_new_int32 (self->fontconfig_timestamp)));
+                                     g_variant_new ("v", g_variant_new_int32 (self->fontconfig_serial)));
 }
 
 static void

--- a/src/settings.c
+++ b/src/settings.c
@@ -20,6 +20,7 @@
 
 #include "config.h"
 
+#include <time.h>
 #include <string.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
@@ -27,6 +28,7 @@
 #include "settings.h"
 #include "xdp-dbus.h"
 #include "xdp-utils.h"
+#include "fc-monitor.h"
 
 typedef struct _Settings Settings;
 typedef struct _SettingsClass SettingsClass;
@@ -36,6 +38,8 @@ struct _Settings
   XdpSettingsSkeleton parent_instance;
 
   GHashTable *settings;
+  FcMonitor *fontconfig_monitor;
+  int fontconfig_timestamp;
 };
 
 struct _SettingsClass
@@ -121,6 +125,17 @@ settings_handle_read_all (XdpSettings           *object,
 
       g_variant_builder_add (&builder, "{s@a{sv}}", key, g_variant_dict_end (&dict));
     }
+
+  if (namespace_matches ("org.gnome.fontconfig", arg_namespace))
+    {
+      GVariantDict dict;
+
+      g_variant_dict_init (&dict, NULL);
+      g_variant_dict_insert_value (&dict, "timestamp", g_variant_new_int32 (self->fontconfig_timestamp));
+      
+      g_variant_builder_add (&builder, "{s@a{sv}}", "org.gnome.fontconfig", g_variant_dict_end (&dict));
+    }
+
   g_variant_builder_close (&builder);
 
   g_dbus_method_invocation_return_value (invocation, g_variant_builder_end (&builder));
@@ -138,30 +153,31 @@ settings_handle_read (XdpSettings           *object,
   g_debug ("Read %s %s", arg_namespace, arg_key);
 
   // TODO: Handle kdeglobals via same interface
-  if (!g_hash_table_contains (self->settings, arg_namespace))
+  if (strcmp (arg_namespace, "org.gnome.fontconfig") == 0)
     {
-      g_debug ("Attempted to read from unknown namespace %s", arg_namespace);
-      g_dbus_method_invocation_return_error_literal (invocation, XDG_DESKTOP_PORTAL_ERROR,
-                                                     XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND,
-                                                     _("Requested setting not found"));
+      if (strcmp (arg_key, "timestamp") == 0)
+        {
+          g_dbus_method_invocation_return_value (invocation,
+                                                 g_variant_new ("(v)", g_variant_new_int32 (self->fontconfig_timestamp)));
+          return TRUE;
+        }
     }
-  else
+  else if (g_hash_table_contains (self->settings, arg_namespace))
     {
       SettingsBundle *bundle = g_hash_table_lookup (self->settings, arg_namespace);
       if (g_settings_schema_has_key (bundle->schema, arg_key))
         {
           g_autoptr (GVariant) variant = NULL;
           variant = g_settings_get_value (bundle->settings, arg_key);
-          g_dbus_method_invocation_return_value (invocation, g_variant_new("(v)", variant));
-        }
-      else
-        {
-          g_debug ("Attempted to read unknown key %s", arg_key);
-          g_dbus_method_invocation_return_error_literal (invocation, XDG_DESKTOP_PORTAL_ERROR,
-                                                         XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND,
-                                                         _("Requested setting not found"));
+          g_dbus_method_invocation_return_value (invocation, g_variant_new ("(v)", variant));
+          return TRUE;
         }
     }
+
+  g_debug ("Attempted to read unknown namespace/key pair: %s %s", arg_namespace, arg_key);
+  g_dbus_method_invocation_return_error_literal (invocation, XDG_DESKTOP_PORTAL_ERROR,
+                                                 XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND,
+                                                 _("Requested setting not found"));
 
   return TRUE;
 }
@@ -239,6 +255,22 @@ init_settings_table (Settings   *self,
 }
 
 static void
+fontconfig_changed (FcMonitor *monitor,
+                    Settings *self)
+{
+  const char *namespace = "org.gnome.fontconfig";
+  const char *key = "timestamp";
+  
+  g_debug ("Emitting changed for %s %s", namespace, key);
+
+  self->fontconfig_timestamp = time (NULL);
+
+  xdp_settings_emit_setting_changed (XDP_SETTINGS (self),
+                                     namespace, key,
+                                     g_variant_new ("v", g_variant_new_int32 (self->fontconfig_timestamp)));
+}
+
+static void
 settings_iface_init (XdpSettingsIface *iface)
 {
   iface->handle_read = settings_handle_read;
@@ -251,6 +283,10 @@ settings_init (Settings *self)
   self->settings = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, (GDestroyNotify)settings_bundle_free);
   init_settings_table (self, self->settings);
 
+  self->fontconfig_monitor = fc_monitor_new ();
+  g_signal_connect (self->fontconfig_monitor, "updated", G_CALLBACK (fontconfig_changed), self);
+  fc_monitor_start (self->fontconfig_monitor);
+
   xdp_settings_set_version (XDP_SETTINGS (self), 1);
 }
 
@@ -259,6 +295,10 @@ settings_finalize (GObject *object)
 {
   Settings *self = (Settings*)object;
   g_hash_table_destroy (self->settings);
+
+  g_signal_handlers_disconnect_by_data (self->fontconfig_monitor, self);
+  fc_monitor_stop (self->fontconfig_monitor);
+  g_object_unref (self->fontconfig_monitor);
 
   G_OBJECT_CLASS (settings_parent_class)->finalize (object);
 }


### PR DESCRIPTION
This is not a gsetting, so we treat it separately.
To make things easy for clients, we put it in a
fake org.gnome.fontconfig namespace.

The fontconfig monitor code here is copied from
gnome-settings-daemon.