### PR TITLE
location: Fix incorrect format string for printing a gint64

### DIFF
--- a/src/location.c
+++ b/src/location.c
@@ -385,7 +385,7 @@ set_location_permissions (const char *app_id,
   if (app_id == NULL)
     return;
 
-  date = g_strdup_printf ("%li", timestamp);
+  date = g_strdup_printf ("%" G_GINT64_FORMAT, timestamp);
   permissions[0] = gclue_accuracy_level_to_string (accuracy);
   permissions[1] = (const char *)date;
   permissions[2] = NULL;


### PR DESCRIPTION
This would have caused problems on architectures where %li is not 64
bits, like 32-bit ARM.

Signed-off-by: Philip Withnall <withnall@endlessm.com>