### PR TITLE
configure.ac: Make Flatpak interface directory configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,12 @@ AC_ARG_WITH(dbus_service_dir,
 DBUS_SERVICE_DIR=$with_dbus_service_dir
 AC_SUBST(DBUS_SERVICE_DIR)
 
+AC_ARG_WITH(flatpak_interfaces_dir,
+        AS_HELP_STRING([--with-flatpak-interfaces-dir=PATH],[choose directory for Flatpak interface files, [default=PREFIX/share/dbus-1/interfaces]]),
+        [[FLATPAK_INTERFACES_DIR="$withval"]],
+	[PKG_CHECK_VAR([FLATPAK_INTERFACES_DIR], [flatpak], [interfaces_dir])])
+AC_SUBST(FLATPAK_INTERFACES_DIR)
+
 AC_ARG_WITH([systemduserunitdir],
             [AS_HELP_STRING([--with-systemduserunitdir=DIR],
                             [Directory for systemd user service files (default=PREFIX/lib/systemd/user)])],

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,7 @@
 NULL =
 
 org.freedesktop.portal.Flatpak.xml :
-	cp $(datadir)/dbus-1/interfaces/org.freedesktop.portal.Flatpak.xml .
+	cp $(FLATPAK_INTERFACES_DIR)/org.freedesktop.portal.Flatpak.xml .
 
 portal_files = 								\
 	org.freedesktop.portal.Flatpak.xml		 		\


### PR DESCRIPTION
The current build scripts look in $datadir for Flatpak interface
descriptions. This does not work if these files are installed under
/usr/share (the default) and the package's $datadir is located under
/usr/local/share (also the default). With the patch, the Flatpak
directory is either autodetected from pkg-config or set on configure's
command line.

Signed-off-by: Thomas Zimmermann <tzimmermann@suse.de>