### PR TITLE
Implement a background monitor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ AC_PATH_PROG([BWRAP], [bwrap])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 
-PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0 fontconfig])
+PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0 fontconfig json-glib-1.0])
 AC_SUBST(BASE_CFLAGS)
 AC_SUBST(BASE_LIBS)
 
@@ -136,7 +136,6 @@ fi
 GLIB_TESTS
 
 PKG_CHECK_MODULES(FUSE, [fuse])
-PKG_CHECK_MODULES(FLATPAK, [flatpak])
 
 AC_CONFIG_FILES([
 Makefile

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -36,4 +36,5 @@ dist_introspection_DATA = \
 	data/org.freedesktop.impl.portal.RemoteDesktop.xml \
 	data/org.freedesktop.impl.portal.Settings.xml \
 	data/org.freedesktop.impl.portal.Lockdown.xml \
+	data/org.freedesktop.impl.portal.Background.xml \
 	$(NULL)

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -19,6 +19,7 @@ dist_introspection_DATA = \
 	data/org.freedesktop.portal.RemoteDesktop.xml \
 	data/org.freedesktop.portal.Location.xml \
 	data/org.freedesktop.portal.Settings.xml \
+	data/org.freedesktop.portal.Background.xml \
 	data/org.freedesktop.impl.portal.PermissionStore.xml \
 	data/org.freedesktop.impl.portal.Request.xml \
 	data/org.freedesktop.impl.portal.Session.xml \

--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2019 Red Hat, Inc
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+    org.freedesktop.impl.portal.Background:
+    @short_description: Background portal backend interface
+
+    This interface provides APIs related to applications
+    that are running in the background.
+  -->
+  <interface name="org.freedesktop.impl.portal.Background">
+
+    <!--
+      EnableAutostart:
+      @app_id: App id of the application
+      @enable: TRUE to enable autostart, FALSE to disable it
+      @commandline: The commandline to use in the autostart file
+      @activatable: Whether to use D-Bus activation in the autostart file
+      @result: TRUE if autostart was enabled, FALSE otherwise
+
+      Enables or disables autostart for an application.
+    -->
+    <method name='EnableAutostart'>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="b" name="enable" direction="in"/>
+      <arg type="as" name="commandline" direction="in"/>
+      <arg type="b" name="activatable" direction="in"/>
+      <arg type="b" name="result" direction="out"/>
+    </method>
+  </interface>
+</node>

--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -65,6 +65,7 @@
             <simplelist>
               <member>0: Forbid background activity by this app</member>
               <member>1: Allow background activity by this app</member>
+              <member>2: Allow this instance of background activity</member>
             </simplelist>
           </para></listitem>
         </varlistentry>

--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -29,6 +29,51 @@
   <interface name="org.freedesktop.impl.portal.Background">
 
     <!--
+      GetAppState:
+      @apps: an array with information about running apps
+
+      Gets information about running apps. Each entry has
+      an application ID as key. The returned values are of
+      type u and have the following meaning:
+      <simplelist>
+        <member>0: Background (no open window)</member>
+        <member>1: Running (at least one open window)</member>
+        <member>2: Active (in the foreground)</member>
+      </simplelist>
+    -->
+    <method name='GetAppState'>
+      <arg type="a{sv}" name="apps" direction="out"/>
+    </method>
+
+    <!--
+      NotifyBackground:
+      @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+      @app_id: App id of the application
+      @name: A display name for the application
+      @response: Numeric response, not used
+      @results: Vardict with results of the call
+
+      Notifies the user that an application is running in the background.
+
+      The following results get returned via the @results vardict:
+      <variablelist>
+        <varlistentry>
+          <term>allow b</term>
+          <listitem><para>
+            TRUE to allow the app to run in the background, FALSE to stop it.
+          </para></listitem>
+        </varlistentry>
+      </variablelist>
+    -->
+    <method name='NotifyBackground'>
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="name" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+
+    <!--
       EnableAutostart:
       @app_id: App id of the application
       @enable: TRUE to enable autostart, FALSE to disable it

--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -58,9 +58,14 @@
       The following results get returned via the @results vardict:
       <variablelist>
         <varlistentry>
-          <term>allow b</term>
+          <term>result u</term>
           <listitem><para>
-            TRUE to allow the app to run in the background, FALSE to stop it.
+            The choice that the user made regarding the background
+            activity:
+            <simplelist>
+              <member>0: Forbid background activity by this app</member>
+              <member>1: Allow background activity by this app</member>
+            </simplelist>
           </para></listitem>
         </varlistentry>
       </variablelist>

--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -78,16 +78,21 @@
       @app_id: App id of the application
       @enable: TRUE to enable autostart, FALSE to disable it
       @commandline: The commandline to use in the autostart file
-      @activatable: Whether to use D-Bus activation in the autostart file
+      @flags: Flags influencing the details of the autostarting
       @result: TRUE if autostart was enabled, FALSE otherwise
 
       Enables or disables autostart for an application.
+
+      The following flags are understood:
+      <simplelist>
+        <member>1: Use D-Bus activation</member>
+      </simplelist>
     -->
     <method name='EnableAutostart'>
       <arg type="s" name="app_id" direction="in"/>
       <arg type="b" name="enable" direction="in"/>
       <arg type="as" name="commandline" direction="in"/>
-      <arg type="b" name="activatable" direction="in"/>
+      <arg type="u" name="flags" direction="in"/>
       <arg type="b" name="result" direction="out"/>
     </method>
   </interface>

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -23,10 +23,9 @@
       org.freedesktop.portal.Background:
       @short_description: Portal for requesting autostart and background activity
 
-      This simple interface lets sandboxed applications request that the
-      application is allowed to run in the background. If the application installs
-      an autostart file, it will be used to run the application when the user
-      logs in.
+      This simple interface lets sandboxed applications request that
+      the application is allowed to run in the background or started
+      automatically when the user logs in.
 
       This documentation describes version 1 of this interface.
   -->
@@ -76,7 +75,7 @@ k linkend="parent_window">Common Conventions</link>
           <varlistentry>
             <term>dbus-activatable b</term>
             <listitem><para>
-              If TRUE, add DBusActivatable=true to the autostart file.
+              If TRUE, use D-Bus activation for autostart.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2019 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Matthias Clasen <mclasen@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Background:
+      @short_description: Portal for requesting autostart and background activity
+
+      This simple interface lets sandboxed applications request that the
+      application is allowed to run in the background. If the application installs
+      an autostart file, it will be used to run the application when the user
+      logs in.
+
+      This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.Background">
+    <!--
+        RequestBackground:
+        @parent_window: Identifier for the application window, see <lin
+k linkend="parent_window">Common Conventions</link>
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Requests that the application is allowed to run in the
+        background.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the
+              @handle. Must be a valid object path element. See the
+              #org.freedesktop.portal.Request documentation for more
+              information about the @handle.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>reason s</term>
+            <listitem><para>
+              User-visible reason for the request.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+       The following results get returned via the
+       #org.freedesktop.portal.Request::Response signal:
+
+      <variablelist>
+        <varlistentry>
+          <term>background b</term>
+          <listitem><para>
+            TRUE if the application is allowed to run in the background.
+          </para></listitem>
+        </varlistentry>
+    -->
+    <method name="RequestBackground">
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -58,6 +58,27 @@ k linkend="parent_window">Common Conventions</link>
               User-visible reason for the request.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>autostart b</term>
+            <listitem><para>
+              TRUE if the app also wants to be started automatically
+              at login.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>commandline as</term>
+            <listitem><para>
+              Commandline to use add when autostarting at login.
+              If this is not specified, the Exec line from the
+              desktop file will be used.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>dbus-activatable b</term>
+            <listitem><para>
+              If TRUE, add DBusActivatable=true to the autostart file.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
        The following results get returned via the
@@ -70,6 +91,13 @@ k linkend="parent_window">Common Conventions</link>
             TRUE if the application is allowed to run in the background.
           </para></listitem>
         </varlistentry>
+        <varlistentry>
+          <term>autostart b</term>
+          <listitem><para>
+            TRUE if the application is will be autostarted.
+          </para></listitem>
+        </varlistentry>
+      </variablelist>
     -->
     <method name="RequestBackground">
       <arg type="s" name="parent_window" direction="in"/>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -39,6 +39,7 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Lockdown.xml	\
 	$(top_srcdir)/data/org.freedesktop.portal.Documents.xml		\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.PermissionStore.xml	\
+	$(top_srcdir)/data/org.freedesktop.impl.portal.Background.xml		\
 	$(NULL)
 
 xml_files = 								\

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -22,6 +22,7 @@ portal_files = 								\
 	$(top_srcdir)/data/org.freedesktop.portal.Device.xml	 	\
 	$(top_srcdir)/data/org.freedesktop.portal.Location.xml		\
 	$(top_srcdir)/data/org.freedesktop.portal.Settings.xml		\
+	$(top_srcdir)/data/org.freedesktop.portal.Background.xml		\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Request.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Session.xml 	\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.FileChooser.xml 	\
@@ -60,6 +61,7 @@ xml_files = 								\
 	portal-org.freedesktop.portal.Device.xml			\
 	portal-org.freedesktop.portal.Location.xml			\
 	portal-org.freedesktop.portal.Settings.xml			\
+	portal-org.freedesktop.portal.Background.xml			\
 	portal-org.freedesktop.impl.portal.Request.xml 			\
 	portal-org.freedesktop.impl.portal.Session.xml 			\
 	portal-org.freedesktop.impl.portal.FileChooser.xml		\

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -146,6 +146,7 @@
     <xi:include href="portal-org.freedesktop.impl.portal.Access.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Settings.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Lockdown.xml"/>
+    <xi:include href="portal-org.freedesktop.impl.portal.Background.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.PermissionStore.xml"/>
   </reference>
 </book>

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -107,6 +107,7 @@
     <xi:include href="portal-org.freedesktop.portal.NetworkMonitor.xml"/>
     <xi:include href="portal-org.freedesktop.portal.ProxyResolver.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Settings.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.Background.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Documents.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Flatpak.xml"/>
   </reference>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -55,6 +55,7 @@ PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.RemoteDesktop.xml \
 	data/org.freedesktop.impl.portal.Settings.xml \
 	data/org.freedesktop.impl.portal.Lockdown.xml \
+	data/org.freedesktop.impl.portal.Background.xml \
 	$(NULL)
 
 $(xdp_dbus_built_sources) : $(PORTAL_IFACE_FILES)
@@ -174,6 +175,7 @@ xdg_desktop_portal_LDADD = \
 	$(BASE_LIBS) \
 	$(PIPEWIRE_LIBS) \
 	$(GEOCLUE_LIBS) \
+        $(FLATPAK_LIBS) \
 	$(NULL)
 xdg_desktop_portal_CFLAGS = \
 	-DPKGDATADIR=\"$(pkgdatadir)\" \
@@ -182,6 +184,7 @@ xdg_desktop_portal_CFLAGS = \
 	$(BASE_CFLAGS) \
 	$(PIPEWIRE_CFLAGS) \
 	$(GEOCLUE_CFLAGS) \
+        $(FLATPAK_CFLAGS) \
 	-I$(srcdir)/src \
 	-I$(builddir)/src \
 	$(NULL)

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -151,6 +151,8 @@ xdg_desktop_portal_SOURCES = \
 	src/fc-monitor.h		\
 	src/background.c		\
 	src/background.h		\
+        src/flatpak-instance.c          \
+        src/flatpak-instance.h          \
 	$(NULL)
 
 if HAVE_PIPEWIRE
@@ -175,7 +177,6 @@ xdg_desktop_portal_LDADD = \
 	$(BASE_LIBS) \
 	$(PIPEWIRE_LIBS) \
 	$(GEOCLUE_LIBS) \
-        $(FLATPAK_LIBS) \
 	$(NULL)
 xdg_desktop_portal_CFLAGS = \
 	-DPKGDATADIR=\"$(pkgdatadir)\" \
@@ -184,7 +185,6 @@ xdg_desktop_portal_CFLAGS = \
 	$(BASE_CFLAGS) \
 	$(PIPEWIRE_CFLAGS) \
 	$(GEOCLUE_CFLAGS) \
-        $(FLATPAK_CFLAGS) \
 	-I$(srcdir)/src \
 	-I$(builddir)/src \
 	$(NULL)

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -35,6 +35,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.RemoteDesktop.xml \
 	data/org.freedesktop.portal.Location.xml \
 	data/org.freedesktop.portal.Settings.xml \
+	data/org.freedesktop.portal.Background.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -147,6 +148,8 @@ xdg_desktop_portal_SOURCES = \
 	src/xdp-utils.h			\
 	src/fc-monitor.c		\
 	src/fc-monitor.h		\
+	src/background.c		\
+	src/background.h		\
 	$(NULL)
 
 if HAVE_PIPEWIRE

--- a/src/background.c
+++ b/src/background.c
@@ -427,8 +427,30 @@ get_one_app_state (const char *app_id,
   return (AppState)GPOINTER_TO_INT (g_hash_table_lookup (app_states, app_id));
 }
 
+typedef struct {
+  FlatpakInstance *instance;
+  int stamp;
+  AppState state;
+  char *handle;
+  gboolean notified;
+  Permission permission;
+} InstanceData;
+
+static void
+instance_data_free (gpointer data)
+{
+  InstanceData *idata = data;
+
+  g_object_unref (idata->instance);
+  g_free (idata->handle);
+
+  g_free (idata);
+}
+
+/* Only used by the monitor thread, so no locking needed
+ * instance ID -> InstanceData
+ */
 static GHashTable *applications;
-G_LOCK_DEFINE_STATIC (applications);
 
 static void
 close_notification (const char *handle)
@@ -446,85 +468,22 @@ close_notification (const char *handle)
 }
 
 static void
-remove_outdated_applications (GPtrArray *apps)
+remove_outdated_instances (int stamp)
 {
-  int j;
   GHashTableIter iter;
-  char *app_id;
-  char *handle;
-  g_autoptr(GPtrArray) handles = NULL;
+  char *id;
+  InstanceData *data;
 
-  handles = g_ptr_array_new_with_free_func (g_free);
-
-  G_LOCK (applications);
   g_hash_table_iter_init (&iter, applications);
-  while (g_hash_table_iter_next (&iter, (gpointer *)&app_id, (gpointer *)&handle))
+  while (g_hash_table_iter_next (&iter, (gpointer *)&id, (gpointer *)&data))
     {
-      gboolean found = FALSE;
-      for (j = 0; j < apps->len && !found; j++)
+      if (data->stamp < stamp)
         {
-          FlatpakInstance *app = g_ptr_array_index (apps, j);
-          found = g_strcmp0 (app_id, flatpak_instance_get_app (app));
-        }
-      if (!found)
-        {
+          if (data->handle)
+            close_notification (data->handle);
           g_hash_table_iter_remove (&iter);
-          if (handle)
-            g_ptr_array_add (handles, g_strdup (handle));
         }
     }
-  G_UNLOCK (applications);
-
-  for (j = 0; j < handles->len; j++)
-    { 
-      const char *handle = g_ptr_array_index (handles, j);
-      close_notification (handle);
-    }
-}
-
-/*
- * Returns whether the @app_id was found in the
- * table of background apps, and if so, sets
- * @value to the value found for it.
- */
-static gboolean
-lookup_background_app (const char *app_id,
-                       char **value)
-{
-  gboolean res;
-  char *orig_key;
-  char *orig_val;
-
-  G_LOCK (applications);
-  res = g_hash_table_lookup_extended (applications, app_id, (gpointer *)&orig_key, (gpointer *)&orig_val);
-  if (res) 
-    *value = g_strdup (orig_val);
-  G_UNLOCK (applications);
-
-  return res;
-}
-
-static void
-add_background_app (const char *app_id,
-                    const char *handle)
-{
-  G_LOCK (applications);
-  g_hash_table_insert (applications, g_strdup (app_id), g_strdup (handle));
-  G_UNLOCK (applications);
-}
-
-static void
-remove_background_app (const char *app_id)
-{
-  g_autofree char *handle = NULL;
-
-  G_LOCK (applications);
-  handle = g_strdup (g_hash_table_lookup (applications, app_id));
-  g_hash_table_remove (applications, app_id);
-  G_UNLOCK (applications);
-
-  if (handle)
-    close_notification (handle);
 }
 
 static char *
@@ -546,39 +505,23 @@ flatpak_instance_get_display_name (FlatpakInstance *instance)
   return g_strdup (app_id);
 }
 
-static FlatpakInstance *
-find_instance (const char *app_id)
-{
-  g_autoptr(GPtrArray) instances = NULL;
-  int i;
-
-  instances = flatpak_instance_get_all ();
-  for (i = 0; i < instances->len; i++)
-    {
-      FlatpakInstance *inst = g_ptr_array_index (instances, i);
-
-      if (g_str_equal (flatpak_instance_get_app (inst), app_id))
-        return g_object_ref (inst);
-    }
-
-  return NULL;
-}
-
 static void
-kill_app (const char *app_id)
+kill_instance (const char *id)
 {
-  g_autoptr(FlatpakInstance) instance = NULL;
+  InstanceData *idata;
 
-  g_debug ("Killing app %s", app_id);
+  idata = g_hash_table_lookup (applications, id);
 
-  instance = find_instance (app_id);
-
-  if (instance)
-    kill (flatpak_instance_get_child_pid (instance), SIGKILL);
+  if (idata)
+    {
+      g_debug ("Killing app %s", flatpak_instance_get_app (idata->instance));
+      kill (flatpak_instance_get_child_pid (idata->instance), SIGKILL);
+    }
 }
 
 typedef struct {
   char *app_id;
+  char *id;
   Permission perm;
 } DoneData;
 
@@ -588,8 +531,14 @@ done_data_free (gpointer data)
   DoneData *ddata = data;
 
   g_free (ddata->app_id);
+  g_free (ddata->id);
   g_free (ddata);
 }
+
+typedef enum {
+  FORBID = 0,
+  ALLOW  = 1
+} NotifyResult;
 
 static void
 notify_background_done (GObject *source,
@@ -601,6 +550,7 @@ notify_background_done (GObject *source,
   g_autoptr(GVariant) results = NULL;
   guint response;
   guint result;
+  InstanceData *idata;
 
   if (!xdp_impl_background_call_notify_background_finish (background_impl,
                                                           &response,
@@ -615,45 +565,54 @@ notify_background_done (GObject *source,
 
   g_variant_lookup (results, "result", "u", &result);
 
-  if (result == 1)
+  if (result == ALLOW)
     {
       g_debug ("Allowing app %s to run in background", ddata->app_id);
+
       if (ddata->perm != ASK)
-        set_permission (ddata->app_id, YES);
+        ddata->perm = YES;
     }
-  else if (result == 0)
+  else if (result == FORBID)
     {
       g_debug ("Forbid app %s to run in background", ddata->app_id);
 
       if (ddata->perm != ASK)
-        set_permission (ddata->app_id, NO);
-      kill_app (ddata->app_id);
+        ddata->perm = NO;
+
+      kill_instance (ddata->id);
     }
   else
     g_debug ("Unexpected response from NotifyBackground: %u", result);
 
-  add_background_app (ddata->app_id, NULL);
+  set_permission (ddata->app_id, ddata->perm);
+
+  idata = g_hash_table_lookup (applications, ddata->id);
+  if (idata)
+    {
+      g_clear_pointer (&idata->handle, g_free);
+      idata->permission = ddata->perm;
+    }
+
   done_data_free (ddata);
 }
 
 static void
-send_notification (FlatpakInstance *instance,
-                   Permission       permission)
+send_notification (InstanceData *idata)
 {
+  FlatpakInstance *instance = idata->instance;
   DoneData *ddata;
   g_autofree char *name = flatpak_instance_get_display_name (instance);
-  g_autofree char *handle = NULL;
   static int count;
+  char *handle;
 
   ddata = g_new (DoneData, 1);
   ddata->app_id = g_strdup (flatpak_instance_get_app (instance));
-  ddata->perm = permission;
+  ddata->id = g_strdup (flatpak_instance_get_id (instance));
+  ddata->perm = idata->permission;
 
   g_debug ("Notify background for %s", ddata->app_id);
 
   handle = g_strdup_printf ("/org/freedesktop/portal/desktop/notify/background%d", count++);
-
-  add_background_app (ddata->app_id, handle);
 
   xdp_impl_background_call_notify_background (background_impl,
                                               handle,
@@ -662,6 +621,10 @@ send_notification (FlatpakInstance *instance,
                                               NULL,
                                               notify_background_done,
                                               ddata);
+
+  g_assert (idata->handle == NULL);
+  idata->handle = handle;
+  idata->notified = TRUE;
 }
 
 static void
@@ -669,8 +632,9 @@ check_background_apps (void)
 {
   g_autoptr(GVariant) perms = NULL;
   g_autoptr(GHashTable) app_states = NULL;
-  g_autoptr(GPtrArray) apps = NULL;
+  g_autoptr(GPtrArray) instances = NULL;
   int i;
+  static int stamp;
 
   app_states = get_app_states ();
   if (app_states == NULL)
@@ -679,68 +643,91 @@ check_background_apps (void)
   g_debug ("Checking background permissions");
 
   perms = get_all_permissions ();
-  apps = flatpak_instance_get_all ();
+  instances = flatpak_instance_get_all ();
 
-  remove_outdated_applications (apps);
+  stamp++;
 
-  for (i = 0; i < apps->len; i++)
+  for (i = 0; i < instances->len; i++)
     {
-      FlatpakInstance *instance = g_ptr_array_index (apps, i);
-      const char *app_id = flatpak_instance_get_app (instance);
+      FlatpakInstance *instance = g_ptr_array_index (instances, i);
+      const char *id;
+      const char *app_id;
+      InstanceData *idata;
       Permission permission;
-      AppState state;
       const char *state_names[] = { "background", "running", "active" };
-      g_autofree char *handle = NULL;
+      gboolean is_new = FALSE;
 
       if (!flatpak_instance_is_running (instance))
         continue;
 
-      state = get_one_app_state (app_id, app_states);
-      g_debug ("App %s is %s", app_id, state_names[state]);
+      id = flatpak_instance_get_id (instance);
+      app_id = flatpak_instance_get_app (instance);
+      idata = g_hash_table_lookup (applications, id);
 
-      if (state != BACKGROUND)
+      if (!idata)
         {
-          remove_background_app (app_id);
-          continue;
+          is_new = TRUE;
+          idata = g_new0 (InstanceData, 1);
+          idata->instance = g_object_ref (instance);
+          g_hash_table_insert (applications, g_strdup (id), idata);
         }
 
-      /* If the app is not in the list of background apps
-       * yet, add it, but don't notify yet - this gives
-       * apps some leeway to get their window app. If it
-       * is still in the background next time around,
-       * we'll proceed to the next step.
-       */
-      if (!lookup_background_app (app_id, &handle))
-        {
-          add_background_app (app_id, NULL);
-          continue;
-        }
+      idata->stamp = stamp;
+      idata->state = get_one_app_state (app_id, app_states);
 
-      if (handle)
-        continue; /* already notified */
+      g_debug ("App %s is %s", app_id, state_names[idata->state]);
 
       permission = get_one_permission (app_id, perms);
-      if (permission == NO)
+
+      if (idata->permission != permission)
         {
-          pid_t pid = flatpak_instance_get_child_pid (instance);
-          g_debug ("Killing app %s (child pid %u)", app_id, pid);
-          kill (pid, SIGKILL);
+          /* Notify again if permissions change */
+          idata->permission = permission;
+          idata->notified = FALSE;
         }
-      else if (permission == ASK || permission == UNSET)
+
+      /* If the app is not in the list yet, add it,
+       * but don't notify yet - this gives apps some
+       * leeway to get their window app. If it is still
+       * in the background next time around, we'll proceed
+       * to the next step.
+       */
+      if (idata->state != BACKGROUND || idata->notified || is_new)
+        continue;
+
+      switch (idata->permission)
         {
-          send_notification (instance, permission);
+        case NO:
+          kill_instance (id);
+          idata->stamp = 0;
+          break;
+
+        case ASK:
+        case UNSET:
+          send_notification (idata);
+          break;
+
+        case YES:
+        default:
+          break;
         }
     }
+
+  remove_outdated_instances (stamp);
 }
 
 static gpointer
 background_monitor (gpointer data)
 {
+  applications = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                        g_free, instance_data_free);
   while (1)
     {
       check_background_apps ();
-      sleep (60);
+      sleep (20);
     }
+
+  g_clear_pointer (&applications, g_hash_table_unref);
 
   return NULL;
 }
@@ -749,8 +736,6 @@ static void
 start_background_monitor (void)
 {
   g_autoptr(GThread) thread = NULL;
-
-  applications = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
   g_debug ("Starting background app monitor");
 

--- a/src/background.c
+++ b/src/background.c
@@ -757,7 +757,7 @@ background_monitor (gpointer data)
   while (1)
     {
       check_background_apps ();
-      sleep (20);
+      sleep (60);
     }
 
   g_clear_pointer (&applications, g_hash_table_unref);

--- a/src/background.c
+++ b/src/background.c
@@ -346,10 +346,35 @@ validate_reason (const char *key,
   return TRUE;
 }
 
+static gboolean
+validate_commandline (const char *key,
+                      GVariant *value,
+                      GVariant *options,
+                      GError **error)
+{
+  gsize length;
+  const char **strv = g_variant_get_strv (value, &length);
+
+  if (g_utf8_strlen (strv[0], -1) > 256)
+    {
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "Not accepting overly long commandlines");
+      return FALSE;
+    }
+
+  if (length > 100)
+    {
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "Not accepting overly long commandlines");
+      return FALSE;
+    }
+
+  return TRUE;
+}
 static XdpOptionKey background_options[] = {
   { "reason", G_VARIANT_TYPE_STRING, validate_reason },
   { "autostart", G_VARIANT_TYPE_BOOLEAN, NULL },
-  { "commandline", G_VARIANT_TYPE_STRING_ARRAY, NULL },
+  { "commandline", G_VARIANT_TYPE_STRING_ARRAY, validate_commandline },
   { "dbus-activatable", G_VARIANT_TYPE_BOOLEAN, NULL },
 };
 

--- a/src/background.c
+++ b/src/background.c
@@ -173,33 +173,6 @@ set_permission (const char *app_id,
     }
 }
 
-static char **
-rewrite_commandline (const char *app_id,
-                     const char * const *commandline)
-{
-  g_autoptr(GPtrArray) args = NULL;
-
-  args = g_ptr_array_new_with_free_func (g_free);
-
-  g_ptr_array_add (args, g_strdup ("flatpak"));
-  g_ptr_array_add (args, g_strdup ("run"));
-  if (commandline && commandline[0])
-    {
-      int i;
-      g_autofree char *cmd = NULL;
-
-      g_ptr_array_add (args, g_strdup_printf ("--command=%s", commandline[0]));
-      g_ptr_array_add (args, g_strdup (app_id));
-      for (i = 1; commandline[i]; i++)
-        g_ptr_array_add (args, g_strdup (commandline[i]));
-    }
-  else
-    g_ptr_array_add (args, g_strdup (app_id));
-  g_ptr_array_add (args, NULL);
-
-  return (char **)g_ptr_array_free (g_steal_pointer (&args), FALSE);
-}
-
 typedef enum {
   AUTOSTART_FLAGS_NONE        = 0,
   AUTOSTART_FLAGS_ACTIVATABLE = 1 << 0,
@@ -300,7 +273,7 @@ handle_request_background_in_thread_func (GTask *task,
   g_debug ("Setting autostart for %s to %s", app_id,
            allowed && autostart_requested ? "enabled" : "disabled");
 
-  commandline = rewrite_commandline (app_id, autostart_exec);
+  commandline = xdp_app_info_rewrite_commandline (request->app_info, autostart_exec);
   if (!xdp_impl_background_call_enable_autostart_sync (background_impl,
                                                        app_id,
                                                        allowed && autostart_requested,

--- a/src/background.c
+++ b/src/background.c
@@ -33,6 +33,33 @@
 #include "xdp-utils.h"
 #include "flatpak-instance.h"
 
+/* Implementation notes:
+ *
+ * We store a YES/NO/ASK permission for "run in background".
+ *
+ * There is a portal api for apps to request this permission
+ * ahead of time. The portal also lets apps ask for being
+ * autostarted.
+ *
+ * We determine this condition by getting per-application
+ * state from the compositor, and comparing that list to
+ * the list of running flatpak instances obtained from
+ * $XDG_RUNTIME_DIR/.flatpak/. A thread is comparing
+ * this list every minute, and if it finds an app that
+ * is in the background twice, we take actions:
+ * - if the permission is NO, we kill it
+ * - if the permission is YES or ASK, we notify the user
+ *
+ * We only notify once per running instance to not be
+ * annoying.
+ *
+ * Platform-dependent parts are in the background portal
+ * backend:
+ * - Notifying the user
+ * - Getting compositor state
+ * - Enable or disable autostart
+ */
+
 #define PERMISSION_TABLE "background"
 #define PERMISSION_ID "background"
 

--- a/src/background.c
+++ b/src/background.c
@@ -654,7 +654,7 @@ notify_background_done (GObject *source,
   g_autoptr(GError) error = NULL;
   g_autoptr(GVariant) results = NULL;
   guint response;
-  gboolean allow;
+  guint result;
 
   if (!xdp_impl_background_call_notify_background_finish (background_impl,
                                                           &response,
@@ -667,15 +667,15 @@ notify_background_done (GObject *source,
       return;
     }
 
-  g_variant_lookup (results, "allow", "b", &allow);
+  g_variant_lookup (results, "result", "u", &result);
 
-  if (allow)
+  if (result == 1)
     {
       g_debug ("Allowing app %s to run in background", ddata->app_id);
       if (ddata->perm != ASK)
         set_permission (ddata->app_id, YES);
     }
-  else
+  else if (result == 0)
     {
       g_debug ("Forbid app %s to run in background", ddata->app_id);
 
@@ -683,6 +683,8 @@ notify_background_done (GObject *source,
         set_permission (ddata->app_id, NO);
       kill_app (ddata->app_id);
     }
+  else
+    g_debug ("Unexpected response from NotifyBackground: %u", result);
 
   add_background_app (ddata->app_id, NULL);
   done_data_free (ddata);

--- a/src/background.c
+++ b/src/background.c
@@ -787,30 +787,28 @@ check_background_apps (void)
     }
 }
 
-static void
-background_monitor (GTask *task,
-                    gpointer source_object,
-                    gpointer task_data,
-                    GCancellable *cancellable)
+static gpointer
+background_monitor (gpointer data)
 {
   while (1)
     {
       check_background_apps ();
       sleep (60);
     }
+
+  return NULL;
 }
 
 static void
 start_background_monitor (void)
 {
-  g_autoptr(GTask) task = NULL;
+  g_autoptr(GThread) thread = NULL;
 
   applications = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
   g_debug ("Starting background app monitor");
 
-  task = g_task_new (NULL, NULL, NULL, NULL);
-  g_task_run_in_thread (task, background_monitor);
+  thread = g_thread_new ("background monitor", background_monitor, NULL);
 }
 
 GDBusInterfaceSkeleton *

--- a/src/background.c
+++ b/src/background.c
@@ -173,32 +173,6 @@ set_permission (const char *app_id,
     }
 }
 
-/* This is conservative, but lets us avoid escaping most
-   regular Exec= lines, which is nice as that can sometimes
-   cause problems for apps launching desktop files. */
-static gboolean
-need_quotes (const char *str)
-{
-  const char *p;
-
-  for (p = str; *p; p++)
-    {
-      if (!g_ascii_isalnum (*p) &&
-          strchr ("-_%.=:/@", *p) == NULL)
-        return TRUE;
-    }
-
-  return FALSE;
-}
-
-static char *
-maybe_quote (const char *str)
-{
-  if (need_quotes (str))
-    return g_shell_quote (str);
-  return g_strdup (str);
-}
-
 static char **
 rewrite_commandline (const char *app_id,
                      const char * const *commandline)
@@ -214,8 +188,7 @@ rewrite_commandline (const char *app_id,
       int i;
       g_autofree char *cmd = NULL;
 
-      cmd = maybe_quote (commandline[0]);
-      g_ptr_array_add (args, g_strdup_printf ("--command=%s", cmd));
+      g_ptr_array_add (args, g_strdup_printf ("--command=%s", commandline[0]));
       g_ptr_array_add (args, g_strdup (app_id));
       for (i = 1; commandline[i]; i++)
         g_ptr_array_add (args, g_strdup (commandline[i]));

--- a/src/background.c
+++ b/src/background.c
@@ -537,7 +537,8 @@ done_data_free (gpointer data)
 
 typedef enum {
   FORBID = 0,
-  ALLOW  = 1
+  ALLOW  = 1,
+  IGNORE = 2
 } NotifyResult;
 
 static void
@@ -581,10 +582,15 @@ notify_background_done (GObject *source,
 
       kill_instance (ddata->id);
     }
+  else if (result == IGNORE)
+    {
+      g_debug ("Allow this instance of %s to run in background without permission changes", ddata->app_id);
+    }
   else
     g_debug ("Unexpected response from NotifyBackground: %u", result);
 
-  set_permission (ddata->app_id, ddata->perm);
+  if (ddata->perm != UNSET)
+    set_permission (ddata->app_id, ddata->perm);
 
   idata = g_hash_table_lookup (applications, ddata->id);
   if (idata)

--- a/src/background.c
+++ b/src/background.c
@@ -300,15 +300,21 @@ handle_request_background_in_thread_func (GTask *task,
   g_debug ("Setting autostart for %s to %s", app_id,
            allowed && autostart_requested ? "enabled" : "disabled");
 
+  autostart_enabled = FALSE;
+
   commandline = xdp_app_info_rewrite_commandline (request->app_info, autostart_exec);
-  if (!xdp_impl_background_call_enable_autostart_sync (background_impl,
-                                                       app_id,
-                                                       allowed && autostart_requested,
-                                                       (const char * const *)commandline,
-                                                       autostart_flags,
-                                                       &autostart_enabled,
-                                                       NULL,
-                                                       &error))
+  if (commandline == NULL)
+    {
+      g_debug ("Autostart not supported for: %s", app_id);
+    }
+  else if (!xdp_impl_background_call_enable_autostart_sync (background_impl,
+                                                            app_id,
+                                                            allowed && autostart_requested,
+                                                            (const char * const *)commandline,
+                                                            autostart_flags,
+                                                            &autostart_enabled,
+                                                            NULL,
+                                                            &error))
     {
       g_warning ("EnableAutostart call failed: %s", error->message);
       g_clear_error (&error);

--- a/src/background.c
+++ b/src/background.c
@@ -25,13 +25,13 @@
 #include <gio/gio.h>
 #include <gio/gdesktopappinfo.h>
 
-#include <flatpak.h>
 #include "background.h"
 #include "request.h"
 #include "permissions.h"
 #include "xdp-dbus.h"
 #include "xdp-impl-dbus.h"
 #include "xdp-utils.h"
+#include "flatpak-instance.h"
 
 #define PERMISSION_TABLE "background"
 #define PERMISSION_ID "background"

--- a/src/background.c
+++ b/src/background.c
@@ -159,6 +159,7 @@ get_one_permission (const char *app_id,
       g_warning ("Wrong background permission format, ignoring (%s)", a);
       return UNSET;
     }
+
   g_debug ("permission store: background, app %s -> %s", app_id, permissions[0]);
 
   if (strcmp (permissions[0], "yes") == 0)
@@ -301,7 +302,11 @@ handle_request_background_in_thread_func (GTask *task,
     autostart_flags |= AUTOSTART_FLAGS_ACTIVATABLE;
 
   app_id = xdp_app_info_get_id (request->app_info);
-  permission = get_permission (app_id);
+
+  if (xdp_app_info_is_host (request->app_info))
+    permission = YES;
+  else
+    permission = get_permission (app_id);
 
   g_debug ("Handle RequestBackground for %s\n", app_id);
 

--- a/src/background.c
+++ b/src/background.c
@@ -1,0 +1,348 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
+
+#include "background.h"
+#include "request.h"
+#include "permissions.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+#include "xdp-utils.h"
+
+#define PERMISSION_TABLE "background"
+#define PERMISSION_ID "background"
+
+typedef struct _Background Background;
+typedef struct _BackgroundClass BackgroundClass;
+
+struct _Background
+{
+  XdpBackgroundSkeleton parent_instance;
+};
+
+struct _BackgroundClass
+{
+  XdpBackgroundSkeletonClass parent_class;
+};
+
+static XdpImplAccess *access_impl;
+static Background *background;
+
+GType background_get_type (void) G_GNUC_CONST;
+static void background_iface_init (XdpBackgroundIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Background, background, XDP_TYPE_BACKGROUND_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_BACKGROUND, background_iface_init));
+
+
+typedef enum { UNSET, NO, YES, ASK } Permission;
+
+static Permission
+get_permission (const char *app_id)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GVariant) out_perms = NULL;
+  g_autoptr(GVariant) out_data = NULL;
+  const char **permissions;
+
+  if (!xdp_impl_permission_store_call_lookup_sync (get_permission_store (),
+                                                   PERMISSION_TABLE,
+                                                   PERMISSION_ID,
+                                                   &out_perms,
+                                                   &out_data,
+                                                   NULL,
+                                                   &error))
+    {
+      g_dbus_error_strip_remote_error (error);
+      g_debug ("No background permissions found: %s", error->message);
+      return UNSET;
+    }
+
+  if (!g_variant_lookup (out_perms, app_id, "^a&s", &permissions))
+    {
+      g_debug ("No permissions stored for: app %s", app_id);
+
+      return UNSET;
+    }
+  else if (g_strv_length ((char **)permissions) != 1)
+    {
+      g_autofree char *a = g_strjoinv (" ", (char **)permissions);
+      g_warning ("Wrong permission format, ignoring (%s)", a);
+      return UNSET;
+    }
+  g_debug ("permission store: app %s -> %s", app_id, permissions[0]);
+
+  if (strcmp (permissions[0], "yes") == 0)
+    return YES;
+  else if (strcmp (permissions[0], "no") == 0)
+    return NO;
+  else if (strcmp (permissions[0], "ask") == 0)
+    return ASK;
+  else
+    {
+      g_autofree char *a = g_strjoinv (" ", (char **)permissions);
+      g_warning ("Wrong permission format, ignoring (%s)", a);
+    }
+
+  return UNSET;
+}
+
+static void
+set_permission (const char *app_id,
+                Permission permission)
+{
+  g_autoptr(GError) error = NULL;
+  const char *permissions[2];
+
+  if (permission == ASK)
+    permissions[0] = "ask";
+  else if (permission == YES)
+    permissions[0] = "yes";
+  else if (permission == NO)
+    permissions[0] = "no";
+  else
+    {
+      g_warning ("Wrong permission format, ignoring");
+      return;
+    }
+  permissions[1] = NULL;
+
+  if (!xdp_impl_permission_store_call_set_permission_sync (get_permission_store (),
+                                                           PERMISSION_TABLE,
+                                                           TRUE,
+                                                           PERMISSION_ID,
+                                                           app_id,
+                                                           (const char * const*)permissions,
+                                                           NULL,
+                                                           &error))
+    {
+      g_dbus_error_strip_remote_error (error);
+      g_warning ("Error updating permission store: %s", error->message);
+    }
+}
+
+static void
+handle_request_background_in_thread_func (GTask *task,
+                                          gpointer source_object,
+                                          gpointer task_data,
+                                          GCancellable *cancellable)
+{
+  Request *request = (Request *)task_data;
+  GVariant *options;
+  const char *app_id;
+  Permission permission;
+  gboolean allowed;
+  const char *reason = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  options = (GVariant *)g_object_get_data (G_OBJECT (request), "options");
+  g_variant_lookup (options, "reason", "s", &reason);
+
+  app_id = xdp_app_info_get_id (request->app_info);
+  permission = get_permission (app_id);
+
+  g_debug ("Handle RequestBackground for %s\n", app_id);
+
+  if (permission == ASK || permission == UNSET)
+    {
+      GVariantBuilder opt_builder;
+      g_autofree char *title = NULL;
+      g_autofree char *subtitle = NULL;
+      g_autofree char *body = NULL;
+      guint32 response = 2;
+      g_autoptr(GVariant) results = NULL;
+      g_autoptr(GError) error = NULL;
+      g_autoptr(GAppInfo) info = NULL;
+
+      if (app_id[0] != 0)
+        {
+          g_autofree char *desktop_id;
+          desktop_id = g_strconcat (app_id, ".desktop", NULL);
+          info = (GAppInfo*)g_desktop_app_info_new (desktop_id);
+        }
+
+      title = g_strdup_printf (_("Allow %s to run in the background?"), info ? g_app_info_get_display_name (info) : app_id);
+      if (reason)
+        subtitle = g_strdup (reason);
+      else
+        subtitle = g_strdup_printf (_("%s requests to run in the background."), info ? g_app_info_get_display_name (info) : app_id);
+      body = g_strdup (_("The ‘run in background’ permission can be changed at any time from the application settings."));
+
+      g_debug ("Calling backend for background access for: %s", app_id);
+
+      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+      g_variant_builder_add (&opt_builder, "{sv}", "deny_label", g_variant_new_string (_("Don't allow")));
+      g_variant_builder_add (&opt_builder, "{sv}", "grant_label", g_variant_new_string (_("Allow")));
+      if (!xdp_impl_access_call_access_dialog_sync (access_impl,
+                                                    request->id,
+                                                    app_id,
+                                                    "",
+                                                    title,
+                                                    subtitle,
+                                                    body,
+                                                    g_variant_builder_end (&opt_builder),
+                                                    &response,
+                                                    &results,
+                                                    NULL,
+                                                    &error))
+        {
+          g_warning ("AccessDialog call failed: %s", error->message);
+          g_clear_error (&error);
+        }
+
+      allowed = response == 0;
+
+      if (permission == UNSET)
+        set_permission (app_id, allowed ? YES : NO);
+    }
+  else
+    allowed = permission == YES ? TRUE : FALSE;
+
+  if (request->exported)
+    {
+      GVariantBuilder results;
+
+      g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
+      g_variant_builder_add (&results, "{sv}", "background", g_variant_new_boolean (allowed));
+      xdp_request_emit_response (XDP_REQUEST (request),
+                                 allowed ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED,
+                                 g_variant_builder_end (&results));
+      request_unexport (request);
+    }
+}
+
+static gboolean
+validate_reason (const char *key,
+                 GVariant *value,
+                 GVariant *options,
+                 GError **error)
+{
+  const char *string = g_variant_get_string (value, NULL);
+
+  if (g_utf8_strlen (string, -1) > 256)
+    {
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "Not accepting overly long reasons");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static XdpOptionKey background_options[] = {
+  { "reason", G_VARIANT_TYPE_STRING, validate_reason }
+};
+
+static gboolean
+handle_request_background (XdpBackground *object,
+                           GDBusMethodInvocation *invocation,
+                           const char *arg_window,
+                           GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpImplRequest) impl_request = NULL;
+  g_autoptr(GTask) task = NULL;
+  GVariantBuilder opt_builder;
+  g_autoptr(GVariant) options = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_filter_options (arg_options, &opt_builder,
+                      background_options, G_N_ELEMENTS (background_options),
+                      NULL);
+
+  options = g_variant_ref_sink (g_variant_builder_end (&opt_builder));
+
+  g_object_set_data_full (G_OBJECT (request), "window", g_strdup (arg_window), g_free);
+  g_object_set_data_full (G_OBJECT (request), "options", g_variant_ref (options), (GDestroyNotify)g_variant_unref);
+
+  impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (access_impl)),
+                                                  G_DBUS_PROXY_FLAGS_NONE,
+                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (access_impl)),
+                                                  request->id,
+                                                  NULL, &error);
+  if (!impl_request)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  request_set_impl_request (request, impl_request);
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  xdp_background_complete_request_background (object, invocation, request->id);
+
+  task = g_task_new (object, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
+  g_task_run_in_thread (task, handle_request_background_in_thread_func);
+
+  return TRUE;
+}
+
+static void
+background_iface_init (XdpBackgroundIface *iface)
+{
+  iface->handle_request_background = handle_request_background;
+}
+
+static void
+background_init (Background *background)
+{
+  xdp_background_set_version (XDP_BACKGROUND (background), 1);
+}
+
+static void
+background_class_init (BackgroundClass *klass)
+{
+}
+
+GDBusInterfaceSkeleton *
+background_create (GDBusConnection *connection,
+                   const char *dbus_name)
+{
+  g_autoptr(GError) error = NULL;
+
+  access_impl = xdp_impl_access_proxy_new_sync (connection,
+                                                G_DBUS_PROXY_FLAGS_NONE,
+                                                dbus_name,
+                                                DESKTOP_PORTAL_OBJECT_PATH,
+                                                NULL,
+                                                &error);
+  if (access_impl == NULL)
+    {
+      g_warning ("Failed to create access proxy: %s", error->message);
+      return NULL;
+    }
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (access_impl), G_MAXINT);
+
+  background = g_object_new (background_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (background);
+}

--- a/src/background.c
+++ b/src/background.c
@@ -321,12 +321,7 @@ handle_request_background_in_thread_func (GTask *task,
       g_autoptr(GError) error = NULL;
       g_autoptr(GAppInfo) info = NULL;
 
-      if (app_id[0] != 0)
-        {
-          g_autofree char *desktop_id;
-          desktop_id = g_strconcat (app_id, ".desktop", NULL);
-          info = (GAppInfo*)g_desktop_app_info_new (desktop_id);
-        }
+      info = xdp_app_info_load_app_info (request->app_info);
 
       title = g_strdup_printf (_("Allow %s to run in the background?"), info ? g_app_info_get_display_name (info) : app_id);
       if (reason)

--- a/src/background.c
+++ b/src/background.c
@@ -680,7 +680,7 @@ notify_background_done (GObject *source,
       g_debug ("Forbid app %s to run in background", ddata->app_id);
 
       if (ddata->perm != ASK)
-        set_permission (ddata->app_id, ASK);
+        set_permission (ddata->app_id, NO);
       kill_app (ddata->app_id);
     }
 

--- a/src/background.h
+++ b/src/background.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * background_create (GDBusConnection *connection,
+                                            const char *dbus_name);

--- a/src/background.h
+++ b/src/background.h
@@ -24,4 +24,5 @@
 #include <gio/gio.h>
 
 GDBusInterfaceSkeleton * background_create (GDBusConnection *connection,
-                                            const char *dbus_name);
+                                            const char *dbus_name_access,
+                                            const char *dbus_name_background);

--- a/src/flatpak-instance.c
+++ b/src/flatpak-instance.c
@@ -1,0 +1,523 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <json-glib/json-glib.h>
+
+#include "flatpak-instance.h"
+
+/**
+ * SECTION:flatpak-instance
+ * @Title: FlatpakInstance
+ * @Short_description: Information about a running sandbox
+ *
+ * A FlatpakInstance refers to a running sandbox, and contains
+ * some basic information about the sandbox setup, such as the
+ * application and runtime used inside the sandbox.
+ *
+ * Importantly, it also gives access to the PID of the main
+ * processes in the sandbox.
+ *
+ * One way to obtain FlatpakInstances is to use flatpak_instance_get_all().
+ * Another way is to use flatpak_installation_launch_full().
+ *
+ * Note that process lifecycle tracking is fundamentally racy.
+ * You have to be prepared for the sandbox and the processes
+ * represented by a FlatpakInstance to not be around anymore.
+ *
+ * The FlatpakInstance api was added in Flatpak 1.1.
+ */
+
+
+#define FLATPAK_METADATA_GROUP_APPLICATION "Application"
+#define FLATPAK_METADATA_GROUP_RUNTIME "Runtime"
+#define FLATPAK_METADATA_KEY_COMMAND "command"
+#define FLATPAK_METADATA_KEY_NAME "name"
+#define FLATPAK_METADATA_KEY_REQUIRED_FLATPAK "required-flatpak"
+#define FLATPAK_METADATA_KEY_RUNTIME "runtime"
+#define FLATPAK_METADATA_KEY_SDK "sdk"
+#define FLATPAK_METADATA_KEY_TAGS "tags"
+
+#define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
+#define FLATPAK_METADATA_KEY_INSTANCE_PATH "instance-path"
+#define FLATPAK_METADATA_KEY_INSTANCE_ID "instance-id"
+#define FLATPAK_METADATA_KEY_APP_PATH "app-path"
+#define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
+#define FLATPAK_METADATA_KEY_APP_EXTENSIONS "app-extensions"
+#define FLATPAK_METADATA_KEY_ARCH "arch"
+#define FLATPAK_METADATA_KEY_BRANCH "branch"
+#define FLATPAK_METADATA_KEY_FLATPAK_VERSION "flatpak-version"
+#define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
+#define FLATPAK_METADATA_KEY_RUNTIME_COMMIT "runtime-commit"
+#define FLATPAK_METADATA_KEY_RUNTIME_EXTENSIONS "runtime-extensions"
+#define FLATPAK_METADATA_KEY_SESSION_BUS_PROXY "session-bus-proxy"
+#define FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY "system-bus-proxy"
+#define FLATPAK_METADATA_KEY_EXTRA_ARGS "extra-args"
+#define FLATPAK_METADATA_KEY_SANDBOX "sandbox"
+#define FLATPAK_METADATA_KEY_BUILD "build"
+
+typedef struct _FlatpakInstancePrivate FlatpakInstancePrivate;
+
+struct _FlatpakInstancePrivate
+{
+  char     *id;
+  char     *dir;
+
+  GKeyFile *info;
+  char     *app;
+  char     *arch;
+  char     *branch;
+  char     *commit;
+  char     *runtime;
+  char     *runtime_commit;
+
+  int       pid;
+  int       child_pid;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (FlatpakInstance, flatpak_instance, G_TYPE_OBJECT)
+
+static void
+flatpak_instance_finalize (GObject *object)
+{
+  FlatpakInstance *self = FLATPAK_INSTANCE (object);
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  g_free (priv->id);
+  g_free (priv->dir);
+  g_free (priv->app);
+  g_free (priv->arch);
+  g_free (priv->branch);
+  g_free (priv->commit);
+  g_free (priv->runtime);
+  g_free (priv->runtime_commit);
+
+  if (priv->info)
+    g_key_file_unref (priv->info);
+
+  G_OBJECT_CLASS (flatpak_instance_parent_class)->finalize (object);
+}
+
+static void
+flatpak_instance_class_init (FlatpakInstanceClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = flatpak_instance_finalize;
+}
+
+static void
+flatpak_instance_init (FlatpakInstance *self)
+{
+}
+
+/**
+ * flatpak_instance_get_id:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the instance ID. The ID is used by Flatpak for bookkeeping
+ * purposes and has no further relevance.
+ *
+ * Returns: the instance ID
+ *
+ * Since: 1.1
+ */
+const char *
+flatpak_instance_get_id (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->id;
+}
+
+/**
+ * flatpak_instance_get_app:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the application ID of the application running in the instance.
+ *
+ * Note that this may return %NULL for sandboxes that don't have an application.
+ *
+ * Returns: the application ID
+ *
+ * Since: 1.1
+ */
+const char *
+flatpak_instance_get_app (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->app;
+}
+
+/**
+ * flatpak_instance_get_arch:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the architecture of the application running in the instance.
+ *
+ * Returns: the architecture
+ *
+ * Since: 1.1
+ */
+const char *
+flatpak_instance_get_arch (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->arch;
+}
+
+/**
+ * flatpak_instance_get_branch:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the branch of the application running in the instance.
+ *
+ * Returns: the architecture
+ *
+ * Since: 1.1
+ */
+const char *
+flatpak_instance_get_branch (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->branch;
+}
+
+/**
+ * flatpak_instance_get_commit:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the commit of the application running in the instance.
+ *
+ * Returns: the commit
+ *
+ * Since: 1.1
+ */
+const char *
+flatpak_instance_get_commit (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->commit;
+}
+
+/**
+ * flatpak_instance_get_runtime:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the ref of the runtime used in the instance.
+ *
+ * Returns: the runtime ref
+ *
+ * Since: 1.1
+ */
+const char *
+flatpak_instance_get_runtime (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->runtime;
+}
+
+/**
+ * flatpak_instance_get_runtime_commit:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the commit of the runtime used in the instance.
+ *
+ * Returns: the runtime commit
+ *
+ * Since: 1.1
+ */
+const char *
+flatpak_instance_get_runtime_commit (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->runtime_commit;
+}
+
+/**
+ * flatpak_instance_get_pid:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the PID of the outermost process in the sandbox. This is not the
+ * application process itself, but a bubblewrap 'babysitter' process.
+ *
+ * See flatpak_instance_get_child_pid().
+ *
+ * Returns: the outermost process PID
+ *
+ * Since: 1.1
+ */
+int
+flatpak_instance_get_pid (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->pid;
+}
+
+static int get_child_pid (const char *dir);
+
+/**
+ * flatpak_instance_get_child_pid:
+ * @self: a #FlatpakInstance
+ *
+ * Gets the PID of the application process in the sandbox.
+ *
+ * See flatpak_instance_get_pid().
+ *
+ * Note that this function may return 0 immediately after launching
+ * a sandbox, for a short amount of time.
+ *
+ * Returns: the application process PID
+ *
+ * Since: 1.1
+ */
+int
+flatpak_instance_get_child_pid (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  if (priv->child_pid == 0)
+    priv->child_pid = get_child_pid (priv->dir);
+
+  return priv->child_pid;
+}
+
+/**
+ * flatpak_instance_get_info:
+ * @self: a #FlatpakInstance
+ *
+ * Gets a keyfile that holds information about the running sandbox.
+ *
+ * This file is available as /.flatpak-info inside the sandbox as well.
+ *
+ * The most important data in the keyfile is available with separate getters,
+ * but there may be more information in the keyfile.
+ *
+ * Returns: the flatpak-info keyfile
+ *
+ * Since: 1.1
+ */
+GKeyFile *
+flatpak_instance_get_info (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  return priv->info;
+}
+
+static GKeyFile *
+get_instance_info (const char *dir)
+{
+  g_autofree char *file = NULL;
+  g_autoptr(GKeyFile) key_file = NULL;
+  g_autoptr(GError) error = NULL;
+
+  file = g_build_filename (dir, "info", NULL);
+
+  key_file = g_key_file_new ();
+  if (!g_key_file_load_from_file (key_file, file, G_KEY_FILE_NONE, &error))
+    {
+      g_debug ("Failed to load instance info file '%s': %s", file, error->message);
+      return NULL;
+    }
+
+  return g_steal_pointer (&key_file);
+}
+
+static int
+get_child_pid (const char *dir)
+{
+  g_autofree char *file = NULL;
+  g_autofree char *contents = NULL;
+  gsize length;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(JsonParser) parser = NULL;
+  JsonNode *node;
+  JsonObject *obj;
+
+  file = g_build_filename (dir, "bwrapinfo.json", NULL);
+
+  if (!g_file_get_contents (file, &contents, &length, &error))
+    {
+      g_debug ("Failed to load bwrapinfo.json file '%s': %s", file, error->message);
+      return 0;
+    }
+
+  parser = json_parser_new ();
+  if (!json_parser_load_from_data (parser, contents, length, &error))
+    {
+      g_debug ("Failed to parse bwrapinfo.json file '%s': %s", file, error->message);
+      return 0;
+    }
+
+  node = json_parser_get_root (parser);
+  if (!node)
+    {
+      g_debug ("Failed to parse bwrapinfo.json file '%s': %s", file, "empty");
+      return 0;
+    }
+
+  obj = json_node_get_object (node);
+
+  return json_object_get_int_member (obj, "child-pid");
+}
+
+static int
+get_pid (const char *dir)
+{
+  g_autofree char *file = NULL;
+  g_autofree char *contents = NULL;
+  g_autoptr(GError) error = NULL;
+
+  file = g_build_filename (dir, "pid", NULL);
+
+  if (!g_file_get_contents (file, &contents, NULL, &error))
+    {
+      g_debug ("Failed to load pid file '%s': %s", file, error->message);
+      return 0;
+    }
+
+  return (int) g_ascii_strtoll (contents, NULL, 10);
+}
+
+static FlatpakInstance *
+flatpak_instance_new (const char *dir)
+{
+  FlatpakInstance *self = g_object_new (flatpak_instance_get_type (), NULL);
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  priv->dir = g_strdup (dir);
+  priv->id = g_path_get_basename (dir);
+
+  priv->pid = get_pid (priv->dir);
+  priv->child_pid = get_child_pid (priv->dir);
+  priv->info = get_instance_info (priv->dir);
+
+  if (priv->info)
+    {
+      if (g_key_file_has_group (priv->info, FLATPAK_METADATA_GROUP_APPLICATION))
+        {
+          priv->app = g_key_file_get_string (priv->info,
+                                             FLATPAK_METADATA_GROUP_APPLICATION, FLATPAK_METADATA_KEY_NAME, NULL);
+          priv->runtime = g_key_file_get_string (priv->info,
+                                                 FLATPAK_METADATA_GROUP_APPLICATION, FLATPAK_METADATA_KEY_RUNTIME, NULL);
+        }
+      else
+        {
+          priv->runtime = g_key_file_get_string (priv->info,
+                                                 FLATPAK_METADATA_GROUP_RUNTIME, FLATPAK_METADATA_KEY_RUNTIME, NULL);
+        }
+
+      priv->arch = g_key_file_get_string (priv->info,
+                                          FLATPAK_METADATA_GROUP_INSTANCE, FLATPAK_METADATA_KEY_ARCH, NULL);
+      priv->branch = g_key_file_get_string (priv->info,
+                                            FLATPAK_METADATA_GROUP_INSTANCE, FLATPAK_METADATA_KEY_BRANCH, NULL);
+      priv->commit = g_key_file_get_string (priv->info,
+                                            FLATPAK_METADATA_GROUP_INSTANCE, FLATPAK_METADATA_KEY_APP_COMMIT, NULL);
+      priv->runtime_commit = g_key_file_get_string (priv->info,
+                                                    FLATPAK_METADATA_GROUP_INSTANCE, FLATPAK_METADATA_KEY_RUNTIME_COMMIT, NULL);
+    }
+
+  return self;
+}
+
+static FlatpakInstance *
+flatpak_instance_new_for_id (const char *id)
+{
+  g_autofree char *dir = NULL;
+
+  dir = g_build_filename (g_get_user_runtime_dir (), ".flatpak", id, NULL);
+  return flatpak_instance_new (dir);
+}
+
+/**
+ * flatpak_instance_get_all:
+ *
+ * Gets FlatpakInstance objects for all running sandboxes in the current session.
+ *
+ * Returns: (transfer full) (element-type FlatpakInstance): a #GPtrArray of
+ *   #FlatpakInstance objects
+ *
+ * Since: 1.1
+ */
+GPtrArray *
+flatpak_instance_get_all (void)
+{
+  g_autoptr(GPtrArray) instances = NULL;
+  g_autofree char *base_dir = NULL;
+  g_autoptr(GFile) file = NULL;
+  g_autoptr(GFileEnumerator) iter = NULL;
+
+  instances = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+  base_dir = g_build_filename (g_get_user_runtime_dir (), ".flatpak", NULL);
+  file = g_file_new_for_path (base_dir);
+  iter = g_file_enumerate_children (file,
+                                    G_FILE_ATTRIBUTE_STANDARD_NAME ","
+                                    G_FILE_ATTRIBUTE_STANDARD_TYPE,
+                                    G_FILE_QUERY_INFO_NONE,
+                                    NULL,
+                                    NULL);
+  if (!iter)
+    return g_steal_pointer (&instances);
+
+  while (TRUE)
+    {
+      GFileInfo *info;
+
+      if (!g_file_enumerator_iterate (iter, &info, NULL, NULL, NULL))
+        break;
+
+      if (!info)
+        break;
+
+      if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY)
+        g_ptr_array_add (instances, flatpak_instance_new_for_id (g_file_info_get_name (info)));
+    }
+
+  return g_steal_pointer (&instances);
+}
+
+/**
+ * flatpak_instance_is_running:
+ * @self: a #FlatpakInstance
+ *
+ * Finds out if the sandbox represented by @self is still running.
+ *
+ * Returns: %TRUE if the sandbox is still running
+ */
+gboolean
+flatpak_instance_is_running (FlatpakInstance *self)
+{
+  FlatpakInstancePrivate *priv = flatpak_instance_get_instance_private (self);
+
+  if (kill (priv->pid, 0) == 0)
+    return TRUE;
+
+  return FALSE;
+}

--- a/src/flatpak-instance.h
+++ b/src/flatpak-instance.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#ifndef __FLATPAK_INSTANCE_H__
+#define __FLATPAK_INSTANCE_H__
+
+typedef struct _FlatpakInstance FlatpakInstance;
+
+#include <glib-object.h>
+
+#define FLATPAK_TYPE_INSTANCE flatpak_instance_get_type ()
+#define FLATPAK_INSTANCE(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_INSTANCE, FlatpakInstance))
+#define FLATPAK_IS_INSTANCE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_INSTANCE))
+
+GType flatpak_instance_get_type (void);
+
+struct _FlatpakInstance
+{
+  GObject parent;
+};
+
+typedef struct
+{
+  GObjectClass parent_class;
+} FlatpakInstanceClass;
+
+
+#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakInstance, g_object_unref)
+#endif
+
+GPtrArray *  flatpak_instance_get_all (void);
+
+const char * flatpak_instance_get_id (FlatpakInstance *self);
+const char * flatpak_instance_get_app (FlatpakInstance *self);
+const char * flatpak_instance_get_arch (FlatpakInstance *self);
+const char * flatpak_instance_get_branch (FlatpakInstance *self);
+const char * flatpak_instance_get_commit (FlatpakInstance *self);
+const char * flatpak_instance_get_runtime (FlatpakInstance *self);
+const char * flatpak_instance_get_runtime_commit (FlatpakInstance *self);
+int          flatpak_instance_get_pid (FlatpakInstance *self);
+int          flatpak_instance_get_child_pid (FlatpakInstance *self);
+GKeyFile *   flatpak_instance_get_info (FlatpakInstance *self);
+
+gboolean     flatpak_instance_is_running (FlatpakInstance *self);
+
+#endif /* __FLATPAK_INSTANCE_H__ */

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -381,6 +381,7 @@ on_bus_acquired (GDBusConnection *connection,
                  gpointer         user_data)
 {
   PortalImplementation *implementation;
+  PortalImplementation *implementation2;
   g_autoptr(GError) error = NULL;
   XdpImplLockdown *lockdown;
 
@@ -436,6 +437,7 @@ on_bus_acquired (GDBusConnection *connection,
                                   inhibit_create (connection, implementation->dbus_name));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Access");
+  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Background");
   if (implementation != NULL)
     {
       export_portal_implementation (connection,
@@ -444,9 +446,13 @@ on_bus_acquired (GDBusConnection *connection,
       export_portal_implementation (connection,
                                     location_create (connection, implementation->dbus_name, lockdown));
 #endif
-      export_portal_implementation (connection,
-                                    background_create (connection, implementation->dbus_name));
     }
+
+  if (implementation != NULL && implementation2 != NULL)
+    export_portal_implementation (connection,
+                                  background_create (connection,
+                                                     implementation->dbus_name,
+                                                     implementation2->dbus_name));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Account");
   if (implementation != NULL)

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -50,6 +50,7 @@
 #include "trash.h"
 #include "location.h"
 #include "settings.h"
+#include "background.h"
 
 static GMainLoop *loop = NULL;
 
@@ -443,6 +444,8 @@ on_bus_acquired (GDBusConnection *connection,
       export_portal_implementation (connection,
                                     location_create (connection, implementation->dbus_name, lockdown));
 #endif
+      export_portal_implementation (connection,
+                                    background_create (connection, implementation->dbus_name));
     }
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Account");

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -209,6 +209,44 @@ xdp_app_info_load_app_info (XdpAppInfo *app_info)
   return G_APP_INFO (g_desktop_app_info_new (desktop_id));
 }
 
+char **
+xdp_app_info_rewrite_commandline (XdpAppInfo *app_info,
+                                  const char * const *commandline)
+{
+  g_return_val_if_fail (app_info != NULL, NULL);
+
+  if (app_info->kind == XDP_APP_INFO_KIND_HOST)
+    {
+      return g_strdupv ((char **)commandline);
+    }
+  else if (app_info->kind == XDP_APP_INFO_KIND_FLATPAK)
+    {
+      g_autoptr(GPtrArray) args = NULL;
+
+      args = g_ptr_array_new_with_free_func (g_free);
+
+      g_ptr_array_add (args, g_strdup ("flatpak"));
+      g_ptr_array_add (args, g_strdup ("run"));
+      if (commandline && commandline[0])
+        {
+          int i;
+          g_autofree char *cmd = NULL;
+
+          g_ptr_array_add (args, g_strdup_printf ("--command=%s", commandline[0]));
+          g_ptr_array_add (args, g_strdup (app_info->id));
+          for (i = 1; commandline[i]; i++)
+            g_ptr_array_add (args, g_strdup (commandline[i]));
+        }
+      else
+        g_ptr_array_add (args, g_strdup (app_info->id));
+      g_ptr_array_add (args, NULL);
+
+      return (char **)g_ptr_array_free (g_steal_pointer (&args), FALSE);
+    }
+  else
+    return NULL;
+}
+
 gboolean
 xdp_app_info_is_host (XdpAppInfo *app_info)
 {

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <mntent.h>
 
+#include <gio/gdesktopappinfo.h>
 
 #include "xdp-utils.h"
 
@@ -191,6 +192,21 @@ xdp_app_info_get_id (XdpAppInfo *app_info)
   g_return_val_if_fail (app_info != NULL, NULL);
 
   return app_info->id;
+}
+
+GAppInfo *
+xdp_app_info_load_app_info (XdpAppInfo *app_info)
+{
+  g_autofree char *desktop_id = NULL;
+
+  g_return_val_if_fail (app_info != NULL, NULL);
+
+  if (app_info->id[0] == '\0')
+    return NULL;
+
+  desktop_id = g_strconcat (app_info->id, ".desktop", NULL);
+
+  return G_APP_INFO (g_desktop_app_info_new (desktop_id));
 }
 
 gboolean

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -62,6 +62,7 @@ char *      xdp_app_info_get_path_for_fd (XdpAppInfo  *app_info,
 gboolean    xdp_app_info_has_network     (XdpAppInfo  *app_info);
 XdpAppInfo *xdp_get_app_info_from_pid    (pid_t        pid,
                                           GError     **error);
+GAppInfo *  xdp_app_info_load_app_info   (XdpAppInfo *app_info);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdpAppInfo, xdp_app_info_unref)
 

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -63,6 +63,8 @@ gboolean    xdp_app_info_has_network     (XdpAppInfo  *app_info);
 XdpAppInfo *xdp_get_app_info_from_pid    (pid_t        pid,
                                           GError     **error);
 GAppInfo *  xdp_app_info_load_app_info   (XdpAppInfo *app_info);
+char **     xdp_app_info_rewrite_commandline (XdpAppInfo *app_info,
+                                              const char *const *commandline);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdpAppInfo, xdp_app_info_unref)
 


### PR DESCRIPTION
Implement a facility that monitors running flatpaks,
and notifies the user if they run in the background.
Add a permission table to store users responses
persistently.

The platform-dependent parts of this (getting the
state of running applications, and notifying the user)
are handled by a portal backend.

There is currently no application API.