### PR TITLE
request: Hardcode vardict options of the "Background" portal

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -294,6 +294,13 @@ get_token (GDBusMethodInvocation *invocation)
     {
       // no request objects
     }
+  else if (strcmp (interface, "org.freedesktop.portal.Background") == 0)
+    {
+        if (strcmp (method, "RequestBackground") == 0 )
+          {
+            options = g_variant_get_child_value (parameters, 1);
+          }
+    }
   else if (strcmp (interface, "org.freedesktop.portal.Camera") == 0)
     {
       if (strcmp (method, "AccessCamera") == 0 )


### PR DESCRIPTION
The "Background" portal vardict option is not handled. This way,
requests won't consider their "options".

Currently, while calling "RequestBackground" a user would get the
error bellow:
Support for org.freedesktop.portal.Background missing in src/request.c:315