### PR TITLE
gamemode: add new portal for GameMode access

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -20,6 +20,7 @@ dist_introspection_DATA = \
 	data/org.freedesktop.portal.Location.xml \
 	data/org.freedesktop.portal.Settings.xml \
 	data/org.freedesktop.portal.Background.xml \
+	data/org.freedesktop.portal.GameMode.xml \
 	data/org.freedesktop.impl.portal.PermissionStore.xml \
 	data/org.freedesktop.impl.portal.Request.xml \
 	data/org.freedesktop.impl.portal.Session.xml \

--- a/data/org.freedesktop.portal.GameMode.xml
+++ b/data/org.freedesktop.portal.GameMode.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2019 Red Hat, Inc.
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ Author: Christian J. Kellner <christian@kellner.me>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+    <!--
+      org.freedesktop.portal.GameMode:
+      @short_description: Portal for accessing GameMode
+
+      Interface for accessing GameMode from within the sandbox. It
+      is analogous to the com.feralinteractive.GameMode interface
+      and will proxy request there, but with additional permission
+      checking and pid mapping. The latter is necessary in the case
+      that sandbox has pid  namespace isolation enabled. See the man
+      page for pid_namespaces(7) for more details, but briefly, it
+      means that the sandbox has its own process id namespace which
+      is separated from the one on the host. Thus there will be two
+      separate process  ids (pids) within two different namespaces
+      that both identify same process. One id from the pid namespace
+      inside the sandbox and one id from the host pid namespace.
+      Since GameMode expects pids from the host pid namespace but
+      programs inside the sandbox can only know pids from the sandbox
+      namespace, process ids need to be translated from the portal to
+      the host namespace. The portal will do that transparently for
+      all calls where this is necessary.
+
+      Note: GameMode will monitor active clients, i.e. games and
+      other programs that have successfully called 'RegisterGame'.
+      In the event that a client terminates without a call to the
+      'UnregisterGame' method, GameMode will automatically un-register
+      the client. This might happen with a (small) delay.
+
+      This documentation describes version 1 of this interface.
+    -->
+    <interface name="org.freedesktop.portal.GameMode">
+      <!--
+          QueryStatus:
+          @pid: Process id to query the GameMode status of
+          @result: The GameMode status for @pid '
+
+          Query the GameMode status for a process. If the caller
+          is running inside a sandbox with pid namespace isolation,
+          the pid will be translated to the respective host pid. See
+          the general introduction for details. Will return:
+            0 if GameMode is inactive,
+            1 if GameMode is active,
+            2 if GameMode is active and @pid is registered,
+           -1 if the query failed inside GameMode
+      -->
+      <method name="QueryStatus">
+        <arg type="i" name="pid" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+      <!--
+          RegisterGame:
+          @pid: Process id of the game to register
+          @result: Status of the request: 0 for success, -1 indicates an error
+
+          Register a game with GameMode and thus request GameMode to
+          be activated. If the caller is running inside a sandbox with
+          pid namespace isolation, the pid will be translated to the
+          respective host pid. See the general introduction for details.
+          If the GameMode has already been requested for @pid before,
+          this call will fail, i.e. result will be -1.
+          Will return:
+            0 if the game with @pid was successfully registered,
+           -1 if the request was rejected by GameMode
+      -->
+      <method name="RegisterGame">
+        <arg type="i" name="pid" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+      <!--
+          UnregisterGame:
+          @pid: Process id of the game to un-register
+          @result: Status of the request: 0 for success, -1 indicates an error
+
+          Un-register a game from GameMode; if the call is successful
+          and there are no other games or clients registered, GameMode
+	  will be deactivated. If the caller is running inside a sandbox
+          with pid namespace isolation, the pid will be translated to
+          the respective host pid.
+          Will return:
+            0 if the game with @pid was successfully un-registered,
+           -1 if the request was rejected by GameMode
+      -->
+      <method name="UnregisterGame">
+        <arg type="i" name="pid" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+
+      <property name="version" type="u" access="read"/>
+    </interface>
+</node>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -23,6 +23,7 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.portal.Location.xml		\
 	$(top_srcdir)/data/org.freedesktop.portal.Settings.xml		\
 	$(top_srcdir)/data/org.freedesktop.portal.Background.xml		\
+	$(top_srcdir)/data/org.freedesktop.portal.GameMode.xml		\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Request.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Session.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.FileChooser.xml 	\
@@ -63,6 +64,7 @@ xml_files = 								\
 	portal-org.freedesktop.portal.Location.xml			\
 	portal-org.freedesktop.portal.Settings.xml			\
 	portal-org.freedesktop.portal.Background.xml			\
+	portal-org.freedesktop.portal.GameMode.xml			\
 	portal-org.freedesktop.impl.portal.Request.xml 			\
 	portal-org.freedesktop.impl.portal.Session.xml 			\
 	portal-org.freedesktop.impl.portal.FileChooser.xml		\

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -108,6 +108,7 @@
     <xi:include href="portal-org.freedesktop.portal.ProxyResolver.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Settings.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Background.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.GameMode.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Documents.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Flatpak.xml"/>
   </reference>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -36,6 +36,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.Location.xml \
 	data/org.freedesktop.portal.Settings.xml \
 	data/org.freedesktop.portal.Background.xml \
+	data/org.freedesktop.portal.GameMode.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -151,6 +152,8 @@ xdg_desktop_portal_SOURCES = \
 	src/fc-monitor.h		\
 	src/background.c		\
 	src/background.h		\
+	src/gamemode.c			\
+	src/gamemode.h			\
         src/flatpak-instance.c          \
         src/flatpak-instance.h          \
 	src/portal-impl.h		\

--- a/src/gamemode.h
+++ b/src/gamemode.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Christian J. Kellner <christian@kellner.me>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * game_mode_create (GDBusConnection *connection);

--- a/src/request.c
+++ b/src/request.c
@@ -290,6 +290,10 @@ get_token (GDBusMethodInvocation *invocation)
     {
       // no request objects
     }
+  else if (strcmp (interface, "org.freedesktop.portal.GameMode") == 0)
+    {
+      // no request objects
+    }
   else
     {
       g_print ("Support for %s missing in " G_STRLOC, interface);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -52,6 +52,7 @@
 #include "location.h"
 #include "settings.h"
 #include "background.h"
+#include "gamemode.h"
 
 static GMainLoop *loop = NULL;
 
@@ -212,6 +213,7 @@ on_bus_acquired (GDBusConnection *connection,
   export_portal_implementation (connection, network_monitor_create (connection));
   export_portal_implementation (connection, proxy_resolver_create (connection));
   export_portal_implementation (connection, trash_create (connection));
+  export_portal_implementation (connection, game_mode_create (connection));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Settings");
   export_portal_implementation (connection, settings_create (connection, implementation ? implementation->dbus_name : NULL));

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -346,8 +346,6 @@ static XdpAppInfo *
 parse_app_info_from_flatpak_info (int pid, GError **error)
 {
   g_autofree char *root_path = NULL;
-  g_autofree char *path = NULL;
-  g_autofree char *content = NULL;
   int root_fd = -1;
   int info_fd = -1;
   struct stat stat_buf;

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -20,6 +20,8 @@
 
 #include "config.h"
 
+#include <json-glib/json-glib.h>
+
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -27,6 +29,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <mntent.h>
+#include <unistd.h>
 
 #include <gio/gdesktopappinfo.h>
 
@@ -121,6 +124,9 @@ struct _XdpAppInfo {
       struct
         {
           GKeyFile *keyfile;
+	   /* pid namespace mapping */
+          GMutex *pidns_lock;
+          ino_t   pidns_id;
         } flatpak;
       struct
         {
@@ -1243,4 +1249,433 @@ xdp_has_path_prefix (const char *str,
       if (*str != '/' && *str != 0)
         return FALSE;
     }
+}
+
+/* pid mapping code */
+static int
+parse_pid (const char *str,
+           pid_t      *pid)
+{
+  char *end;
+  guint64 v;
+  pid_t p;
+
+  errno = 0;
+  v = g_ascii_strtoull (str, &end, 0);
+  if (end == str)
+    return -ENOENT;
+  else if (errno != 0)
+    return -errno;
+
+  p = (pid_t) v;
+
+  if (p < 1 || (guint64) p != v)
+    return -ERANGE;
+
+  if (pid)
+    *pid = p;
+
+  return 0;
+}
+
+static int
+parse_status_field_pid (const char *val,
+                        pid_t      *pid)
+{
+  const char *t;
+
+  t = strrchr (val, '\t');
+  if (t == NULL)
+    return -ENOENT;
+
+  return parse_pid (t, pid);
+}
+
+static int
+parse_status_field_uid (const char *val,
+                        uid_t      *uid)
+{
+  const char *t;
+  char *end;
+  guint64 v;
+  uid_t u;
+
+  t = strrchr (val, '\t');
+  if (t == NULL)
+    return -ENOENT;
+
+  errno = 0;
+  v = g_ascii_strtoull (t, &end, 0);
+  if (end == val)
+    return -ENOENT;
+  else if (errno != 0)
+    return -errno;
+
+  u = (uid_t) v;
+
+  if ((guint64) u != v)
+    return -ERANGE;
+
+  if (uid)
+    *uid = u;
+
+  return 0;
+}
+
+static int
+parse_status_file (int    pid_fd,
+                   pid_t *pid_out,
+                   uid_t *uid_out)
+{
+  g_autofree char *key = NULL;
+  g_autofree char *val = NULL;
+  gboolean have_pid = pid_out == NULL;
+  gboolean have_uid = uid_out == NULL;
+  FILE *f;
+  size_t keylen = 0;
+  size_t vallen = 0;
+  ssize_t n;
+  int fd;
+  int r = 0;
+
+  g_return_val_if_fail (pid_fd > -1, FALSE);
+
+  fd = openat (pid_fd, "status",  O_RDONLY | O_CLOEXEC | O_NOCTTY);
+  if (fd == -1)
+    return -errno;
+
+  f = fdopen (fd, "r");
+
+  if (f == NULL)
+    return -errno;
+
+  fd = -1; /* fd is now owned by f */
+
+  do {
+    n = getdelim (&key, &keylen, ':', f);
+    if (n == -1)
+      {
+        r = -errno;
+        break;
+      }
+
+    n = getdelim (&val, &vallen, '\n', f);
+    if (n == -1)
+      {
+        r = -errno;
+        break;
+      }
+
+    g_strstrip (key);
+    g_strstrip (val);
+
+    if (!strncmp (key, "NSpid", strlen ("NSpid")))
+      {
+        r = parse_status_field_pid (val, pid_out);
+        have_pid = r > -1;
+      }
+    else if (!strncmp (key, "Uid", strlen ("Uid")))
+      {
+        r = parse_status_field_uid (val, uid_out);
+        have_uid = r > -1;
+      }
+
+    if (r < 0)
+      g_warning ("Failed to parse 'status::%s': %s",
+                 key, g_strerror (-r));
+
+  } while (r == 0 && (!have_uid || !have_pid));
+
+  fclose (f);
+
+  if (r != 0)
+    return r;
+  else if (!have_uid || !have_pid)
+    return -ENXIO; /* ENOENT for the fields */
+
+  return 0;
+}
+
+static int
+lookup_ns_from_pid_fd (int    pid_fd,
+                       ino_t *ns)
+{
+  struct stat st;
+  int r;
+
+  g_return_val_if_fail (ns != NULL, FALSE);
+
+  r = fstatat (pid_fd, "ns/pid", &st, 0);
+  if (r == -1)
+    return -errno;
+
+  /* The inode number (together with the device ID) encode
+   * the identity of the pid namespace, see namespaces(7)
+   */
+  *ns = st.st_ino;
+
+  return 0;
+}
+
+static int
+open_pid_fd (int      proc_fd,
+             pid_t    pid,
+             GError **error)
+{
+  char buf[20] = {0, };
+  int fd;
+
+  snprintf (buf, sizeof(buf), "%u", (guint) pid);
+
+  fd = openat (proc_fd, buf, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
+
+  if (fd == -1)
+    g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                 "Could not to open '/proc/pid/%u': %s", (guint) pid,
+                 g_strerror (errno));
+
+  return fd;
+}
+
+static inline gboolean
+find_pid (pid_t *pids,
+          guint  n_pids,
+          pid_t  want,
+          guint *idx)
+{
+  for (guint i = 0; i < n_pids; i++)
+    {
+      if (pids[i] == want)
+        {
+          *idx = i;
+          return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
+static gboolean
+map_pids (DIR     *proc,
+          ino_t    pidns,
+          pid_t   *pids,
+          guint    n_pids,
+          uid_t    target_uid,
+          GError **error)
+{
+  pid_t *res = NULL;
+  struct dirent *de;
+  guint count = 0;
+
+  res = g_alloca (sizeof (pid_t) * n_pids);
+
+  while ((de = readdir (proc)) != NULL)
+    {
+      xdp_autofd int pid_fd = -1;
+      pid_t outside = 0;
+      pid_t inside = 0;
+      uid_t uid = 0;
+      guint idx;
+      ino_t ns;
+      int r;
+
+      if (de->d_type != DT_DIR)
+        continue;
+
+      pid_fd = openat (dirfd (proc), de->d_name, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
+      if (pid_fd == -1)
+        continue;
+
+      r = lookup_ns_from_pid_fd (pid_fd, &ns);
+      if (r < 0)
+        continue;
+
+      if (pidns != ns)
+        continue;
+
+      r = parse_pid (de->d_name, &outside);
+      if (r < 0)
+        continue;
+
+      r = parse_status_file (pid_fd, &inside, &uid);
+      if (r < 0)
+        continue;
+
+      if (!find_pid (pids, n_pids, inside, &idx))
+        continue;
+
+      /* We got a match, let's make sure the real uids match as well */
+      if (uid != target_uid)
+        {
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
+                               "Matching pid doesn't belong to the target user");
+          return FALSE;
+        }
+
+      res[idx] = outside;
+      count++;
+    }
+
+  if (count != n_pids)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                           "Some process ids could not be found");
+      return FALSE;
+    }
+
+  memcpy (pids, res, sizeof (pid_t) * n_pids);
+
+  return TRUE;
+}
+
+static pid_t
+xdp_app_info_get_child_pid (XdpAppInfo *app_info,
+                            GError    **error)
+{
+  g_autoptr(JsonParser) parser = NULL;
+  g_autofree char *instance = NULL;
+  g_autofree char *data = NULL;
+  JsonNode *root;
+  JsonObject *cpo;
+  gsize len;
+  char *path;
+  pid_t pid;
+
+  g_return_val_if_fail (app_info != NULL, 0);
+
+  instance = xdp_app_info_get_instance (app_info);
+
+  if (instance == NULL)
+    return 0;
+
+  path = g_build_filename (g_get_user_runtime_dir (),
+                           ".flatpak",
+                           instance,
+                           "bwrapinfo.json",
+                           NULL);
+
+  if (!g_file_get_contents (path, &data, &len, error))
+    return 0;
+
+  parser = json_parser_new ();
+  if (!json_parser_load_from_data (parser, data, len, error))
+    {
+      g_prefix_error (error, "Could not parse '%s': ", path);
+      return 0;
+    }
+
+  root = json_parser_get_root (parser);
+  if (!root)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Could not parse '%s': empty file", path);
+      return 0;
+    }
+
+  if (!JSON_NODE_HOLDS_OBJECT (root))
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Could not parse '%s': invalid structure", path);
+      return 0;
+    }
+
+  cpo = json_node_get_object (root);
+
+  pid = json_object_get_int_member (cpo, "child-pid");
+  if (pid == 0)
+    g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                 "Could not parse '%s': child-pid missing", path);
+
+  return pid;
+}
+
+#define xdp_lockguard G_GNUC_UNUSED __attribute__((cleanup(xdp_auto_unlock_helper)))
+
+static gboolean
+xdg_app_info_ensure_pidns (XdpAppInfo  *app_info,
+                           DIR         *proc,
+                           GError     **error)
+{
+  xdp_lockguard GMutex *guard = NULL;
+  xdp_autofd int fd = -1;
+  pid_t pid;
+  ino_t ns;
+  int r;
+
+  guard = xdp_auto_lock_helper (app_info->u.flatpak.pidns_lock);
+
+  if (app_info->u.flatpak.pidns_id != 0)
+    return TRUE;
+
+  pid = xdp_app_info_get_child_pid (app_info, error);
+  if (pid == 0)
+    return FALSE;
+
+  fd = open_pid_fd (dirfd (proc), pid, error);
+  if (fd == -1)
+    return FALSE;
+
+  r = lookup_ns_from_pid_fd (fd, &ns);
+  if (r < 0)
+    {
+      int code = g_io_error_from_errno (-r);
+      g_set_error (error, G_IO_ERROR, code,
+                   "Could not query /proc/%u/ns/pid: %s",
+                   (guint) pid, g_strerror (-r));
+      return FALSE;
+    }
+
+  app_info->u.flatpak.pidns_id = ns;
+
+  return TRUE;
+}
+
+gboolean
+xdg_app_info_map_pids (XdpAppInfo  *app_info,
+                       pid_t       *pids,
+                       guint        n_pids,
+                       GError     **error)
+{
+  gboolean ok;
+  DIR *proc;
+  uid_t uid;
+  ino_t ns;
+
+  g_return_val_if_fail (app_info != NULL, FALSE);
+  g_return_val_if_fail (pids != NULL, FALSE);
+
+  if (app_info->kind != XDP_APP_INFO_KIND_FLATPAK)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                           "Mapping pids is not supported.");
+      return FALSE;
+    }
+
+  proc = opendir ("/proc");
+  if (proc == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Could not open '/proc: %s", g_strerror (errno));
+      return FALSE;
+    }
+
+  /* Make sure we know the pid namespace the app is running in */
+  ok = xdg_app_info_ensure_pidns (app_info, proc, error);
+  if (!ok)
+    {
+      g_prefix_error (error, "Could not determine pid namespace: ");
+      goto out;
+    }
+
+  /* we also make sure the real user id matches
+   * to the process owner we are trying to resolve
+   */
+  uid = getuid ();
+
+  ns = app_info->u.flatpak.pidns_id;
+  ok = map_pids (proc, ns, pids, n_pids, uid, error);
+
+ out:
+  closedir (proc);
+  return ok;
 }

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -247,6 +247,20 @@ xdp_app_info_rewrite_commandline (XdpAppInfo *app_info,
     return NULL;
 }
 
+char *
+xdp_app_info_get_instance (XdpAppInfo *app_info)
+{
+  g_return_val_if_fail (app_info != NULL, NULL);
+
+  if (app_info->kind != XDP_APP_INFO_KIND_FLATPAK)
+    return NULL;
+
+  return g_key_file_get_string (app_info->u.flatpak.keyfile,
+                                FLATPAK_METADATA_GROUP_INSTANCE,
+                                FLATPAK_METADATA_KEY_INSTANCE_ID,
+                                NULL);
+}
+
 gboolean
 xdp_app_info_is_host (XdpAppInfo *app_info)
 {

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -56,6 +56,10 @@ gboolean    xdp_app_info_is_host         (XdpAppInfo  *app_info);
 gboolean    xdp_app_info_supports_opath  (XdpAppInfo  *app_info);
 char *      xdp_app_info_remap_path      (XdpAppInfo  *app_info,
                                           const char  *path);
+gboolean    xdg_app_info_map_pids        (XdpAppInfo  *app_info,
+					  pid_t       *pids,
+					  guint        n_pids,
+					  GError     **error);
 char *      xdp_app_info_get_path_for_fd (XdpAppInfo  *app_info,
                                           int          fd,
                                           int          require_st_mode,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -35,6 +35,7 @@
 #define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
 #define FLATPAK_METADATA_KEY_APP_PATH "app-path"
 #define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
+#define FLATPAK_METADATA_KEY_INSTANCE_ID "instance-id"
 
 gint xdp_mkstempat (int    dir_fd,
                     gchar *tmpl,
@@ -50,6 +51,7 @@ typedef struct _XdpAppInfo XdpAppInfo;
 XdpAppInfo *xdp_app_info_ref             (XdpAppInfo  *app_info);
 void        xdp_app_info_unref           (XdpAppInfo  *app_info);
 const char *xdp_app_info_get_id          (XdpAppInfo  *app_info);
+char *      xdp_app_info_get_instance    (XdpAppInfo  *app_info);
 gboolean    xdp_app_info_is_host         (XdpAppInfo  *app_info);
 gboolean    xdp_app_info_supports_opath  (XdpAppInfo  *app_info);
 char *      xdp_app_info_remap_path      (XdpAppInfo  *app_info,


### PR DESCRIPTION
This is to resolve flathub/com.valvesoftware.Steam#77 where the main problem is that we need to resolve the process id from within the flatpak so that GameMode can work with the correct one: 

Add a new portal so that GameMode service can be accessed from within the sandbox. GameMode expects to get the process id (pid) of the game so it can:
  - track the lifetime of the game
  - modify process parameters (nice level, scheduler policy, ...)
  - resolve the executable name and trigger configured actions

Since processes inside the sandbox run in a separate pid namespace sending the client pid obtained via getpid(2) won't work. Getting the pid via the D-Bus connection will result in getting the pid of the dbus proxy. According to pid_namespaces(7) process ids will be translated by the kernel when they are passed over a unix domain socket. But passing a connected unix socket via dbus messages and then obtaining the credentials for that socket (pair) will also resolve the pid to the dbus proxy. Therefore we nest one level more and send a socket of a socket pair via a connected socket that was passed via dbus. This additional level of indirection then results in the correct credentials.

I wanted to get some feedback on the general approach, before I continue going down that road. I looked at different options to get the pid from within the sandbox but most obvious was the pass socket over socket approach. If someone has a better idea I am all ears. Also, currently I am using the data part of the message, where the nested socket gets passed, to send which gamemode action (Register, Unregister) to execute but that could be split up into individual message if that is deemed to be cleaner.

There is a simple tester app (gamemode-tester) that has the corresponding client code in the [`portal`](https://github.com/gicmo/gamemode-tester/tree/portal) branch (NB: the use native library option needs to be off). 

