### PR TITLE
Add a secret portal

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -22,6 +22,7 @@ dist_introspection_DATA = \
 	data/org.freedesktop.portal.Background.xml \
 	data/org.freedesktop.portal.GameMode.xml \
 	data/org.freedesktop.portal.Camera.xml \
+	data/org.freedesktop.portal.Secret.xml \
 	data/org.freedesktop.impl.portal.PermissionStore.xml \
 	data/org.freedesktop.impl.portal.Request.xml \
 	data/org.freedesktop.impl.portal.Session.xml \
@@ -39,4 +40,5 @@ dist_introspection_DATA = \
 	data/org.freedesktop.impl.portal.Settings.xml \
 	data/org.freedesktop.impl.portal.Lockdown.xml \
 	data/org.freedesktop.impl.portal.Background.xml \
+	data/org.freedesktop.impl.portal.Secret.xml \
 	$(NULL)

--- a/data/org.freedesktop.impl.portal.Secret.xml
+++ b/data/org.freedesktop.impl.portal.Secret.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2019 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Daiki Ueno <dueno@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.impl.portal.Secret:
+      @short_description: Secret portal backend interface
+
+      The Secret portal allows sandboxed applications to retrieve a
+      per-application master secret.
+  -->
+  <interface name="org.freedesktop.impl.portal.Secret">
+
+    <!--
+        RetrieveSecret:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @app_id: App id of the application
+        @fd: Writable file descriptor for transporting the secret
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Retrieves a master secret for a sandboxed application.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>token s</term>
+            <listitem><para>
+	      An opaque string associated with the retrieve secret.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="RetrieveSecret">
+      <annotation name="org.gtk.GDBus.C.Name" value="retrieve_secret"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="h" name="fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.Secret.xml
+++ b/data/org.freedesktop.portal.Secret.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2019 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Daiki Ueno <dueno@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Secret:
+      @short_description: Portal for retrieving application secret
+
+      The Secret portal allows sandboxed applications to retrieve a
+      per-application secret.  The secret can then be used for
+      encrypting confidential data inside the sandbox.
+
+      This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.Secret">
+
+    <!--
+        RetrieveSecret:
+        @fd: Writable file descriptor for transporting the secret
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Retrieves a master secret for a sandboxed application.
+
+	The master secret is unique per application and does not
+	change as long as the application is installed (once it has
+	been created). In a typical backend implementation, it is
+	stored in the user's keyring, under the application ID as a
+	key.
+
+	While the master secret can be used for encrypting any
+	confidential data in the sandbox, the format is opaque to the
+	application. In particular, the length of the secret might not
+	be sufficient for the use with certain encryption
+	algorithm. In that case, the application is supposed to expand
+	it using a KDF algorithm.
+
+	The portal may return an additional identifier associated with
+	the secret in the results vardict of
+	org.freedesktop.portal.Request.Response() call. In the next
+	call of this method, the application shall indicate it through
+	a token element in @options.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>token s</term>
+            <listitem><para>
+	      An opaque string returned by a previous org.freedesktop.portal.Secret.RetrieveSecret() call.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="RetrieveSecret">
+      <annotation name="org.gtk.GDBus.C.Name" value="retrieve_secret"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="h" name="fd" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -38,6 +38,7 @@ PORTAL_IFACE_FILES =\
 	data/org.freedesktop.portal.Background.xml \
 	data/org.freedesktop.portal.GameMode.xml \
 	data/org.freedesktop.portal.Camera.xml \
+	data/org.freedesktop.portal.Secret.xml \
 	$(NULL)
 
 PORTAL_IMPL_IFACE_FILES =\
@@ -58,6 +59,7 @@ PORTAL_IMPL_IFACE_FILES =\
 	data/org.freedesktop.impl.portal.Settings.xml \
 	data/org.freedesktop.impl.portal.Lockdown.xml \
 	data/org.freedesktop.impl.portal.Background.xml \
+	data/org.freedesktop.impl.portal.Secret.xml \
 	$(NULL)
 
 $(xdp_dbus_built_sources) : $(PORTAL_IFACE_FILES)
@@ -155,6 +157,8 @@ xdg_desktop_portal_SOURCES = \
 	src/background.h		\
 	src/gamemode.c			\
 	src/gamemode.h			\
+	src/secret.c			\
+	src/secret.h			\
         src/flatpak-instance.c          \
         src/flatpak-instance.h          \
 	src/portal-impl.h		\

--- a/src/request.c
+++ b/src/request.c
@@ -317,6 +317,10 @@ get_token (GDBusMethodInvocation *invocation)
                      interface, method, G_STRLOC);
         }
     }
+  else if (strcmp (interface, "org.freedesktop.portal.Secret") == 0)
+    {
+      options = g_variant_get_child_value (parameters, 1);
+    }
   else
     {
       g_print ("Support for %s missing in " G_STRLOC, interface);

--- a/src/secret.c
+++ b/src/secret.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Daiki Ueno <dueno@redhat.com>
+ */
+
+#include "config.h"
+
+#include <locale.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+#include "secret.h"
+#include "request.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+#include "xdp-utils.h"
+
+typedef struct _Secret Secret;
+typedef struct _SecretClass SecretClass;
+
+struct _Secret
+{
+  XdpSecretSkeleton parent_instance;
+};
+
+struct _SecretClass
+{
+  XdpSecretSkeletonClass parent_class;
+};
+
+static XdpImplSecret *impl;
+static Secret *secret;
+
+GType secret_get_type (void) G_GNUC_CONST;
+static void secret_iface_init (XdpSecretIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Secret, secret, XDP_TYPE_SECRET_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_SECRET, secret_iface_init));
+
+static XdpOptionKey retrieve_secret_options[] = {
+  { "token", G_VARIANT_TYPE_STRING, NULL },
+};
+
+static void
+send_response_in_thread_func (GTask *task,
+                              gpointer source_object,
+                              gpointer task_data,
+                              GCancellable *cancellable)
+{
+  Request *request = task_data;
+  guint response;
+  GVariantBuilder new_results;
+
+  g_variant_builder_init (&new_results, G_VARIANT_TYPE_VARDICT);
+
+  REQUEST_AUTOLOCK (request);
+
+  response = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (request), "response"));
+
+  if (request->exported)
+    {
+      xdp_request_emit_response (XDP_REQUEST (request),
+                                 response,
+                                 g_variant_builder_end (&new_results));
+      request_unexport (request);
+    }
+}
+
+static void
+retrieve_secret_done (GObject *source,
+		      GAsyncResult *result,
+		      gpointer data)
+{
+  g_autoptr(Request) request = data;
+  guint response = 2;
+  g_autoptr(GVariant) results = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GTask) task = NULL;
+
+  if (!xdp_impl_secret_call_retrieve_secret_finish (XDP_IMPL_SECRET (source),
+						    &response,
+						    &results,
+						    NULL,
+						    result,
+						    &error))
+    {
+      g_warning ("Backend call failed: %s", error->message);
+    }
+
+  g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
+
+  task = g_task_new (NULL, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
+  g_task_run_in_thread (task, send_response_in_thread_func);
+}
+
+static gboolean
+handle_retrieve_secret (XdpSecret *object,
+			GDBusMethodInvocation *invocation,
+			GUnixFDList *fd_list,
+			GVariant *arg_fd,
+			GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  const char *app_id = xdp_app_info_get_id (request->app_info);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpImplRequest) impl_request = NULL;
+  GVariantBuilder options;
+
+  REQUEST_AUTOLOCK (request);
+
+  impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                                  G_DBUS_PROXY_FLAGS_NONE,
+                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                                  request->id,
+                                                  NULL, &error);
+  if (!impl_request)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
+
+  if (!xdp_filter_options (arg_options, &options,
+                           retrieve_secret_options, G_N_ELEMENTS (retrieve_secret_options),
+                           &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  request_set_impl_request (request, impl_request);
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  xdp_secret_complete_retrieve_secret (object, invocation, NULL, request->id);
+
+  xdp_impl_secret_call_retrieve_secret (impl,
+					request->id,
+					app_id,
+					arg_fd,
+					g_variant_builder_end (&options),
+					fd_list,
+					NULL,
+					retrieve_secret_done,
+					g_object_ref (request));
+
+  return TRUE;
+}
+
+static void
+secret_iface_init (XdpSecretIface *iface)
+{
+  iface->handle_retrieve_secret = handle_retrieve_secret;
+}
+
+static void
+secret_init (Secret *secret)
+{
+  xdp_secret_set_version (XDP_SECRET (secret), 1);
+}
+
+static void
+secret_class_init (SecretClass *klass)
+{
+}
+
+GDBusInterfaceSkeleton *
+secret_create (GDBusConnection *connection,
+	       const char      *dbus_name)
+{
+  g_autoptr(GError) error = NULL;
+
+  impl = xdp_impl_secret_proxy_new_sync (connection,
+					 G_DBUS_PROXY_FLAGS_NONE,
+					 dbus_name,
+					 DESKTOP_PORTAL_OBJECT_PATH,
+					 NULL,
+					 &error);
+  if (impl == NULL)
+    {
+      g_warning ("Failed to create secret proxy: %s", error->message);
+      return NULL;
+    }
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl), G_MAXINT);
+
+  secret = g_object_new (secret_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (secret);
+}

--- a/src/secret.h
+++ b/src/secret.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Daiki Ueno <dueno@redhat.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * secret_create (GDBusConnection *connection,
+					const char *dbus_name);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -54,6 +54,7 @@
 #include "background.h"
 #include "gamemode.h"
 #include "camera.h"
+#include "secret.h"
 
 static GMainLoop *loop = NULL;
 
@@ -287,6 +288,11 @@ on_bus_acquired (GDBusConnection *connection,
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   email_create (connection, implementation->dbus_name));
+
+  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Secret");
+  if (implementation != NULL)
+    export_portal_implementation (connection,
+				  secret_create (connection, implementation->dbus_name));
 
 #if HAVE_PIPEWIRE
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.ScreenCast");


### PR DESCRIPTION
This adds a portal interface to provide sandboxed applications with master secret to locally encrypt credentials.  It works as follows: the application first creates a pipe, sends the write end to the portal, and the portal sends back a secret value through the FD. That way, we can avoid any transport encryption.

If the master secret doesn't exist in keyring, the portal generates a random secret. This step needs to be done with a standard conforming crypto library as the secret is used for encryption. Therefore the backend implementation resides in gnome-keyring.

See also:
- https://gitlab.gnome.org/GNOME/libsecret/merge_requests/6
- https://gitlab.gnome.org/GNOME/gnome-keyring/merge_requests/18

Fixes #14 