### PR TITLE
Implement lockdown for some portals

### DIFF
--- a/data/org.freedesktop.impl.portal.AppChooser.xml
+++ b/data/org.freedesktop.impl.portal.AppChooser.xml
@@ -83,5 +83,6 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+    <property name="disabled" type="b" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -197,5 +197,6 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+    <property name="save-disabled" type="b" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -141,5 +141,6 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+    <property name="disabled" type="b" access="read"/>
   </interface>
 </node>

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -514,6 +514,17 @@ handle_save_file (XdpFileChooser *object,
   XdpImplRequest *impl_request;
   GVariantBuilder options;
 
+
+  if (xdp_impl_file_chooser_get_save_disabled (impl))
+    {
+      g_debug ("File saving disabled");
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "File saving disabled");
+      return TRUE;
+    }
+
   REQUEST_AUTOLOCK (request);
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -618,6 +618,16 @@ handle_open_uri (XdpOpenURI *object,
   g_autoptr(GTask) task = NULL;
   gboolean writable;
 
+  if (xdp_impl_app_chooser_get_disabled (impl))
+    {
+      g_debug ("Application handlers disabled");
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "Application handlers disabled");
+      return TRUE;
+    }
+
   if (!g_variant_lookup (arg_options, "writable", "b", &writable))
     writable = FALSE;
 
@@ -648,6 +658,16 @@ handle_open_file (XdpOpenURI *object,
   gboolean writable;
   int fd_id, fd;
   g_autoptr(GError) error = NULL;
+
+  if (xdp_impl_app_chooser_get_disabled (impl))
+    {
+      g_debug ("Application handlers disabled");
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "Application handlers disabled");
+      return TRUE;
+    }
 
   if (!g_variant_lookup (arg_options, "writable", "b", &writable))
     writable = FALSE;

--- a/src/print.c
+++ b/src/print.c
@@ -115,6 +115,17 @@ handle_print (XdpPrint *object,
   g_autoptr(XdpImplRequest) impl_request = NULL;
   GVariantBuilder opt_builder;
 
+  if (xdp_impl_print_get_disabled (impl))
+    {
+      g_debug ("Printing disabled");
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "Printing disabled");
+      return TRUE;
+    }
+
+
   REQUEST_AUTOLOCK (request);
 
   impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
@@ -216,6 +227,16 @@ handle_prepare_print (XdpPrint *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpImplRequest) impl_request = NULL;
   GVariantBuilder opt_builder;
+
+  if (xdp_impl_print_get_disabled (impl))
+    {
+      g_debug ("Printing disabled");
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "Printing disabled");
+      return TRUE;
+    }
 
   REQUEST_AUTOLOCK (request);
 


### PR DESCRIPTION
GNOME has lockdown settings for printing, file saving and
application handlers. Add 'disabled' properties to the
corresponding portal backend interfaces, and respect these
in the frontends by returning 'not allowed' errors.

To explain the design I ended up with here:

I started to add the lockdown in the backend (returning errors from portal backend calls),
but it turns out that the openuri portal frontend has shortcuts and doesn't use a backend
at all, some of the time. To address this, I moved the lockdown handling to the frontend.

It is a good fit with the other permission handling that happens in the frontend.

To keep the desktop-specific implementation (GNOME lockdown settings) out of the
frontend, I added 'disabled' properties to the backend interfaces in question, which
the frontend can consult.
