### PR TITLE
Permission store data

### DIFF
--- a/document-portal/xdg-permission-store.c
+++ b/document-portal/xdg-permission-store.c
@@ -436,6 +436,7 @@ handle_set_value (XdgPermissionStore     *object,
 {
   Table *table;
 
+  g_autoptr(GVariant) data_child = NULL;
   g_autoptr(PermissionDbEntry) entry = NULL;
   g_autoptr(PermissionDbEntry) new_entry = NULL;
 
@@ -443,12 +444,14 @@ handle_set_value (XdgPermissionStore     *object,
   if (table == NULL)
     return TRUE;
 
+  data_child = g_variant_get_child_value (data, 0);
+
   entry = permission_db_lookup (table->db, id);
   if (entry == NULL)
     {
       if (create)
         {
-          new_entry = permission_db_entry_new (data);
+          new_entry = permission_db_entry_new (data_child);
         }
       else
         {
@@ -460,7 +463,7 @@ handle_set_value (XdgPermissionStore     *object,
     }
   else
     {
-      new_entry = permission_db_entry_modify_data (entry, data);
+      new_entry = permission_db_entry_modify_data (entry, data_child);
     }
 
   permission_db_set_entry (table->db, id, new_entry);

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -115,7 +115,7 @@ test_open_uri_http (void)
   portal = xdp_portal_new ();
 
   got_info = 0;
-  xdp_portal_open_uri (portal, NULL, "http://www.flatpak.org", FALSE, NULL, open_uri_cb, keyfile);
+  xdp_portal_open_uri (portal, NULL, "http://www.flatpak.org", FALSE, FALSE, NULL, open_uri_cb, keyfile);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
@@ -148,7 +148,7 @@ test_open_uri_http2 (void)
   portal = xdp_portal_new ();
 
   got_info = 0;
-  xdp_portal_open_uri (portal, NULL, "http://www.flatpak.org", FALSE, NULL, open_uri_cb, keyfile);
+  xdp_portal_open_uri (portal, NULL, "http://www.flatpak.org", FALSE, FALSE, NULL, open_uri_cb, keyfile);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
@@ -185,7 +185,7 @@ test_open_uri_file (void)
   uri = g_strconcat ("file://", path, NULL);
 
   got_info = 0;
-  xdp_portal_open_uri (portal, NULL, uri, FALSE, NULL, open_uri_cb, keyfile);
+  xdp_portal_open_uri (portal, NULL, uri, FALSE, FALSE, NULL, open_uri_cb, keyfile);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
@@ -222,7 +222,7 @@ test_open_uri_delay (void)
   uri = g_strconcat ("file://", path, NULL);
 
   got_info = 0;
-  xdp_portal_open_uri (portal, NULL, uri, FALSE, NULL, open_uri_cb, keyfile);
+  xdp_portal_open_uri (portal, NULL, uri, FALSE, FALSE, NULL, open_uri_cb, keyfile);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
@@ -259,7 +259,7 @@ test_open_uri_cancel (void)
   uri = g_strconcat ("file://", path, NULL);
 
   got_info = 0;
-  xdp_portal_open_uri (portal, NULL, uri, FALSE, NULL, open_uri_cb, keyfile);
+  xdp_portal_open_uri (portal, NULL, uri, FALSE, FALSE, NULL, open_uri_cb, keyfile);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
@@ -311,7 +311,7 @@ test_open_uri_close (void)
   uri = g_strconcat ("file://", path, NULL);
 
   got_info = 0;
-  xdp_portal_open_uri (portal, NULL, uri, FALSE, cancellable, open_uri_cb, keyfile);
+  xdp_portal_open_uri (portal, NULL, uri, FALSE, FALSE, cancellable, open_uri_cb, keyfile);
 
   g_timeout_add (100, cancel_call, cancellable);
 
@@ -344,7 +344,7 @@ test_open_uri_lockdown (void)
   portal = xdp_portal_new ();
 
   got_info = 0;
-  xdp_portal_open_uri (portal, NULL, "http://www.flatpak.org", FALSE, NULL, open_uri_cb, keyfile);
+  xdp_portal_open_uri (portal, NULL, "http://www.flatpak.org", FALSE, FALSE, NULL, open_uri_cb, keyfile);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -197,6 +197,59 @@ test_lookup (void)
 }
 
 static void
+test_set_value (void)
+{
+  gboolean res;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GVariant) p = NULL;
+  g_autoptr(GVariant) d = NULL;
+
+  res = xdg_permission_store_call_lookup_sync (permissions,
+                                               "TEST",
+                                               "test-resource",
+                                               &p,
+                                               &d,
+                                               NULL,
+                                               &error);
+  g_assert_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND);
+  g_assert_false (res);
+  g_clear_error (&error);
+
+  res = xdg_permission_store_call_set_value_sync (permissions,
+                                                  "TEST", TRUE,
+                                                  "test-resource",
+                                                  g_variant_new_variant (g_variant_new_boolean (TRUE)),
+                                                  NULL,
+                                                  &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  res = xdg_permission_store_call_lookup_sync (permissions,
+                                               "TEST",
+                                               "test-resource",
+                                               &p,
+                                               &d,
+                                               NULL,
+                                               &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  g_assert_true (g_variant_is_of_type (p, G_VARIANT_TYPE ("a{sas}")));
+  g_assert_cmpint (g_variant_n_children (p), ==, 0);
+  g_assert_true (res);
+  g_assert_true (g_variant_is_of_type (d, G_VARIANT_TYPE_VARIANT));
+  g_assert_true (g_variant_is_of_type (g_variant_get_variant (d), G_VARIANT_TYPE_BOOLEAN));
+  g_assert_true (g_variant_get_boolean (g_variant_get_variant (d)));
+
+  res = xdg_permission_store_call_delete_sync (permissions,
+                                               "TEST",
+                                               "test-resource",
+                                               NULL,
+                                               &error);
+  g_assert_no_error (error);
+}
+
+static void
 test_create1 (void)
 {
   gboolean res;
@@ -510,6 +563,7 @@ main (int argc, char **argv)
   g_test_add_func ("/permissions/delete4", test_delete4);
   g_test_add_func ("/permissions/create1", test_create1);
   g_test_add_func ("/permissions/create2", test_create2);
+  g_test_add_func ("/permissions/set-value", test_set_value);
 
   global_setup ();
 


### PR DESCRIPTION
The Set call is stripping one level of GVariant wrapping
from the data, but SetValue wasn't, leading to extra
wrapping accumulating in the database.
