### PR TITLE
Lockdown, part 2

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -34,4 +34,5 @@ dist_introspection_DATA = \
 	data/org.freedesktop.impl.portal.ScreenCast.xml \
 	data/org.freedesktop.impl.portal.RemoteDesktop.xml \
 	data/org.freedesktop.impl.portal.Settings.xml \
+	data/org.freedesktop.impl.portal.Lockdown.xml \
 	$(NULL)

--- a/data/org.freedesktop.impl.portal.AppChooser.xml
+++ b/data/org.freedesktop.impl.portal.AppChooser.xml
@@ -97,7 +97,5 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="as" name="choices" direction="in"/>
     </method>
-
-    <property name="disabled" type="b" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -197,6 +197,5 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
-    <property name="save-disabled" type="b" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Lockdown.xml
+++ b/data/org.freedesktop.impl.portal.Lockdown.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2018 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+    org.freedesktop.impl.portal.Lockdown:
+    @short_description: Lockdown backend interface
+
+    This interface provides access to high-level desktop lockdown
+    settings that can disable entire portals, such as disabling
+    printing or location services.
+
+    This is meant to be used by different portal frontends.
+  -->
+  <interface name="org.freedesktop.impl.portal.Lockdown">
+
+    <property name="disable-printing" type="b" access="read"/>
+    <property name="disable-save-to-disk" type="b" access="read"/>
+    <property name="disable-application-handlers" type="b" access="read"/>
+    <property name="disable-location" type="b" access="read"/>
+    <property name="disable-camera" type="b" access="read"/>
+    <property name="disable-microphone" type="b" access="read"/>
+    <property name="disable-sound-output" type="b" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -141,6 +141,5 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
-    <property name="disabled" type="b" access="read"/>
   </interface>
 </node>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -35,6 +35,7 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Inhibit.xml	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Access.xml	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Settings.xml	\
+	$(top_srcdir)/data/org.freedesktop.impl.portal.Lockdown.xml	\
 	$(top_srcdir)/data/org.freedesktop.portal.Documents.xml		\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.PermissionStore.xml	\
 	$(NULL)
@@ -72,6 +73,7 @@ xml_files = 								\
 	portal-org.freedesktop.impl.portal.Inhibit.xml	 		\
 	portal-org.freedesktop.impl.portal.Access.xml	 		\
 	portal-org.freedesktop.impl.portal.Settings.xml	 		\
+	portal-org.freedesktop.impl.portal.Lockdown.xml	 		\
 	portal-org.freedesktop.impl.portal.PermissionStore.xml		\
 	$(NULL)
 

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -144,6 +144,7 @@
     <xi:include href="portal-org.freedesktop.impl.portal.Inhibit.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Access.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Settings.xml"/>
+    <xi:include href="portal-org.freedesktop.impl.portal.Lockdown.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.PermissionStore.xml"/>
   </reference>
 </book>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -54,6 +54,7 @@ PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.ScreenCast.xml \
 	data/org.freedesktop.impl.portal.RemoteDesktop.xml \
 	data/org.freedesktop.impl.portal.Settings.xml \
+	data/org.freedesktop.impl.portal.Lockdown.xml \
 	$(NULL)
 
 $(xdp_dbus_built_sources) : $(PORTAL_IFACE_FILES)

--- a/src/device.h
+++ b/src/device.h
@@ -23,4 +23,5 @@
 #include <gio/gio.h>
 
 GDBusInterfaceSkeleton * device_create (GDBusConnection *connection,
-                                        const char      *dbus_name);
+                                        const char      *dbus_name,
+                                        gpointer         lockdown);

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -53,6 +53,7 @@ struct _FileChooserClass
   XdpFileChooserSkeletonClass parent_class;
 };
 
+static XdpImplLockdown *lockdown;
 static XdpImplFileChooser *impl;
 static FileChooser *file_chooser;
 
@@ -514,8 +515,7 @@ handle_save_file (XdpFileChooser *object,
   XdpImplRequest *impl_request;
   GVariantBuilder options;
 
-
-  if (xdp_impl_file_chooser_get_save_disabled (impl))
+  if (xdp_impl_lockdown_get_disable_save_to_disk (lockdown))
     {
       g_debug ("File saving disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -582,9 +582,12 @@ file_chooser_class_init (FileChooserClass *klass)
 
 GDBusInterfaceSkeleton *
 file_chooser_create (GDBusConnection *connection,
-                     const char      *dbus_name)
+                     const char      *dbus_name,
+                     gpointer         lockdown_proxy)
 {
   g_autoptr(GError) error = NULL;
+
+  lockdown = lockdown_proxy;
 
   impl = xdp_impl_file_chooser_proxy_new_sync (connection,
                                                G_DBUS_PROXY_FLAGS_NONE,

--- a/src/file-chooser.h
+++ b/src/file-chooser.h
@@ -23,4 +23,5 @@
 #include <gio/gio.h>
 
 GDBusInterfaceSkeleton * file_chooser_create (GDBusConnection *connection,
-                                              const char      *dbus_name);
+                                              const char      *dbus_name,
+                                              gpointer         lockdown);

--- a/src/location.h
+++ b/src/location.h
@@ -24,4 +24,5 @@
 #include <gio/gio.h>
 
 GDBusInterfaceSkeleton * location_create (GDBusConnection *connection,
-                                          const char *dbus_name);
+                                          const char *dbus_name,
+                                          gpointer lockdown);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -69,6 +69,7 @@ enum {
 static XdpImplAppChooser *impl;
 static OpenURI *open_uri;
 static GAppInfoMonitor *monitor;
+static XdpImplLockdown *lockdown;
 
 GType open_uri_get_type (void) G_GNUC_CONST;
 static void open_uri_iface_init (XdpOpenURIIface *iface);
@@ -645,7 +646,7 @@ handle_open_uri (XdpOpenURI *object,
   g_autoptr(GTask) task = NULL;
   gboolean writable;
 
-  if (xdp_impl_app_chooser_get_disabled (impl))
+  if (xdp_impl_lockdown_get_disable_application_handlers (lockdown))
     {
       g_debug ("Application handlers disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -686,7 +687,7 @@ handle_open_file (XdpOpenURI *object,
   int fd_id, fd;
   g_autoptr(GError) error = NULL;
 
-  if (xdp_impl_app_chooser_get_disabled (impl))
+  if (xdp_impl_lockdown_get_disable_application_handlers (lockdown))
     {
       g_debug ("Application handlers disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -741,9 +742,12 @@ open_uri_class_init (OpenURIClass *klass)
 
 GDBusInterfaceSkeleton *
 open_uri_create (GDBusConnection *connection,
-                 const char *dbus_name)
+                 const char *dbus_name,
+                 gpointer lockdown_proxy)
 {
   g_autoptr(GError) error = NULL;
+
+  lockdown = lockdown_proxy;
 
   impl = xdp_impl_app_chooser_proxy_new_sync (connection,
                                               G_DBUS_PROXY_FLAGS_NONE,

--- a/src/open-uri.h
+++ b/src/open-uri.h
@@ -24,5 +24,5 @@
 #include <gio/gio.h>
 
 GDBusInterfaceSkeleton * open_uri_create (GDBusConnection *connection,
-                                          const char      *dbus_name);
-
+                                          const char      *dbus_name,
+                                          gpointer         lockdown);

--- a/src/print.c
+++ b/src/print.c
@@ -53,6 +53,7 @@ struct _PrintClass
 
 static XdpImplPrint *impl;
 static Print *print;
+static XdpImplLockdown *lockdown;
 
 GType print_get_type (void) G_GNUC_CONST;
 static void print_iface_init (XdpPrintIface *iface);
@@ -115,7 +116,7 @@ handle_print (XdpPrint *object,
   g_autoptr(XdpImplRequest) impl_request = NULL;
   GVariantBuilder opt_builder;
 
-  if (xdp_impl_print_get_disabled (impl))
+  if (xdp_impl_lockdown_get_disable_printing (lockdown))
     {
       g_debug ("Printing disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -228,7 +229,7 @@ handle_prepare_print (XdpPrint *object,
   g_autoptr(XdpImplRequest) impl_request = NULL;
   GVariantBuilder opt_builder;
 
-  if (xdp_impl_print_get_disabled (impl))
+  if (xdp_impl_lockdown_get_disable_printing (lockdown))
     {
       g_debug ("Printing disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -294,9 +295,12 @@ print_class_init (PrintClass *klass)
 
 GDBusInterfaceSkeleton *
 print_create (GDBusConnection *connection,
-              const char *dbus_name)
+              const char *dbus_name,
+              gpointer lockdown_proxy)
 {
   g_autoptr(GError) error = NULL;
+
+  lockdown = lockdown_proxy;
 
   impl = xdp_impl_print_proxy_new_sync (connection,
                                         G_DBUS_PROXY_FLAGS_NONE,

--- a/src/print.h
+++ b/src/print.h
@@ -23,4 +23,5 @@
 #include <gio/gio.h>
 
 GDBusInterfaceSkeleton * print_create (GDBusConnection *connection,
-                                       const char      *dbus_name);
+                                       const char      *dbus_name,
+                                       gpointer         lockdown);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -439,7 +439,7 @@ on_bus_acquired (GDBusConnection *connection,
                                     device_create (connection, implementation->dbus_name));
 #ifdef HAVE_GEOCLUE
       export_portal_implementation (connection,
-                                    location_create (connection, implementation->dbus_name));
+                                    location_create (connection, implementation->dbus_name, lockdown));
 #endif
     }
 

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -436,7 +436,7 @@ on_bus_acquired (GDBusConnection *connection,
   if (implementation != NULL)
     {
       export_portal_implementation (connection,
-                                    device_create (connection, implementation->dbus_name));
+                                    device_create (connection, implementation->dbus_name, lockdown));
 #ifdef HAVE_GEOCLUE
       export_portal_implementation (connection,
                                     location_create (connection, implementation->dbus_name, lockdown));

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -29,6 +29,7 @@
 
 #include "xdp-utils.h"
 #include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
 #include "request.h"
 #include "call.h"
 #include "documents.h"
@@ -378,10 +379,21 @@ on_bus_acquired (GDBusConnection *connection,
 {
   PortalImplementation *implementation;
   g_autoptr(GError) error = NULL;
+  XdpImplLockdown *lockdown;
 
   xdp_connection_track_name_owners (connection, peer_died_cb);
   init_document_proxy (connection);
   init_permission_store (connection);
+
+  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Lockdown");
+  if (implementation != NULL)
+    lockdown = xdp_impl_lockdown_proxy_new_sync (connection,
+                                                 G_DBUS_PROXY_FLAGS_NONE,
+                                                 implementation->dbus_name,
+                                                 DESKTOP_PORTAL_OBJECT_PATH,
+                                                 NULL, &error);
+  else
+    lockdown = xdp_impl_lockdown_skeleton_new ();
 
   export_portal_implementation (connection, network_monitor_create (connection));
   export_portal_implementation (connection, proxy_resolver_create (connection));
@@ -393,17 +405,17 @@ on_bus_acquired (GDBusConnection *connection,
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.FileChooser");
   if (implementation != NULL)
     export_portal_implementation (connection,
-                                  file_chooser_create (connection, implementation->dbus_name));
+                                  file_chooser_create (connection, implementation->dbus_name, lockdown));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.AppChooser");
   if (implementation != NULL)
     export_portal_implementation (connection,
-                                  open_uri_create (connection, implementation->dbus_name));
+                                  open_uri_create (connection, implementation->dbus_name, lockdown));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Print");
   if (implementation != NULL)
     export_portal_implementation (connection,
-                                  print_create (connection, implementation->dbus_name));
+                                  print_create (connection, implementation->dbus_name, lockdown));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Screenshot");
   if (implementation != NULL)


### PR DESCRIPTION
Redo lockdown properties as a separate interface, to avoid problems with the lack of backends for some portals that may grow lockdown.