### PR TITLE
utils: Recognize applications in Toolbox containers from the host

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -380,7 +380,14 @@ parse_app_info_from_flatpak_info (int pid, GError **error)
   root_fd = openat (AT_FDCWD, root_path, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
   if (root_fd == -1)
     {
-      /* Not able to open the root dir shouldn't happen. Probably the app died and
+      if (errno == EACCES)
+        {
+          /* Access to the root dir isn't allowed => inside a Toolbox
+             container, return NULL with no error */
+          return NULL;
+        }
+
+      /* Otherwise, we should be able to open the root dir. Probably the app died and
          we're failing due to /proc/$pid not existing. In that case fail instead
          of treating this as privileged. */
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,


### PR DESCRIPTION
Toolbox [1] containers are development environments whose primary goal
isn't secure containment of processes, but to offer a safe haven for
development without touching the host operating system. This is
particularly useful on OSTree based systems like Fedora Silverblue,
where it's significantly difficult to set up a development prefix
directly on the host OS. These containers are rootless OCI containers,
not Flatpak containers, and are designed to blur the divide between the
host and the container as much as possible - full access to $HOME, the
D-Bus sockets, the Wayland and X11 sockets, host network access, no
PID namespace, etc..

Therefore, conceptually, running an application inside a Toolbox
container is the same thing as running it on the host.

Identifying the runtime environment for applications starts with
opening /proc/<app-pid>/root. For an application running inside a
toolbox and a portal on the host, the PID is visible to the portal, but
it fails to open it because /proc/<app-pid>/root points to the
container's root directory, not the host's. The openat(2) call fails
with EACCES.

So far, any failure to open /proc/<app-pid>/root was treated as an
indication that the application has died. This specific error
condition is now special-cased to denote applications running on the
host.

[1] https://github.com/debarshiray/toolbox