### PR TITLE
Document portal: set st_nlink to 1 for documents

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -1002,6 +1002,7 @@ xdp_inode_stat (XdpInode    *inode,
         stbuf->st_atim = tmp_stbuf.st_atim;
         stbuf->st_mtim = tmp_stbuf.st_mtim;
         stbuf->st_ctim = tmp_stbuf.st_ctim;
+        stbuf->st_nlink = 1;
       }
       break;
 


### PR DESCRIPTION
If it's not set, the default value is 0 and Qt fails to detect whether the mounted file exists or not.