### PR TITLE
Implementation of org.freedesktop.portal.FileChooser::SaveFiles

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -211,5 +211,101 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+    <!--
+      SaveFiles:
+      @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
+      @title: Title for the file chooser dialog
+      @options: Vardict with optional further information
+      @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+      Asks for a folder as a location to save one or more files. The
+      names of the files will be used as-is and appended to the
+      selected folder's path in the list of returned files. If the
+      selected folder already contains a file with one of the given
+      names, the portal may prompt or take some other action to
+      construct a unique file name and return that instead.
+
+      Supported keys in the @options vardict include:
+      <variablelist>
+        <varlistentry>
+          <term>handle_token s</term>
+          <listitem><para>
+            A string that will be used as the last element of the
+            @handle. Must be a valid object path element. See the
+            #org.freedesktop.portal.Request documentation for more
+            information about the @handle.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>accept_label s</term>
+          <listitem><para>
+            Label for the accept button. Mnemonic underlines are allowed.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>modal b</term>
+          <listitem><para>
+            Whether the dialog should be modal. Default is yes.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>choices a(ssa(ss)s)</term>
+          <listitem><para>
+            List of serialized combo boxes.
+            See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>current_folder ay</term>
+          <listitem>
+            <para>
+              Suggested folder to save the files in. The byte array is
+              expected to be null-terminated.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+        <term>files aay</term>
+          <listitem>
+            <para>
+              An array of file names to be saved. The array and byte
+              arrays are expected to be null-terminated.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+
+      The following results get returned via the
+      #org.freedesktop.portal.Request::Response signal:
+      <variablelist>
+        <varlistentry>
+          <term>uris as</term>
+          <listitem><para>
+            An array of strings containing the uri corresponding to
+            each file given by @options, in the same order. Note that
+            the file names may have changed, for example if a file
+            with the same name in the selected folder already exists.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>choices a(ss)</term>
+          <listitem><para>
+            An array of pairs of strings, corresponding to the passed-in choices.
+            See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          </para></listitem>
+        </varlistentry>
+      </variablelist>
+    -->
+    <method name="SaveFiles">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="s" name="title" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -250,6 +250,97 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <!--
+      SaveFiles:
+      @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
+      @title: Title for the file chooser dialog
+      @options: Vardict with optional further information
+      @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+      Asks for a folder as a location to save one or more files. The
+      names of the files will be used as-is and appended to the
+      selected folder's path in the list of returned files. If the
+      selected folder already contains a file with one of the given
+      names, the portal may prompt or take some other action to
+      construct a unique file name and return that instead.
+
+      Supported keys in the @options vardict include:
+      <variablelist>
+        <varlistentry>
+          <term>handle_token s</term>
+          <listitem><para>
+            A string that will be used as the last element of the
+            @handle. Must be a valid object path element. See the
+            #org.freedesktop.portal.Request documentation for more
+            information about the @handle.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>accept_label s</term>
+          <listitem><para>
+            Label for the accept button. Mnemonic underlines are allowed.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>modal b</term>
+          <listitem><para>
+            Whether the dialog should be modal. Default is yes.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>choices a(ssa(ss)s)</term>
+          <listitem><para>
+            List of serialized combo boxes.
+            See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>current_folder ay</term>
+          <listitem>
+            <para>
+              Suggested folder to save the files in. The byte array is
+              expected to be null-terminated.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+        <term>files aay</term>
+          <listitem>
+            <para>
+              An array of file names to be saved. The byte arrays are
+              expected to be null-terminated.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+
+      The following results get returned via the
+      #org.freedesktop.portal.Request::Response signal:
+      <variablelist>
+        <varlistentry>
+          <term>uris as</term>
+          <listitem><para>
+            An array of strings containing the uri corresponding to
+            each file given by @options, in the same order. Note that
+            the file names may have changed, for example if a file
+            with the same name in the selected folder already exists.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>choices a(ss)</term>
+          <listitem><para>
+            An array of pairs of strings, corresponding to the passed-in choices.
+            See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          </para></listitem>
+        </varlistentry>
+      </variablelist>
+    -->
+    <method name="SaveFiles">
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="s" name="title" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
     <property name="version" type="u" access="read"/>
   </interface>
 </node>


### PR DESCRIPTION
Adds definition and implementation of org.freedesktop.portal.FileChooser::SaveFiles

The general idea here is to enable applications saving multiple files at once. This is typically done by opening a Save file chooser in "select a folder" mode, but that's not possible to implement securely for sandboxed applications. To address this, the `SaveFiles` method allows the application to specify all of the file names that need to be saved, then forwards these to the implementation portal to have it open a Save file chooser in folder mode. When a folder is selected, the portal sends back a list of absolute URIs being the folder selected joined with the names of each of the given files. The application then is returned a list of files it can write to.

Fixes #158 