### PR TITLE
notification: Write back permissions

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -133,6 +133,7 @@ get_notification_allowed (const char *app_id)
   g_autoptr(GVariant) out_perms = NULL;
   g_autoptr(GVariant) out_data = NULL;
   g_autoptr(GError) error = NULL;
+  const char *permissions[2];
 
   if (!xdp_impl_permission_store_call_lookup_sync (get_permission_store (),
                                                    TABLE_NAME,
@@ -160,6 +161,22 @@ get_notification_allowed (const char *app_id)
     }
 
   g_debug ("No notification permissions stored for %s: allowing", app_id);
+
+  permissions[0] = "yes";
+  permissions[1] = NULL;
+
+  if (!xdp_impl_permission_store_call_set_permission_sync (get_permission_store (),
+                                                           TABLE_NAME,
+                                                           TRUE,
+                                                           "notification",
+                                                           app_id,
+                                                           (const char * const*)permissions,
+                                                           NULL,
+                                                           &error))
+    {
+      g_warning ("Error updating permission store: %s", error->message);
+    }
+
 
   return TRUE;
 }


### PR DESCRIPTION
We want to use the fact that there are permissions in the
permission store for an app to hide or show the corresponding
row in the control-center. Basically, we want the permission
store to record which apps have used this portal. So, make
the notification portal write back a "yes" when the app is
using it.