### PR TITLE
OpenURI: add option to open files with default associated app

### DIFF
--- a/data/org.freedesktop.impl.portal.AppChooser.xml
+++ b/data/org.freedesktop.impl.portal.AppChooser.xml
@@ -62,6 +62,14 @@
             <listitem><para>The filename to choose an application for. Note that this
                is just a basename, without a path.</para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>use_associated_app b</term>
+            <listitem><para>
+              Whether to automatically use default application associated with the mime type
+              of the file we want to open.
+            </para></listitem>
+          </varlistentry>
+
         </variablelist>
 
         The following results get returned via the @results vardict:

--- a/data/org.freedesktop.portal.OpenURI.xml
+++ b/data/org.freedesktop.portal.OpenURI.xml
@@ -101,6 +101,13 @@
               is sandboxed itself.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>use-associated-app b</term>
+            <listitem><para>
+              Whether to automatically use default application associated with the mime type
+              of the file we want to open.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The OpenFile method was introduced in version 2 of the OpenURI portal API.


### PR DESCRIPTION
This should allow backends to automatically open files with apps associated with given mimetype. Main use-case for this is file browsers (e.g. Dolphin or Nautilus), where double-click should automatically open selected file with the default application and not always present a dialog with list of apps. The dialog should be used for example when "Open with" option from file browsers is used. I made this option to be "FALSE" by default to keep current behavior in case this is not implemented everywhere so users are not forced to have files opened with just the default application.