### PR TITLE
Camera portal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_ARG_ENABLE(pipewire,
 	      [AS_HELP_STRING([--enable-pipewire],[Enable PipeWire support. Needed for screen cast portal])],
 	      enable_pipewire=$enableval, enable_pipewire=yes)
 if test x$enable_pipewire = xyes ; then
-	PKG_CHECK_MODULES(PIPEWIRE, [libpipewire-0.2 >= 0.2.2])
+	PKG_CHECK_MODULES(PIPEWIRE, [libpipewire-0.2 >= 0.2.6])
 	AC_DEFINE([HAVE_PIPEWIRE],[1], [Define to enable PipeWire support])
 fi
 AM_CONDITIONAL([HAVE_PIPEWIRE],[test "$enable_pipewire" = "yes"])

--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2018 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Camera:
+      @short_description: Camera portal
+
+      The camera portal enables applications to access camera devices, such as
+      web cams.
+  -->
+  <interface name="org.freedesktop.portal.Camera">
+    <!--
+        AccessCamera:
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the @handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Request documentation for
+              more information about the @handle.
+            </para></listitem>
+          </varlistentry>
+
+        Following the #org.freedesktop.portal.Request::Response signal, if
+        granted, #org.freedesktop.org.Camera.OpenPipeWireRemote can be used to
+        open a PipeWire remote.
+    -->
+    <method name="AccessCamera">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+    <!--
+        OpenPipeWireRemote:
+        @options: Vardict with optional further information
+        @fd: File descriptor of an open PipeWire remote.
+
+        Open a file descriptor to the PipeWire remote where the camera nodes
+        are available. The file descriptor should be used to create a
+        <classname>pw_remote</classname> object, by using
+        <function>pw_remote_connect_fd</function>.
+
+        This method will only succeed if the application already has permission
+        to access camera devices.
+    -->
+    <method name="OpenPipeWireRemote">
+      <annotation name="org.gtk.GDBus.C.Name" value="open_pipewire_remote"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="h" name="fd" direction="out"/>
+    </method>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -68,6 +68,12 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>
+    <!--
+        IsCameraPresent:
+
+        A boolean stating whether there is any cameras available.
+    -->
+    <property name="IsCameraPresent" type="b" access="read"/>
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -37,6 +37,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.Settings.xml \
 	data/org.freedesktop.portal.Background.xml \
 	data/org.freedesktop.portal.GameMode.xml \
+	data/org.freedesktop.portal.Camera.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -142,6 +143,8 @@ xdg_desktop_portal_SOURCES = \
         src/email.h                     \
 	src/settings.c			\
 	src/settings.h			\
+	src/camera.c			\
+	src/camera.h			\
 	src/session.c			\
 	src/session.h			\
 	src/trash.c			\

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2018-2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+#include <gio/gunixfdlist.h>
+#include <gio/gdesktopappinfo.h>
+#include <stdio.h>
+
+#include "device.h"
+#include "request.h"
+#include "permissions.h"
+#include "pipewire.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+
+typedef struct _Camera Camera;
+typedef struct _CameraClass CameraClass;
+
+struct _Camera
+{
+  XdpCameraSkeleton parent_instance;
+};
+
+struct _CameraClass
+{
+  XdpCameraSkeletonClass parent_class;
+};
+
+static Camera *camera;
+
+GType camera_get_type (void);
+static void camera_iface_init (XdpCameraIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Camera, camera, XDP_TYPE_CAMERA_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_CAMERA,
+                                                camera_iface_init))
+
+static void
+handle_access_camera_in_thread_func (GTask *task,
+                                     gpointer source_object,
+                                     gpointer task_data,
+                                     GCancellable *cancellable)
+{
+  Request *request = (Request *)task_data;
+  const char *app_id;
+  gboolean allowed;
+  g_autoptr(GError) error = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  app_id = (const char *)g_object_get_data (G_OBJECT (request), "app-id");
+
+  allowed = device_query_permission_sync (app_id, "camera", request->id);
+
+  if (request->exported)
+    {
+      GVariantBuilder results;
+      guint32 response;
+
+      g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
+
+      response = allowed ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS
+                         : XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED;
+      xdp_request_emit_response (XDP_REQUEST (request),
+                                 response,
+                                 g_variant_builder_end (&results));
+      request_unexport (request);
+    }
+}
+
+static gboolean
+handle_access_camera (XdpCamera *object,
+                      GDBusMethodInvocation *invocation,
+                      GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  const char *app_id;
+  g_autoptr(GTask) task = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  app_id = xdp_app_info_get_id (request->app_info);
+
+  g_object_set_data_full (G_OBJECT (request), "app-id", g_strdup (app_id), g_free);
+
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  xdp_camera_complete_access_camera (object, invocation, request->id);
+
+  task = g_task_new (object, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
+  g_task_run_in_thread (task, handle_access_camera_in_thread_func);
+
+  return TRUE;
+}
+
+static PipeWireRemote *
+open_pipewire_camera_remote (const char *app_id,
+                             GError **error)
+{
+  PipeWireRemote *remote;
+  struct spa_dict_item permission_items[1];
+  struct pw_properties *pipewire_properties;
+
+  pipewire_properties =
+    pw_properties_new ("pipewire.access.portal.app_id", app_id,
+                       "pipewire.access.portal.media_roles", "Camera",
+                       NULL);
+  remote = pipewire_remote_new_sync (pipewire_properties, error);
+  if (!remote)
+    return NULL;
+
+  /*
+   * Hide all existing and future nodes by default. PipeWire will use the
+   * permission store to set up permissions.
+   */
+  permission_items[0].key = PW_CORE_PROXY_PERMISSIONS_DEFAULT;
+  permission_items[0].value = "---";
+
+  pw_core_proxy_permissions (pw_remote_get_core_proxy (remote->remote),
+                             &SPA_DICT_INIT (permission_items,
+                                             G_N_ELEMENTS (permission_items)));
+
+  pipewire_remote_roundtrip (remote);
+
+  return remote;
+}
+
+static gboolean
+handle_open_pipewire_remote (XdpCamera *object,
+                             GDBusMethodInvocation *invocation,
+                             GUnixFDList *in_fd_list,
+                             GVariant *arg_options)
+{
+  g_autoptr(XdpAppInfo) app_info = NULL;
+  const char *app_id;
+  Permission permission;
+  g_autoptr(GUnixFDList) out_fd_list = NULL;
+  int fd;
+  int fd_id;
+  g_autoptr(GError) error = NULL;
+  PipeWireRemote *remote;
+
+  app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, &error);
+  app_id = xdp_app_info_get_id (app_info);
+  permission = device_get_permission_sync (app_id, "camera");
+  if (permission != PERMISSION_YES)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "Permission denied");
+      return TRUE;
+    }
+
+  remote = open_pipewire_camera_remote (app_id, &error);
+  if (!remote)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_FAILED,
+                                             "Failed to open PipeWire remote: %s",
+                                             error->message);
+      return TRUE;
+    }
+
+  out_fd_list = g_unix_fd_list_new ();
+  fd = pw_remote_steal_fd (remote->remote);
+  fd_id = g_unix_fd_list_append (out_fd_list, fd, &error);
+  close (fd);
+  pipewire_remote_destroy (remote);
+
+  if (fd_id == -1)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_FAILED,
+                                             "Failed to append fd: %s",
+                                             error->message);
+      return TRUE;
+    }
+
+  xdp_camera_complete_open_pipewire_remote (object, invocation,
+                                            out_fd_list,
+                                            g_variant_new_handle (fd_id));
+  return TRUE;
+}
+
+static void
+camera_iface_init (XdpCameraIface *iface)
+{
+  iface->handle_access_camera = handle_access_camera;
+  iface->handle_open_pipewire_remote = handle_open_pipewire_remote;
+}
+
+static void
+camera_init (Camera *camera)
+{
+  xdp_camera_set_version (XDP_CAMERA (camera), 1);
+}
+
+static void
+camera_class_init (CameraClass *klass)
+{
+}
+
+GDBusInterfaceSkeleton *
+camera_create (GDBusConnection *connection)
+{
+  camera = g_object_new (camera_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (camera);
+}

--- a/src/camera.h
+++ b/src/camera.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * camera_create (GDBusConnection *connection);

--- a/src/device.c
+++ b/src/device.c
@@ -71,27 +71,39 @@ static const char *known_devices[] = {
   NULL
 };
 
+Permission
+device_get_permission_sync (const char *app_id,
+                            const char *device)
+{
+  char **permissions;
+
+  permissions = get_permissions_sync (app_id, PERMISSION_TABLE, device);
+  if (!permissions)
+    {
+      return PERMISSION_UNSET;
+    }
+  else
+    {
+      Permission permission;
+
+      g_debug ("device: %s %s, app %s -> %s",
+               PERMISSION_TABLE, device, app_id, permissions[0]);
+
+      permission = permissions_to_tristate (permissions);
+      g_strfreev (permissions);
+      return permission;
+    }
+}
+
 gboolean
 device_query_permission_sync (const char *app_id,
                               const char *device,
                               const char *request_handle)
 {
-  char **permissions;
   Permission permission;
   gboolean allowed;
 
-  permissions = get_permissions_sync (app_id, PERMISSION_TABLE, device);
-  if (!permissions)
-    {
-      permission = PERMISSION_UNSET;
-    }
-  else
-    {
-      g_debug ("device: %s %s, app %s -> %s",
-               PERMISSION_TABLE, device, app_id, permissions[0]);
-      permission = permissions_to_tristate (permissions);
-    }
-
+  permission = device_get_permission_sync (app_id, device);
   if (permission == PERMISSION_ASK || permission == PERMISSION_UNSET)
     {
       GVariantBuilder opt_builder;

--- a/src/device.c
+++ b/src/device.c
@@ -72,10 +72,10 @@ static const char *known_devices[] = {
 };
 
 static void
-handle_access_microphone_in_thread (GTask *task,
-                                    gpointer source_object,
-                                    gpointer task_data,
-                                    GCancellable *cancellable)
+handle_access_device_in_thread (GTask *task,
+                                gpointer source_object,
+                                gpointer task_data,
+                                GCancellable *cancellable)
 {
   Request *request = (Request *)task_data;
   const char *app_id;
@@ -302,7 +302,7 @@ handle_access_device (XdpDevice *object,
 
   task = g_task_new (object, NULL, NULL, NULL);
   g_task_set_task_data (task, g_object_ref (request), g_object_unref);
-  g_task_run_in_thread (task, handle_access_microphone_in_thread);
+  g_task_run_in_thread (task, handle_access_device_in_thread);
 
   return TRUE;
 }

--- a/src/device.h
+++ b/src/device.h
@@ -22,6 +22,12 @@
 
 #include <gio/gio.h>
 
+#include "request.h"
+
+gboolean device_query_permission_sync (const char *app_id,
+                                       const char *device,
+                                       const char *request_handle);
+
 GDBusInterfaceSkeleton * device_create (GDBusConnection *connection,
                                         const char      *dbus_name,
                                         gpointer         lockdown);

--- a/src/device.h
+++ b/src/device.h
@@ -23,6 +23,10 @@
 #include <gio/gio.h>
 
 #include "request.h"
+#include "permissions.h"
+
+Permission device_get_permission_sync (const char *app_id,
+                                       const char *device);
 
 gboolean device_query_permission_sync (const char *app_id,
                                        const char *device,

--- a/src/permissions.c
+++ b/src/permissions.c
@@ -32,7 +32,7 @@ get_permissions_sync (const char *app_id,
   g_autoptr(GError) error = NULL;
   g_autoptr(GVariant) out_perms = NULL;
   g_autoptr(GVariant) out_data = NULL;
-  char **permissions;
+  g_autofree char **permissions = NULL;
 
   if (!xdp_impl_permission_store_call_lookup_sync (permission_store,
                                                    table,

--- a/src/permissions.h
+++ b/src/permissions.h
@@ -23,5 +23,26 @@
 #include <gio/gio.h>
 #include "xdp-impl-dbus.h"
 
+typedef enum _Permission
+{
+  PERMISSION_UNSET,
+  PERMISSION_NO,
+  PERMISSION_YES,
+  PERMISSION_ASK
+} Permission;
+
+char **get_permissions_sync (const char *app_id,
+                             const char *table,
+                             const char *id);
+
+void set_permissions_sync (const char *app_id,
+                           const char *table,
+                           const char *id,
+                           const char * const *permissions);
+
+char **permissions_from_tristate (Permission permission);
+
+Permission permissions_to_tristate (char **permissions);
+
 void init_permission_store (GDBusConnection *connection);
 XdpImplPermissionStore *get_permission_store (void);

--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -18,10 +18,18 @@
 
 #include "config.h"
 
+#include <errno.h>
 #include <glib.h>
 #include <pipewire/pipewire.h>
 
 #include "pipewire.h"
+
+typedef struct _PipeWireSource
+{
+  GSource base;
+
+  PipeWireRemote *remote;
+} PipeWireSource;
 
 static gboolean is_pipewire_initialized = FALSE;
 
@@ -45,6 +53,8 @@ registry_event_global (void *user_data,
   };
 
   g_hash_table_insert (remote->globals, GINT_TO_POINTER (id), global);
+  if (remote->global_added_cb)
+    remote->global_added_cb (remote, id, type, props, remote->user_data);
 
   if (type != core_type->factory)
     return;
@@ -60,9 +70,21 @@ registry_event_global (void *user_data,
     }
 }
 
+static void
+registry_event_global_remove (void *user_data,
+                              uint32_t id)
+{
+  PipeWireRemote *remote = user_data;
+
+  if (remote->global_removed_cb)
+    remote->global_removed_cb (remote, id, remote->user_data);
+  g_hash_table_remove (remote->globals, GINT_TO_POINTER (id));
+}
+
 static const struct pw_registry_proxy_events registry_events = {
   PW_VERSION_REGISTRY_PROXY_EVENTS,
   .global = registry_event_global,
+  .global_remove = registry_event_global_remove,
 };
 
 void
@@ -156,6 +178,61 @@ static const struct pw_core_proxy_events core_events = {
   .done = core_event_done,
 };
 
+static gboolean
+pipewire_loop_source_prepare (GSource *base,
+                              int *timeout)
+{
+  *timeout = -1;
+  return FALSE;
+}
+
+static gboolean
+pipewire_loop_source_dispatch (GSource *source,
+                               GSourceFunc callback,
+                               gpointer user_data)
+{
+  PipeWireSource *pipewire_source = (PipeWireSource *) source;
+  struct pw_loop *loop;
+  int result;
+
+  loop = pw_main_loop_get_loop (pipewire_source->remote->loop);
+  result = pw_loop_iterate (loop, 0);
+  if (result < 0)
+    g_warning ("pipewire_loop_iterate failed: %s", spa_strerror (result));
+
+  if (pipewire_source->remote->error)
+    {
+      GFunc error_callback;
+
+      g_warning ("Caught PipeWire error: %s", pipewire_source->remote->error->message);
+
+      error_callback = pipewire_source->remote->error_callback;
+      if (error_callback)
+        error_callback (pipewire_source->remote,
+                        pipewire_source->remote->user_data);
+    }
+
+  return TRUE;
+}
+
+static void
+pipewire_loop_source_finalize (GSource *source)
+{
+  PipeWireSource *pipewire_source = (PipeWireSource *) source;
+  struct pw_loop *loop;
+
+  loop = pw_main_loop_get_loop (pipewire_source->remote->loop);
+  pw_loop_leave (loop);
+}
+
+static GSourceFuncs pipewire_source_funcs =
+{
+  pipewire_loop_source_prepare,
+  NULL,
+  pipewire_loop_source_dispatch,
+  pipewire_loop_source_finalize
+};
+
 void
 pipewire_remote_destroy (PipeWireRemote *remote)
 {
@@ -179,8 +256,34 @@ ensure_pipewire_is_initialized (void)
   is_pipewire_initialized = TRUE;
 }
 
+GSource *
+pipewire_remote_create_source (PipeWireRemote *remote)
+{
+  PipeWireSource *pipewire_source;
+  struct pw_loop *loop;
+
+
+  pipewire_source = (PipeWireSource *) g_source_new (&pipewire_source_funcs,
+                                                     sizeof (PipeWireSource));
+  pipewire_source->remote = remote;
+
+  loop = pw_main_loop_get_loop (pipewire_source->remote->loop);
+  g_source_add_unix_fd (&pipewire_source->base,
+                        pw_loop_get_fd (loop),
+                        G_IO_IN | G_IO_ERR);
+
+  pw_loop_enter (loop);
+  g_source_attach (&pipewire_source->base, NULL);
+
+  return &pipewire_source->base;
+}
+
 PipeWireRemote *
 pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
+                          PipeWireGlobalAddedCallback global_added_cb,
+                          PipeWireGlobalRemovedCallback global_removed_cb,
+                          GFunc error_callback,
+                          gpointer user_data,
                           GError **error)
 {
   PipeWireRemote *remote;
@@ -188,6 +291,11 @@ pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
   ensure_pipewire_is_initialized ();
 
   remote = g_new0 (PipeWireRemote, 1);
+
+  remote->global_added_cb = global_added_cb;
+  remote->global_removed_cb = global_removed_cb;
+  remote->error_callback = error_callback;
+  remote->user_data = user_data;
 
   remote->loop = pw_main_loop_new (NULL);
   if (!remote->loop)

--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -166,7 +166,8 @@ ensure_pipewire_is_initialized (void)
 }
 
 PipeWireRemote *
-pipewire_remote_new_sync (GError **error)
+pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
+                          GError **error)
 {
   PipeWireRemote *remote;
 
@@ -178,6 +179,7 @@ pipewire_remote_new_sync (GError **error)
   if (!remote->loop)
     {
       pipewire_remote_destroy (remote);
+      pw_properties_free (pipewire_properties);
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "Couldn't create PipeWire main loop");
       return NULL;
@@ -187,12 +189,13 @@ pipewire_remote_new_sync (GError **error)
   if (!remote->core)
     {
       pipewire_remote_destroy (remote);
+      pw_properties_free (pipewire_properties);
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "Couldn't create PipeWire core");
       return NULL;
     }
 
-  remote->remote = pw_remote_new (remote->core, NULL, 0);
+  remote->remote = pw_remote_new (remote->core, pipewire_properties, 0);
   if (!remote->remote)
     {
       pipewire_remote_destroy (remote);

--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -110,13 +110,19 @@ on_state_changed (void *user_data,
   switch (state)
     {
     case PW_REMOTE_STATE_ERROR:
-      g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "%s", error);
+      if (!remote->error)
+        {
+          g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "%s", error);
+        }
       pw_main_loop_quit (remote->loop);
       break;
     case PW_REMOTE_STATE_UNCONNECTED:
-      g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Disconnected");
+      if (!remote->error)
+        {
+          g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Disconnected");
+        }
       pw_main_loop_quit (remote->loop);
       break;
     case PW_REMOTE_STATE_CONNECTING:

--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -70,13 +70,12 @@ discover_node_factory_sync (PipeWireRemote *remote,
 {
   struct pw_type *core_type = pw_core_get_type (remote->core);
   struct pw_registry_proxy *registry_proxy;
-  struct spa_hook registry_listener;
 
   registry_proxy = pw_core_proxy_get_registry (remote->core_proxy,
                                                core_type->registry,
                                                PW_VERSION_REGISTRY, 0);
   pw_registry_proxy_add_listener (registry_proxy,
-                                  &registry_listener,
+                                  &remote->registry_listener,
                                   &registry_events,
                                   remote);
 

--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -22,6 +22,12 @@
 #include <pipewire/pipewire.h>
 #include <stdint.h>
 
+typedef struct _PipeWireGlobal
+{
+  uint32_t parent_id;
+  gboolean permission_set;
+} PipeWireGlobal;
+
 typedef struct _PipeWireRemote
 {
   struct pw_main_loop *loop;
@@ -35,6 +41,7 @@ typedef struct _PipeWireRemote
 
   struct spa_hook registry_listener;
 
+  GHashTable *globals;
   uint32_t node_factory_id;
 
   GError *error;

--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -22,13 +22,25 @@
 #include <pipewire/pipewire.h>
 #include <stdint.h>
 
+typedef struct _PipeWireRemote PipeWireRemote;
+
 typedef struct _PipeWireGlobal
 {
   uint32_t parent_id;
   gboolean permission_set;
 } PipeWireGlobal;
 
-typedef struct _PipeWireRemote
+typedef void (* PipeWireGlobalAddedCallback) (PipeWireRemote *remote,
+                                              uint32_t id,
+                                              uint32_t type,
+                                              const struct spa_dict *props,
+                                              gpointer user_data);
+
+typedef void (* PipeWireGlobalRemovedCallback) (PipeWireRemote *remote,
+                                                uint32_t id,
+                                                gpointer user_data);
+
+struct _PipeWireRemote
 {
   struct pw_main_loop *loop;
   struct pw_core *core;
@@ -42,14 +54,25 @@ typedef struct _PipeWireRemote
   struct spa_hook registry_listener;
 
   GHashTable *globals;
+  PipeWireGlobalAddedCallback global_added_cb;
+  PipeWireGlobalRemovedCallback global_removed_cb;
+  gpointer user_data;
+  GFunc error_callback;
+
   uint32_t node_factory_id;
 
   GError *error;
-} PipeWireRemote;
+};
 
 PipeWireRemote * pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
+                                           PipeWireGlobalAddedCallback global_added_cb,
+                                           PipeWireGlobalRemovedCallback global_removed_cb,
+                                           GFunc error_callback,
+                                           gpointer user_data,
                                            GError **error);
 
 void pipewire_remote_destroy (PipeWireRemote *remote);
 
 void pipewire_remote_roundtrip (PipeWireRemote *remote);
+
+GSource * pipewire_remote_create_source (PipeWireRemote *remote);

--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -38,7 +38,8 @@ typedef struct _PipeWireRemote
   GError *error;
 } PipeWireRemote;
 
-PipeWireRemote * pipewire_remote_new_sync (GError **error);
+PipeWireRemote * pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
+                                           GError **error);
 
 void pipewire_remote_destroy (PipeWireRemote *remote);
 

--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -33,6 +33,8 @@ typedef struct _PipeWireRemote
   struct spa_hook core_listener;
   uint32_t sync_seq;
 
+  struct spa_hook registry_listener;
+
   uint32_t node_factory_id;
 
   GError *error;

--- a/src/request.c
+++ b/src/request.c
@@ -294,6 +294,22 @@ get_token (GDBusMethodInvocation *invocation)
     {
       // no request objects
     }
+  else if (strcmp (interface, "org.freedesktop.portal.Camera") == 0)
+    {
+      if (strcmp (method, "AccessCamera") == 0 )
+        {
+          options = g_variant_get_child_value (parameters, 0);
+        }
+      else if (strcmp (method, "OpenPipewireRemote") == 0)
+        {
+          // no request objects
+        }
+      else
+        {
+          g_warning ("Support for %s::%s missing in %s",
+                     interface, method, G_STRLOC);
+        }
+    }
   else
     {
       g_print ("Support for %s missing in " G_STRLOC, interface);

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -595,7 +595,9 @@ open_pipewire_screen_cast_remote (const char *app_id,
   pipewire_properties = pw_properties_new ("pipewire.access.portal.app_id", app_id,
                                            "pipewire.access.portal.media_roles", "",
                                            NULL);
-  remote = pipewire_remote_new_sync (pipewire_properties, error);
+  remote = pipewire_remote_new_sync (pipewire_properties,
+                                     NULL, NULL, NULL, NULL,
+                                     error);
   if (!remote)
     return FALSE;
 

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -513,9 +513,11 @@ screen_cast_stream_get_pipewire_node_id (ScreenCastStream *stream)
 }
 
 static PipeWireRemote *
-open_pipewire_screen_cast_remote (GList *streams,
+open_pipewire_screen_cast_remote (const char *app_id,
+                                  GList *streams,
                                   GError **error)
 {
+  struct pw_properties *pipewire_properties;
   PipeWireRemote *remote;
   GList *l;
   unsigned int n_streams, i;
@@ -524,7 +526,10 @@ open_pipewire_screen_cast_remote (GList *streams,
   g_autofree char *node_factory_permission_string = NULL;
   char **stream_permission_values;
 
-  remote = pipewire_remote_new_sync (error);
+  pipewire_properties = pw_properties_new ("pipewire.access.portal.app_id", app_id,
+                                           "pipewire.access.portal.media_types", "",
+                                           NULL);
+  remote = pipewire_remote_new_sync (pipewire_properties, error);
   if (!remote)
     return FALSE;
 
@@ -864,7 +869,7 @@ handle_open_pipewire_remote (XdpScreenCast *object,
       return TRUE;
     }
 
-  remote = open_pipewire_screen_cast_remote (streams, &error);
+  remote = open_pipewire_screen_cast_remote (session->app_id, streams, &error);
   if (!remote)
     {
       g_dbus_method_invocation_return_error (invocation,

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -816,7 +816,7 @@ handle_open_pipewire_remote (XdpScreenCast *object,
   Session *session;
   GList *streams;
   PipeWireRemote *remote;
-  GUnixFDList *out_fd_list;
+  g_autoptr(GUnixFDList) out_fd_list = NULL;
   int fd;
   int fd_id;
   g_autoptr(GError) error = NULL;

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -53,6 +53,7 @@
 #include "settings.h"
 #include "background.h"
 #include "gamemode.h"
+#include "camera.h"
 
 static GMainLoop *loop = NULL;
 
@@ -113,6 +114,13 @@ method_needs_request (GDBusMethodInvocation *invocation)
   else if (strcmp (interface, "org.freedesktop.portal.RemoteDesktop") == 0)
     {
       if (strstr (method, "Notify") == method)
+        return FALSE;
+      else
+        return TRUE;
+    }
+  if (strcmp (interface, "org.freedesktop.portal.Camera") == 0)
+    {
+      if (strcmp (method, "OpenPipeWireRemote") == 0)
         return FALSE;
       else
         return TRUE;
@@ -257,6 +265,10 @@ on_bus_acquired (GDBusConnection *connection,
 #ifdef HAVE_GEOCLUE
       export_portal_implementation (connection,
                                     location_create (connection, implementation->dbus_name, lockdown));
+#endif
+
+#if HAVE_PIPEWIRE
+      export_portal_implementation (connection, camera_create (connection));
 #endif
     }
 


### PR DESCRIPTION
This adds a camera portal. It also includes fixes to the screen-cast portal, including one that will make it work with pipewire-0.2.6.

The portal works the following way:

There is a method `AccessCamera`, that will query the permission store and maybe the `Access` to query the user.

There is a method `OpenPipeWireRemote` that will open a pw_remote file descriptor. This method will only work if "yes" is already in the permission store. The PipeWire remote will be prepared with portal related metadata using `pipewire.access.portal.*` properties. All permissions will be set to `---` meaning no nodes will be available via the remote initially. PipeWire daemon side, there is a `module-portal` that then will handle keeping permissions up to date by querying and listening to the permission store.

In order to allow an application to only request camera permission would there be any cameras available, there is a `IsCameraPresent` boolean property that will expose whether there are any cameras available at all.

Note that pipewire-0.2.6 doesn't exist yet, but I bumped the required version anyway.