### PR TITLE
inhibit: Add session state to the StateChanged signal

### DIFF
--- a/data/org.freedesktop.impl.portal.Inhibit.xml
+++ b/data/org.freedesktop.impl.portal.Inhibit.xml
@@ -68,9 +68,10 @@
     <!--
         CreateMonitor:
         @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @session_handle: Object path for the created #org.freedesktop.impl.portal.Session object
         @app_id: App id of the application
         @window: the parent window
+        @response: the result of the operation (0 == success)
 
         Creates a monitoring session. While this session is
         active, the caller will receive StateChanged signals
@@ -92,6 +93,11 @@
         The StateChanged signal is sent to active monitoring sessions when
         the session state changes.
 
+        When the session state changes to 'Query End', clients with active monitoring
+        sessions are expected to respond by calling
+        org.freedesktop.impl.portal.Inhibit.QueryEndResponse() within a second
+        of receiving the StateChanged signal.
+
         The following information may get returned in the @state vardict:
         <variablelist>
            <varlistentry>
@@ -100,12 +106,36 @@
               Whether the screensaver is active.
             </para></listitem>
           </varlistentry>
+           <varlistentry>
+            <term>session-state u</term>
+            <listitem><para>
+              The state of the session.
+            </para>
+            <simplelist>
+              <member>1: Running</member>
+              <member>2: Query End</member>
+              <member>3: Ending</member>
+            </simplelist>
+            </listitem>
+          </varlistentry>
         </variablelist>
     -->
     <signal name="StateChanged">
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="a{sv}" name="state" direction="out"/>
     </signal>
+
+    <!--
+      QueryEndResponse:
+      @session_handle: Object path for the #org.freedesktop.impl.portal.Session object
+
+      Acknowledges that the caller received the #org.freedesktop.impl.portal.Inhibit::StateChanged
+      signal. This method should be called within one second or receiving a StateChanged
+      signal with the 'Query End' state.
+    -->
+    <method name="QueryEndResponse">
+      <arg type="o" name="session_handle" direction="in"/>
+    </method>
 
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -134,6 +134,12 @@
         The StateChanged signal is sent to active monitoring sessions when
         the session state changes.
 
+        When the session state changes to 'Query End', clients with active monitoring
+        sessions are expected to respond by calling 
+        org.freedesktop.portal.Inhibit.QueryEndResponse() within a second
+        of receiving the StateChanged signal. They may call org.freedesktop.portal.Inhibit.Inhibit()
+        first to inhibit logout, to prevent the session from proceeding to the Ending state.
+
         The following information may get returned in the @state vardict:
         <variablelist>
           <varlistentry>
@@ -142,12 +148,36 @@
               Whether the screensaver is active.
             </para></listitem>
           </varlistentry>
+           <varlistentry>
+            <term>session-state u</term>
+            <listitem><para>
+              The state of the session.
+            </para>
+            <simplelist>
+              <member>1: Running</member>
+              <member>2: Query End</member>
+              <member>3: Ending</member>
+            </simplelist>
+            </listitem>
+          </varlistentry>
         </variablelist>
     -->
     <signal name="StateChanged">
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="a{sv}" name="state" direction="out"/>
     </signal>
+
+    <!--
+      QueryEndResponse:
+      @session_handle: Object path for the #org.freedesktop.portal.Session object
+
+      Acknowledges that the caller received the #org.freedesktop.portal.Inhibit::StateChanged
+      signal. This method should be called within one second or receiving a StateChanged
+      signal with the 'Query End' state.
+    -->
+    <method name="QueryEndResponse">
+      <arg type="o" name="session_handle" direction="in"/>
+    </method>
 
     <property name="version" type="u" access="read"/>
   </interface>

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -26,7 +26,7 @@
       This simple interface lets sandboxed applications inhibit the user
       session from ending, suspending, idling or getting switched away.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes version 3 of this interface.
   -->
   <interface name="org.freedesktop.portal.Inhibit">
     <!--
@@ -151,7 +151,7 @@
            <varlistentry>
             <term>session-state u</term>
             <listitem><para>
-              The state of the session.
+              The state of the session. This member is new in version 3.
             </para>
             <simplelist>
               <member>1: Running</member>
@@ -174,6 +174,8 @@
       Acknowledges that the caller received the #org.freedesktop.portal.Inhibit::StateChanged
       signal. This method should be called within one second or receiving a StateChanged
       signal with the 'Query End' state.
+
+      Since version 3.
     -->
     <method name="QueryEndResponse">
       <arg type="o" name="session_handle" direction="in"/>

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -475,7 +475,7 @@ inhibit_iface_init (XdpInhibitIface *iface)
 static void
 inhibit_init (Inhibit *inhibit)
 {
-  xdp_inhibit_set_version (XDP_INHIBIT (inhibit), 2);
+  xdp_inhibit_set_version (XDP_INHIBIT (inhibit), 3);
 }
 
 static void


### PR DESCRIPTION
This will be used to inform monitoring applications about
the impending end of the session.