### PR TITLE
test-doc-portal: Skip all tests if FUSE isn't supported

### DIFF
--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -858,6 +858,12 @@ global_teardown (void)
 static void
 test_version (void)
 {
+  if (!have_fuse)
+    {
+      g_test_skip ("this test requires FUSE");
+      return;
+    }
+
   g_assert_cmpint (xdp_dbus_documents_get_version (documents), ==, 3);  
 }
 


### PR DESCRIPTION
Distribution autobuilders sometimes use a hardened OS configuration that
does not allow module loading or FUSE; in particular, this is the case
in Debian. In this environment, global setup does not complete,
`documents` is NULL and this test would segfault. Skip the test and rely
on installed-tests to cover it instead.