### PR TITLE
Add support for GameMode 1.4 APIs

### DIFF
--- a/data/org.freedesktop.portal.GameMode.xml
+++ b/data/org.freedesktop.portal.GameMode.xml
@@ -42,7 +42,7 @@
       'UnregisterGame' method, GameMode will automatically un-register
       the client. This might happen with a (small) delay.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
     -->
     <interface name="org.freedesktop.portal.GameMode">
       <!--
@@ -98,6 +98,54 @@
       -->
       <method name="UnregisterGame">
         <arg type="i" name="pid" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+
+      <!--
+          QueryStatusByPid:
+          @target: Process id to query the GameMode status of
+          @requester: Process id of the process requesting the information
+          @result: The GameMode status for @target
+
+          Query the GameMode status for a process.
+	  Like org.freedesktop.portal.GameMode.QueryStatus() but @requester
+          acting on behalf of @target.
+      -->
+      <method name="QueryStatusByPid">
+        <arg type="i" name="target" direction="in"/>
+	<arg type="i" name="requester" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+
+      <!--
+          RegisterGameByPid:
+          @target: Process id of the game to register
+          @requester: Process id of the process requesting the registration
+          @result: Status of the request: 0 for success, -1 indicates an error
+
+          Register a game with GameMode.
+	  Like org.freedesktop.portal.GameMode.RegisterGame() but @requester
+          acting on behalf of @target.
+      -->
+      <method name="RegisterGameByPid">
+        <arg type="i" name="target" direction="in"/>
+	<arg type="i" name="requester" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+
+      <!--
+          UnregisterGameByPid:
+          @target: Process id of the game to un-register
+          @requester: Process id of the process requesting the un-registration
+          @result: Status of the request: 0 for success, -1 indicates an error
+
+          Register a game with GameMode.
+	  Like org.freedesktop.portal.GameMode.UnregisterGame() but @requester
+          acting on behalf of @target.
+      -->
+      <method name="UnregisterGameByPid">
+        <arg type="i" name="target" direction="in"/>
+	<arg type="i" name="requester" direction="in"/>
         <arg type="i" name="result" direction="out"/>
       </method>
 

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -1512,8 +1512,16 @@ map_pids (DIR     *proc,
           return FALSE;
         }
 
-      res[idx] = outside;
-      count++;
+      /* this handles the first occurrence, already identified by find_pid,
+       * as well as duplicate entries */
+      for (guint i = idx; i < n_pids; i++)
+        {
+          if (pids[i] == inside)
+            {
+              res[idx] = outside;
+              count++;
+            }
+        }
     }
 
   if (count != n_pids)

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -1468,6 +1468,7 @@ map_pids (DIR     *proc,
   guint count = 0;
 
   res = g_alloca (sizeof (pid_t) * n_pids);
+  memset (res, 0, sizeof (pid_t) * n_pids);
 
   while ((de = readdir (proc)) != NULL)
     {
@@ -1526,8 +1527,17 @@ map_pids (DIR     *proc,
 
   if (count != n_pids)
     {
-      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                           "Some process ids could not be found");
+      g_autoptr(GString) str = NULL;
+
+      str = g_string_new ("Process ids could not be found: ");
+
+      for (guint i = 0; i < n_pids; i++)
+        if (res[i] == 0)
+          g_string_append_printf (str, "%d, ", (guint32) pids[i]);
+
+      g_string_truncate (str, str->len - 2);
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, str->str);
+
       return FALSE;
     }
 


### PR DESCRIPTION
GameMode 1.4 added a set of new APIs that mirror the existing ones
but where once process can act on behalf of the another. The only
difference of the new function calls to the existing one is the
additional "requester" argument (a process id). In case of faltpak
this new pid argument also needs to be to be mapped from the pid
namespace of the sandbox to the pid namespace of the host.

