### PR TITLE
open-uri: Revamp the policy

### DIFF
--- a/document-portal/permission-store.c
+++ b/document-portal/permission-store.c
@@ -48,6 +48,7 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
+  g_debug ("Name lost.");
   exit (1);
 }
 

--- a/document-portal/xdg-permission-store.c
+++ b/document-portal/xdg-permission-store.c
@@ -480,6 +480,8 @@ xdg_permission_store_start (GDBusConnection *connection)
   XdgPermissionStore *store;
   GError *error = NULL;
 
+  g_debug ("Starting permission store");
+
   tables = g_hash_table_new_full (g_str_hash, g_str_equal,
                                   g_free, (GDestroyNotify) table_free);
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -142,7 +142,9 @@ get_latest_choice_info (const char *app_id,
 
   if (out_data != NULL)
     {
-      g_variant_lookup (out_data, "always-ask", "b", &ask);
+      g_autoptr(GVariant) data = g_variant_get_child_value (out_data, 0);
+      if (g_variant_is_of_type (data, G_VARIANT_TYPE_VARDICT))
+        g_variant_lookup (data, "always-ask", "b", &ask);
     }
 
   if (out_perms != NULL)

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -83,13 +83,11 @@ static void
 parse_permissions (const char **permissions,
                    char **app_id,
                    gint *app_count,
-                   gint *app_threshold,
-                   gboolean *always_ask)
+                   gint *app_threshold)
 {
   char *perms_id = NULL;
   gint perms_count = 0;
   gint perms_threshold = DEFAULT_THRESHOLD;
-  gboolean perms_always_ask = FALSE;
 
   if ((permissions != NULL) &&
       (permissions[PERM_APP_ID] != NULL) &&
@@ -101,17 +99,13 @@ parse_permissions (const char **permissions,
         {
           g_autofree char *threshold = g_strdup (permissions[PERM_APP_THRESHOLD]);
           if (g_strstrip(threshold)[0] != '\0')
-            {
-              perms_threshold = atoi (permissions[PERM_APP_THRESHOLD]);
-              perms_always_ask = perms_threshold == G_MAXINT;
-            }
+            perms_threshold = atoi (permissions[PERM_APP_THRESHOLD]);
         }
     }
 
   *app_id = perms_id;
   *app_count = perms_count;
   *app_threshold = perms_threshold;
-  *always_ask = perms_always_ask;
 }
 
 static gboolean
@@ -119,13 +113,11 @@ get_latest_choice_info (const char *app_id,
                         const char *content_type,
                         gchar **latest_id,
                         gint *latest_count,
-                        gint *latest_threshold,
-                        gboolean *always_ask)
+                        gint *latest_threshold)
 {
   char *choice_id = NULL;
   gint choice_count = 0;
   gint choice_threshold = DEFAULT_THRESHOLD;
-  gboolean choice_always_ask = FALSE;
   g_autoptr(GError) error = NULL;
   g_autoptr(GVariant) out_perms = NULL;
   g_autoptr(GVariant) out_data = NULL;
@@ -161,7 +153,7 @@ get_latest_choice_info (const char *app_id,
           g_variant_get (child, "{&s^a&s}", &child_app_id, &permissions);
           if (g_strcmp0 (child_app_id, app_id) == 0)
             {
-              parse_permissions (permissions, &choice_id, &choice_count, &choice_threshold, &choice_always_ask);
+              parse_permissions (permissions, &choice_id, &choice_count, &choice_threshold);
               app_found = TRUE;
             }
           g_variant_unref (child);
@@ -171,7 +163,6 @@ get_latest_choice_info (const char *app_id,
   *latest_id = choice_id;
   *latest_count = choice_count;
   *latest_threshold = choice_threshold;
-  *always_ask = choice_always_ask;
 
   return (choice_id != NULL);
 }
@@ -179,10 +170,26 @@ get_latest_choice_info (const char *app_id,
 static gboolean
 is_sandboxed (GDesktopAppInfo *info)
 {
-  g_autofree char *exec;
+  g_autofree char *flatpak = NULL;
 
-  exec = g_desktop_app_info_get_string (info, G_KEY_FILE_DESKTOP_KEY_EXEC);
-  return strstr (exec, "flatpak run ") != NULL;
+  flatpak = g_desktop_app_info_get_string (G_DESKTOP_APP_INFO (info), "X-Flatpak");
+
+  return flatpak != NULL;
+}
+
+static char *
+get_actual_app_id (GAppInfo *info)
+{
+  g_autofree char *flatpak = NULL;
+  const char *desktop_id;
+
+  flatpak = g_desktop_app_info_get_string (G_DESKTOP_APP_INFO (info), "X-Flatpak");
+  desktop_id = g_app_info_get_id (info);
+
+  if (flatpak)
+    return g_steal_pointer (&flatpak);
+  else
+    return g_strndup (desktop_id, strlen (desktop_id) - strlen (".desktop"));
 }
 
 static gboolean
@@ -245,10 +252,9 @@ update_permissions_store (const char *app_id,
   g_autofree char *latest_id = NULL;
   gint latest_count;
   gint latest_threshold;
-  gboolean always_ask;
   g_auto(GStrv) in_permissions = NULL;
 
-  if (get_latest_choice_info (app_id, content_type, &latest_id, &latest_count, &latest_threshold, &always_ask) &&
+  if (get_latest_choice_info (app_id, content_type, &latest_id, &latest_count, &latest_threshold) &&
       (g_strcmp0 (chosen_id, latest_id) == 0))
     {
       /* same app chosen once again: update the counter */
@@ -259,15 +265,14 @@ update_permissions_store (const char *app_id,
     }
   else
     {
-      /* latest_id is heap-allocated */
       latest_id = g_strdup (chosen_id);
-      latest_count = 0;
+      latest_count = 1;
     }
 
   in_permissions = (GStrv) g_new0 (char *, LAST_PERM + 1);
   in_permissions[PERM_APP_ID] = g_strdup (latest_id);
   in_permissions[PERM_APP_COUNT] = g_strdup_printf ("%u", latest_count);
-  in_permissions[PERM_APP_THRESHOLD] = always_ask ? g_strdup ("") : g_strdup_printf ("%u", latest_threshold);
+  in_permissions[PERM_APP_THRESHOLD] = g_strdup_printf ("%u", latest_threshold);
 
   g_debug ("updating permissions for %s: content-type %s, handler %s, count %s / %s",
            app_id,
@@ -431,33 +436,20 @@ can_skip_app_chooser (const char *scheme,
 static void
 find_recommended_choices (const char *scheme,
                           const char *content_type,
+                          char **default_app,
                           GStrv *choices,
-                          gboolean *skip_app_chooser)
+                          guint *choices_len)
 {
-  GAppInfo *default_app = NULL;
+  GAppInfo *info;
   GList *infos, *l;
   guint n_choices = 0;
   GStrv result = NULL;
   int i;
 
-  default_app = g_app_info_get_default_for_type (content_type, FALSE);
-  if (default_app != NULL && can_skip_app_chooser (scheme, content_type))
-    {
-      /* Use the default application if it's set */
-      const char *desktop_id = g_app_info_get_id (default_app);
+  info = g_app_info_get_default_for_type (content_type, FALSE);
+  *default_app = get_actual_app_id (info);
 
-      result = g_new (char *, 2);
-      result[0] = g_strndup (desktop_id, strlen (desktop_id) - strlen (".desktop"));
-      result[1] = NULL;
-
-      *skip_app_chooser = TRUE;
-      *choices = result;
-
-      g_debug ("Using default application %s for %s, %s. Skipping app chooser", result[0], scheme, content_type);
-
-      g_object_unref (default_app);
-      return;
-    }
+  g_debug ("Default handler %s for %s, %s", *default_app, scheme, content_type);
 
   infos = g_app_info_get_recommended_for_type (content_type);
   /* Use fallbacks if we have no recommended application for this type */
@@ -468,28 +460,19 @@ find_recommended_choices (const char *scheme,
   result = g_new (char *, n_choices + 1);
   for (l = infos, i = 0; l; l = l->next)
     {
-      const char *desktop_id;
-
-      GAppInfo *info = l->data;
-      desktop_id = g_app_info_get_id (info);
-      result[i++] = g_strndup (desktop_id, strlen (desktop_id) - strlen (".desktop"));
+      info = l->data;
+      result[i++] = get_actual_app_id (info);
     }
   result[i] = NULL;
   g_list_free_full (infos, g_object_unref);
 
   {
     g_autofree char *a = g_strjoinv (", ", result);
-    g_debug ("Possible handlers for %s, %s: %s", scheme, content_type, a);
+    g_debug ("Recommended handlers for %s, %s: %s", scheme, content_type, a);
   }
 
-  /* We might skip the dialog too if there's only one possible option to handle the URI */
-  if ((n_choices == 1) && can_skip_app_chooser (scheme, content_type))
-    {
-      g_debug ("Skipping app chooser, since only one choice");
-      *skip_app_chooser = TRUE;
-    }
-
   *choices = result;
+  *choices_len = n_choices;
 }
 
 static void
@@ -498,12 +481,13 @@ app_info_changed (GAppInfoMonitor *monitor,
 {
   const char *scheme;
   const char *content_type;
+  g_autofree char *default_app = NULL;
   g_auto(GStrv) choices = NULL;
-  gboolean skip_app_chooser = FALSE;
+  guint n_choices;
 
   scheme = (const char *)g_object_get_data (G_OBJECT (request), "scheme");
   content_type = (const char *)g_object_get_data (G_OBJECT (request), "content-type");
-  find_recommended_choices (scheme, content_type, &choices, &skip_app_chooser);
+  find_recommended_choices (scheme, content_type, &default_app, &choices, &n_choices);
 
   xdp_impl_app_chooser_call_update_choices (impl,
                                             request->id,
@@ -524,20 +508,22 @@ handle_open_in_thread_func (GTask *task,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autofree char *uri = NULL;
   g_autoptr(XdpImplRequest) impl_request = NULL;
+  g_autofree char *default_app = NULL;
   g_auto(GStrv) choices = NULL;
+  guint n_choices;
   g_autofree char *scheme = NULL;
   g_autofree char *content_type = NULL;
   g_autofree char *latest_id = NULL;
   g_autofree char *basename = NULL;
   gint latest_count;
   gint latest_threshold;
-  gboolean always_ask;
   GVariantBuilder opts_builder;
   gboolean skip_app_chooser = FALSE;
   int fd;
   gboolean writable = FALSE;
   gboolean ask = FALSE;
   gboolean open_dir = FALSE;
+  gboolean can_skip = FALSE;
 
   parent_window = (const char *)g_object_get_data (G_OBJECT (request), "parent-window");
   uri = g_strdup ((const char *)g_object_get_data (G_OBJECT (request), "uri"));
@@ -604,37 +590,62 @@ handle_open_in_thread_func (GTask *task,
   g_object_set_data_full (G_OBJECT (request), "scheme", g_strdup (scheme), g_free);
   g_object_set_data_full (G_OBJECT (request), "content-type", g_strdup (content_type), g_free);
 
-  find_recommended_choices (scheme, content_type, &choices, &skip_app_chooser);
-  get_latest_choice_info (app_id, content_type, &latest_id, &latest_count, &latest_threshold, &always_ask);
+  /* collect all the information */
+  find_recommended_choices (scheme, content_type, &default_app, &choices, &n_choices);
+  can_skip = can_skip_app_chooser (scheme, content_type);
+  get_latest_choice_info (app_id, content_type, &latest_id, &latest_count, &latest_threshold);
 
-  if (!ask && ((always_ask && skip_app_chooser) || (!always_ask && (latest_count >= latest_threshold))))
+  /* apply default handling: skip if the we have a default handler and its http or inode/directory */
+  if ((default_app != NULL && can_skip) || n_choices == 1)
+    skip_app_chooser = TRUE;
+
+  /* also skip if the user has made the same choice often enough */
+  if (latest_id != NULL && latest_count >= latest_threshold)
+    skip_app_chooser = TRUE;
+
+  /* respect the app choices */
+  if (ask)
+    skip_app_chooser = FALSE;
+
+  /* respect the users choices: paranoid mode overrides everything else */
+  if (latest_threshold == G_MAXINT)
+    skip_app_chooser = FALSE;
+
+  if (skip_app_chooser)
     {
-      /* If a recommended choice is found, just use it and skip the chooser dialog */
-      gboolean result = launch_application_with_uri (skip_app_chooser ? choices[0] : latest_id,
-                                                     uri,
-                                                     parent_window,
-                                                     writable);
-      if (request->exported)
+      const char *app;
+
+      if (latest_id != NULL)
+        app = latest_id;
+      else if (default_app != NULL)
+        app = default_app;
+      else
+        app = choices[0];
+
+      if (app)
         {
-          g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
-          xdp_request_emit_response (XDP_REQUEST (request),
-                                     result ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
-                                     g_variant_builder_end (&opts_builder));
-          request_unexport (request);
+          /* Launch the app directly */
+
+          gboolean result = launch_application_with_uri (app, uri, parent_window, writable);
+          if (request->exported)
+            {
+              g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
+              xdp_request_emit_response (XDP_REQUEST (request),
+                                         result ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
+                                         g_variant_builder_end (&opts_builder));
+              request_unexport (request);
+            }
+
+          return;
         }
-      return;
     }
 
   g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
 
   if (latest_id != NULL)
-    {
-      /* Add extra options to the request for the backend */
-      g_variant_builder_add (&opts_builder,
-                             "{sv}",
-                             "last_choice",
-                             g_variant_new_string (latest_id));
-    }
+    g_variant_builder_add (&opts_builder, "{sv}", "last_choice", g_variant_new_string (latest_id));
+  else if (default_app != NULL)
+    g_variant_builder_add (&opts_builder, "{sv}", "last_choice", g_variant_new_string (default_app));
 
   g_object_set_data_full (G_OBJECT (request), "content-type", g_strdup (content_type), g_free);
 

--- a/tests/backend/appchooser.c
+++ b/tests/backend/appchooser.c
@@ -51,13 +51,13 @@ send_response (gpointer data)
   if (handle->request->exported)
     request_unexport (handle->request);
 
-  if (handle->choices[0] == NULL)
-    response = 2;
-
   if (response == 0)
     {
-      g_debug ("choice: %s\n", handle->choices[0]);
-      g_variant_builder_add (&opt_builder, "{sv}", "choice", g_variant_new_string (handle->choices[0]));
+      if (handle->choices[0])
+        {
+          g_debug ("choice: %s", handle->choices[0]);
+          g_variant_builder_add (&opt_builder, "{sv}", "choice", g_variant_new_string (handle->choices[0]));
+        }
     }
 
   g_debug ("send response %d", response);

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -43,11 +43,24 @@ set_openuri_permissions (const char *type,
 static void
 unset_openuri_permissions (const char *type)
 {
+  GVariantBuilder data_builder;
+
   xdp_impl_permission_store_call_delete_sync (permission_store,
                                               "desktop-used-apps",
                                               type,
                                               NULL,
                                               NULL);
+
+  /* turn on paranoid mode to ensure we get a backend call */
+  g_variant_builder_init (&data_builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&data_builder, "{sv}", "always-ask", g_variant_new_boolean (TRUE));
+  xdp_impl_permission_store_call_set_value_sync (permission_store,
+                                                 "desktop-used-apps",
+                                                 TRUE,
+                                                 type,
+                                                 g_variant_new_variant (g_variant_builder_end (&data_builder)),
+                                                 NULL,
+                                                 NULL);
   /* Ignore the error here, since this fails if the table doesn't exist */
 }
 

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -29,6 +29,12 @@ set_openuri_permissions (const char *type,
   permissions[2] = threshold_s;
   permissions[3] = NULL;
 
+  xdp_impl_permission_store_call_delete_sync (permission_store,
+                                              "desktop-used-apps",
+                                              type,
+                                              NULL,
+                                              NULL);
+
   xdp_impl_permission_store_call_set_permission_sync (permission_store,
                                                       "desktop-used-apps",
                                                       TRUE,
@@ -43,13 +49,18 @@ set_openuri_permissions (const char *type,
 static void
 unset_openuri_permissions (const char *type)
 {
-  GVariantBuilder data_builder;
-
   xdp_impl_permission_store_call_delete_sync (permission_store,
                                               "desktop-used-apps",
                                               type,
                                               NULL,
                                               NULL);
+  /* Ignore the error here, since this fails if the table doesn't exist */
+}
+
+static void
+enable_paranoid_mode (const char *type)
+{
+  GVariantBuilder data_builder;
 
   /* turn on paranoid mode to ensure we get a backend call */
   g_variant_builder_init (&data_builder, G_VARIANT_TYPE_VARDICT);
@@ -61,7 +72,6 @@ unset_openuri_permissions (const char *type)
                                                  g_variant_new_variant (g_variant_builder_end (&data_builder)),
                                                  NULL,
                                                  NULL);
-  /* Ignore the error here, since this fails if the table doesn't exist */
 }
 
 static void
@@ -114,6 +124,7 @@ test_open_uri_http (void)
   g_autofree char *path = NULL;
 
   unset_openuri_permissions ("x-scheme-handler/http");
+  enable_paranoid_mode ("x-scheme-handler/http");
 
   keyfile = g_key_file_new ();
 
@@ -142,10 +153,20 @@ test_open_uri_http2 (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
   g_autoptr(GAppInfo) app = NULL;
+  g_autofree char *app_id = NULL;
 
   app = g_app_info_get_default_for_type ("x-scheme-handler/http", FALSE);
 
-  set_openuri_permissions ("x-scheme-handler/http", g_app_info_get_id (app), 3, 3);
+  if (app == NULL)
+    {
+      g_test_skip ("No default handler for x-scheme-handler/http set");
+      return;
+    }
+
+  app_id = g_strndup (g_app_info_get_id (app), strlen (g_app_info_get_id (app)) - strlen (".desktop"));
+
+  unset_openuri_permissions ("text/plain");
+  set_openuri_permissions ("x-scheme-handler/http", app_id, 3, 3);
 
   keyfile = g_key_file_new ();
 
@@ -177,6 +198,7 @@ test_open_uri_file (void)
   g_autofree char *uri = NULL;
 
   unset_openuri_permissions ("text/plain");
+  enable_paranoid_mode ("x-scheme-handler/http");
 
   keyfile = g_key_file_new ();
 
@@ -214,6 +236,7 @@ test_open_uri_delay (void)
   g_autofree char *uri = NULL;
 
   unset_openuri_permissions ("text/plain");
+  enable_paranoid_mode ("x-scheme-handler/http");
 
   keyfile = g_key_file_new ();
 
@@ -251,6 +274,7 @@ test_open_uri_cancel (void)
   g_autofree char *uri = NULL;
 
   unset_openuri_permissions ("text/plain");
+  enable_paranoid_mode ("text/plain");
 
   keyfile = g_key_file_new ();
 
@@ -300,6 +324,7 @@ test_open_uri_close (void)
   GCancellable *cancellable;
 
   unset_openuri_permissions ("text/plain");
+  enable_paranoid_mode ("x-scheme-handler/http");
 
   keyfile = g_key_file_new ();
 
@@ -415,6 +440,12 @@ test_open_directory (void)
   keyfile = g_key_file_new ();
 
   app = g_app_info_get_default_for_type ("inode/directory", FALSE);
+
+  if (app == NULL)
+    {
+      g_test_skip ("No default handler for inode/directory set");
+      return;
+    }
 
   g_key_file_set_integer (keyfile, "backend", "delay", 200);
   g_key_file_set_integer (keyfile, "backend", "response", 0);

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -198,7 +198,7 @@ test_open_uri_file (void)
   g_autofree char *uri = NULL;
 
   unset_openuri_permissions ("text/plain");
-  enable_paranoid_mode ("x-scheme-handler/http");
+  enable_paranoid_mode ("text/plain");
 
   keyfile = g_key_file_new ();
 
@@ -236,7 +236,7 @@ test_open_uri_delay (void)
   g_autofree char *uri = NULL;
 
   unset_openuri_permissions ("text/plain");
-  enable_paranoid_mode ("x-scheme-handler/http");
+  enable_paranoid_mode ("text/plain");
 
   keyfile = g_key_file_new ();
 
@@ -324,7 +324,7 @@ test_open_uri_close (void)
   GCancellable *cancellable;
 
   unset_openuri_permissions ("text/plain");
-  enable_paranoid_mode ("x-scheme-handler/http");
+  enable_paranoid_mode ("text/plain");
 
   keyfile = g_key_file_new ();
 


### PR DESCRIPTION
Collect all the code that handles the 'shall we open a dialog'
policy in one place. And tweak the rules we apply slightly, with
the goal of being less annoying by default, while still supporting
paranoid use cases.

By default, we skip the app chooser and directly launch the
default handler for http and inode/directory requests. We also
skip the app chooser if there is only one choice.

Lastly, we skip the app chooser if the last choice he been
selected often enough by the user (the threshold we use here
is 3).

The application can override these defaults by passing the
'ask' open with the OpenURI request. If that option is present,
we always show the app chooser.

The user can override everything by setting the threshold value
in the permission store to the special value 2147483647 (INT_MAX).
If the threshold has this value, we always show the app chooser.