### PR TITLE
Add note about byte array properties in filechooser portal

### DIFF
--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -194,11 +194,19 @@
         </varlistentry>
         <varlistentry>
           <term>current_folder ay</term>
-          <listitem><para>Suggested folder to save the file in.</para></listitem>
+          <listitem>
+            <para>
+              Suggested folder to save the file in. The byte array is expected to be null-terminated.
+            </para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>current_file ay</term>
-          <listitem><para>The current file (when saving an existing file).</para></listitem>
+          <listitem>
+            <para>
+              The current file (when saving an existing file). The byte array is expected to be null-terminated.
+            </para>
+          </listitem>
         </varlistentry>
       </variablelist>
 


### PR DESCRIPTION
Properties which are send as byte array need to be null-terminated. 
