### PR TITLE
Handle file not found error from g_file_load_contents

### DIFF
--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -288,7 +288,8 @@ initable_init (GInitable    *initable,
   if (self->gvdb_contents == NULL)
     {
       if (!self->fail_if_not_found &&
-          g_error_matches (my_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+          (g_error_matches (my_error, G_FILE_ERROR, G_FILE_ERROR_NOENT) ||
+           g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND)))
         {
           g_error_free (my_error);
         }


### PR DESCRIPTION
g_file_load_contents returns G_IO_ERROR/G_IO_ERROR_NOT_FOUND if the database doesn't exist.
This only becomes an issue on the NFS path because the non-NFS path doesn't use this call.
Add error handling for this domain/error combination so xdg-document-portal doesn't fail to start.

Fixes #369 