### PR TITLE
gamemode: add pidfd based API

### DIFF
--- a/data/org.freedesktop.portal.GameMode.xml
+++ b/data/org.freedesktop.portal.GameMode.xml
@@ -42,7 +42,7 @@
       'UnregisterGame' method, GameMode will automatically un-register
       the client. This might happen with a (small) delay.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes version 3 of this interface.
     -->
     <interface name="org.freedesktop.portal.GameMode">
       <!--
@@ -146,6 +146,58 @@
       <method name="UnregisterGameByPid">
         <arg type="i" name="target" direction="in"/>
 	<arg type="i" name="requester" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+
+      <!-- PidFd based APIs -->
+      <!--
+          QueryStatusByPIDFd:
+          @target: Pidfd to query the GameMode status of
+          @requester: Pidfd of the process requesting the information
+          @result: The GameMode status for @target
+
+          Query the GameMode status for a process.
+	  Like org.freedesktop.portal.GameMode.QueryStatusByPid() but @requester
+          and @target are pidfds representing the processes.
+      -->
+      <method name="QueryStatusByPIDFd">
+        <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+        <arg type="h" name="target" direction="in"/>
+        <arg type="h" name="requester" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+
+      <!--
+          RegisterGameByPIDFd:
+          @target: Pidfd of the game to register
+          @requester: Pidfd of the process requesting the registration
+          @result: Status of the request: 0 for success, -1 indicates an error
+
+          Register a game with GameMode.
+	  Like org.freedesktop.portal.GameMode.RegisterGameByPid() but @requester
+          and @target are pidfds representing the processes.
+      -->
+      <method name="RegisterGameByPIDFd">
+        <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+        <arg type="h" name="target" direction="in"/>
+	<arg type="h" name="requester" direction="in"/>
+        <arg type="i" name="result" direction="out"/>
+      </method>
+
+      <!--
+          UnregisterGameByPIDFd:
+          @target: Pidfd of the game to un-register
+          @requester: Pidfd of the process requesting the un-registration
+          @result: Status of the request: 0 for success, -1 indicates an error
+
+          Register a game with GameMode.
+	  Like org.freedesktop.portal.GameMode.UnregisterGameByPid() but @requester
+          and @target are pidfds representing the processes.
+      -->
+      <method name="UnregisterGameByPIDFd">
+        <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+        <arg type="h" name="target" direction="in"/>
+	<arg type="h" name="requester" direction="in"/>
         <arg type="i" name="result" direction="out"/>
       </method>
 

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -60,6 +60,11 @@ gboolean    xdg_app_info_map_pids        (XdpAppInfo  *app_info,
 					  pid_t       *pids,
 					  guint        n_pids,
 					  GError     **error);
+gboolean    xdg_app_info_pidfds_to_pids (XdpAppInfo  *app_info,
+                                         const int   *fds,
+                                         pid_t       *pids,
+                                         gint         count,
+                                         GError     **error);
 char *      xdp_app_info_get_path_for_fd (XdpAppInfo  *app_info,
                                           int          fd,
                                           int          require_st_mode,


### PR DESCRIPTION
I created a patchset adding a set of pidfd based D-Bus APIs to gamemode. See PR FeralInteractive/gamemode#173 for more details but the gist of it is that we can avoid the costly mapping operation from the container pidns to the host pidns. 