### PR TITLE
Document portal: Don't raise a critical when removing entries

### DIFF
--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -228,7 +228,7 @@ permission_db_init (PermissionDb *self)
 
   self->main_updates =
     g_hash_table_new_full (g_str_hash, g_str_equal,
-                           g_free, (GDestroyNotify) g_variant_unref);
+                           g_free, (GDestroyNotify) permission_db_entry_unref);
   self->app_additions =
     g_hash_table_new_full (g_str_hash, g_str_equal,
                            g_free, (GDestroyNotify) g_ptr_array_unref);
@@ -947,7 +947,8 @@ permission_db_entry_ref (PermissionDbEntry *entry)
 void
 permission_db_entry_unref (PermissionDbEntry *entry)
 {
-  g_variant_unref ((GVariant *) entry);
+  if (entry != NULL)
+    g_variant_unref ((GVariant *) entry);
 }
 
 /* Transfer: full */


### PR DESCRIPTION
We can store a NULL PermissionDbError (which is just an alias for
GVariant) in main_updates, as a "white-out" that indicates that an
entry has been removed. Callig g_variant_unref() on NULL is considered
to be a programming error.