### PR TITLE
Make document portal exit on unmount

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -2295,7 +2295,22 @@ xdp_fuse_access (fuse_req_t req, fuse_ino_t ino, int mask)
   fuse_reply_err (req, 0);
 }
 
+extern void on_fuse_unmount (void);
+
+static int destroyed;
+
+static void
+xdp_fuse_destroy (void *userdata)
+{
+  g_debug ("xdp_fuse_destroy");
+
+  destroyed = 1;
+
+  on_fuse_unmount ();
+}
+
 static struct fuse_lowlevel_ops xdp_fuse_oper = {
+  .destroy      = xdp_fuse_destroy,
   .lookup       = xdp_fuse_lookup,
   .forget       = xdp_fuse_forget,
   .getattr      = xdp_fuse_getattr,
@@ -2381,7 +2396,7 @@ xdp_fuse_get_mountpoint (void)
 void
 xdp_fuse_exit (void)
 {
-  if (session)
+  if (!destroyed && session)
     fuse_session_exit (session);
 
   if (fuse_pthread)

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1361,6 +1361,23 @@ on_name_lost (GDBusConnection *connection,
   g_main_loop_quit (loop);
 }
 
+void
+on_fuse_unmount (void)
+{
+  if (!g_main_loop_is_running (loop))
+    return;
+
+  g_debug ("fuse fs unmounted externally");
+
+ if (final_exit_status == 0)
+   final_exit_status = 21;
+
+  if (exit_error == NULL)
+    g_set_error (&exit_error, G_IO_ERROR, G_IO_ERROR_FAILED, "Fuse filesystem unmounted");
+
+  g_main_loop_quit (loop);
+}
+
 static void
 exit_handler (int sig)
 {


### PR DESCRIPTION
Make the document portal exit when the fuse filesystem
is unmounted externally. This should fix 'suddenly stops
working' issues after suspend.