### PR TITLE
Pass all options to validation functions

### DIFF
--- a/src/email.c
+++ b/src/email.c
@@ -118,6 +118,7 @@ compose_email_done (GObject *source,
 static gboolean
 validate_email_address (const char *key,
                         GVariant *value,
+                        GVariant *options,
                         GError **error)
 {
   const char *string = g_variant_get_string (value, NULL);
@@ -136,6 +137,7 @@ g_print ("'%s' looks like an a-ok email\n", string);
 static gboolean
 validate_email_subject (const char *key,
                         GVariant *value,
+                        GVariant *options,
                         GError **error)
 {
   const char *string = g_variant_get_string (value, NULL);

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -251,6 +251,7 @@ check_filter (GVariant *filter,
 static gboolean
 validate_filters (const char *key,
                   GVariant *value,
+                  GVariant *options,
                   GError **error)
 {
   int i;
@@ -362,6 +363,7 @@ check_choice (GVariant *choice,
 static gboolean
 validate_choices (const char *key,
                   GVariant *value,
+                  GVariant *options,
                   GError **error)
 {
   int i;

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -359,6 +359,7 @@ select_devices_done (GObject *source_object,
 static gboolean
 validate_device_types (const char *key,
                        GVariant *value,
+                       GVariant *options,
                        GError **error)
 {
   guint32 types = g_variant_get_uint32 (value);

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -340,6 +340,7 @@ select_sources_done (GObject *source_object,
 static gboolean
 validate_device_types (const char *key,
                        GVariant *value,
+                       GVariant *options,
                        GError **error)
 {
   guint32 types = g_variant_get_uint32 (value);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -708,7 +708,7 @@ xdp_filter_options (GVariant *options,
         {
           g_autoptr(GError) local_error = NULL;
 
-          if (!supported_options[i].validate (supported_options[i].key, value, &local_error))
+          if (!supported_options[i].validate (supported_options[i].key, value, options, &local_error))
             {
               if (ret)
                 {

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -75,7 +75,7 @@ void   xdp_connection_track_name_owners  (GDBusConnection       *connection,
 typedef struct {
   const char *key;
   const GVariantType *type;
-  gboolean (* validate) (const char *key, GVariant *value, GError **error);
+  gboolean (* validate) (const char *key, GVariant *value, GVariant *options, GError **error);
 } XdpOptionKey;
 
 gboolean xdp_filter_options (GVariant *options_in,


### PR DESCRIPTION
This lets us do validation depending on the values
of other options, which is sometimes necessary.

Update all callers.