### PR TITLE
test-doc-portal: Check for FUSE support more thoroughly

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -2537,7 +2537,8 @@ xdp_fuse_init (GError **error)
   main_ch = fuse_mount (path, &args);
   if (main_ch == NULL)
     {
-      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_FAILED, "Can't mount fuse fs");
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_FAILED,
+                   "Can't mount fuse fs on %s: %s", path, g_strerror (errno));
       return FALSE;
     }
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -13,10 +13,11 @@ testdb_LDADD = \
 	$(NULL)
 testdb_SOURCES = tests/testdb.c	$(DB_SOURCES)
 
-test_doc_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
+test_doc_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(FUSE_CFLAGS)
 test_doc_portal_LDADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
+	$(FUSE_LIBS) \
 	$(NULL)
 test_doc_portal_SOURCES = tests/test-doc-portal.c
 nodist_test_doc_portal_SOURCES = document-portal/document-portal-dbus.c


### PR DESCRIPTION
Some CI pipelines do the build and `make check` as root in a container,
with CAP_DAC_ADMIN, which means /dev/fuse is writable; but if we
do not have appropriate permissions in the inheritable set (notably
CAP_SYS_ADMIN) then we cannot actually mount FUSE filesystems.