### PR TITLE
settings: Expose "org.gnome.desktop.input-sources"

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -287,6 +287,7 @@ init_settings_table (Settings   *self,
     "org.gnome.desktop.wm.preferences",
     "org.gnome.settings-daemon.plugins.xsettings",
     "org.gnome.desktop.a11y",
+    "org.gnome.desktop.input-sources",
   };
   size_t i;
   GSettingsSchemaSource *source = g_settings_schema_source_get_default ();


### PR DESCRIPTION
GNOME Boxes needs access to input-sources so it can propagate the
host default sources to virtual machines that are automatically
created throughout our express-install technology.

See https://gitlab.gnome.org/GNOME/gnome-boxes/blob/master/src/unattended-installer.vala#L684

____________________

I spoke briefly to @matthiasclasen about this in irc #boxes. He said that he was open to discussing the addition of input-sources settings.