### PR TITLE
openuri: Add an open directory method

### DIFF
--- a/data/org.freedesktop.portal.OpenURI.xml
+++ b/data/org.freedesktop.portal.OpenURI.xml
@@ -27,7 +27,7 @@
        URIs (e.g. a http: link to the applications homepage)
        under the control of the user.
 
-       This documentation describes version 2 of this interface.
+       This documentation describes version 3 of this interface.
   -->
   <interface name="org.freedesktop.portal.OpenURI">
     <!--
@@ -106,6 +106,37 @@
         The OpenFile method was introduced in version 2 of the OpenURI portal API.
     -->
     <method name="OpenFile">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="h" name="fd" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+        OpenDirectory:
+        @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
+        @fd: File descriptor for a file
+        @options: Vardict with optional further onformation
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Asks to open the directory containing a local file in the file browser.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the @handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Request documentation for
+              more information about the @handle.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        The OpenDirectory method was introduced in version 3 of the OpenURI portal API.
+    -->
+    <method name="OpenDirectory">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="h" name="fd" direction="in"/>


### PR DESCRIPTION
Add an OpenDirectory method that opens the directory
containing a file in the file browser. The use case
for this is e.g. opening a downloads directory.

See https://github.com/flatpak/xdg-desktop-portal/issues/95