### PR TITLE
Fix leak of .flatpak-info fd

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -441,7 +441,12 @@ parse_app_info_from_flatpak_info (int pid, GError **error)
 
   id = g_key_file_get_string (metadata, group, "name", error);
   if (id == NULL)
-    return NULL;
+    {
+      close (info_fd);
+      return NULL;
+    }
+
+  close (info_fd);
 
   app_info = xdp_app_info_new (XDP_APP_INFO_KIND_FLATPAK);
   app_info->id = g_steal_pointer (&id);


### PR DESCRIPTION
Fixes #352

Because xdg-desktop-portal is kinda hard to set up and run, this is a low-effort **untested** merge request. No warranty. But it looks right. We might need to keep info_fd open until we're done with the GMappedFile that's using it -- not sure -- but at this point we are already done with it, so should be OK.