### PR TITLE
file-chooser: Add support for proxying current_filter

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -67,6 +67,13 @@
             </para></listitem>
           </varlistentry>
           <varlistentry>
+            <term>current_filter (sa(us))</term>
+            <listitem><para>
+              Request that this filter be set by default at dialog creation.
+              See org.freedesktop.portal.FileChooser.OpenFile() for details.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
             <term>choices a(ssa(ss)s)</term>
             <listitem><para>
               A list of serialized combo boxes.
@@ -139,6 +146,13 @@
             <term>filters a(sa(us))</term>
             <listitem><para>
               A list of serialized file filters.
+              See org.freedesktop.portal.FileChooser.OpenFile() for details.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>current_filter (sa(us))</term>
+            <listitem><para>
+              Request that this filter be set by default at dialog creation.
               See org.freedesktop.portal.FileChooser.OpenFile() for details.
             </para></listitem>
           </varlistentry>

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -89,6 +89,16 @@
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term>current_filter (sa(us))</term>
+          <listitem><para>
+            Request that this filter be set by default at dialog creation. If
+            the filters list is nonempty, it should match a filter in the
+            list to set the default filter from the list. Alternatively, it
+            may be specified when the list is empty to apply the filter
+            unconditionally.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
           <term>choices a(ssa(ss)s)</term>
           <listitem>
             <para>
@@ -178,6 +188,13 @@
           <term>filters a(sa(us))</term>
           <listitem><para>
             List of serialized file filters.
+            See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>current_filter (sa(us))</term>
+          <listitem><para>
+            Request that this filter be set by default at dialog creation.
             See org.freedesktop.portal.FileChooser.OpenFile() for details.
           </para></listitem>
         </varlistentry>


### PR DESCRIPTION
This will allow xdg-desktop-portal-gtk to call
gtk_file_chooser_set_filter() to make file filters not suck to use.

https://gitlab.gnome.org/GNOME/gtk/issues/1492