### PR TITLE
Fix test-portal when installed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ noinst_LTLIBRARIES = $(NULL)
 noinst_SCRIPTS =
 noinst_DATA =
 libexec_PROGRAMS = $(NULL)
+test_extra_programs =
 CLEANFILES = $(NULL)
 DISTCLEANFILES= $(NULL)
 BUILT_SOURCES = $(NULL)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -99,9 +99,11 @@ if ENABLE_INSTALLED_TESTS
 endif
 
 installed_test_dbsdir = $(installed_testdir)/dbs
+installed_test_portalsdir = $(installed_testdir)/portals
 
 if ENABLE_INSTALLED_TESTS
 dist_installed_test_dbs_DATA = tests/dbs/no_tables
+dist_installed_test_portals_DATA = tests/portals/test.portal
 endif
 
 dist_test_scripts = \
@@ -112,10 +114,6 @@ test_programs += \
 	test-doc-portal \
 	test-permission-store \
 	$(NULL)
-
-EXTRA_DIST += \
-        tests/portals/test.portal \
-        $(BNULL)
 
 DISTCLEANFILES += \
 	tests/services/org.freedesktop.portal.Documents.service \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -2,6 +2,7 @@ test_programs =
 
 TESTS_ENVIRONMENT = \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
+	XDP_UNINSTALLED=1 \
 	$(NULL)
 
 testdb_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal -I$(builddir)/
@@ -29,6 +30,7 @@ test_portals_LDADD = \
 	$(LIBPORTAL_LIBS) \
 	$(NULL)
 test_portals_SOURCES = tests/test-portals.c
+test_portals_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(libexecdir)\"
 if HAVE_LIBPORTAL
 test_portals_CFLAGS += $(LIBPORTAL_CFLAGS)
 test_portals_LDADD += $(LIBPORTAL_LIBS)

--- a/tests/backend/Makefile.am.inc
+++ b/tests/backend/Makefile.am.inc
@@ -1,9 +1,9 @@
-test_backends_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
-test_backends_LDADD = \
+tests_test_backends_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
+tests_test_backends_LDADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
 	$(NULL)
-test_backends_SOURCES = \
+tests_test_backends_SOURCES = \
 	tests/backend/test-backends.c \
 	tests/backend/request.h \
 	tests/backend/request.c \
@@ -36,8 +36,10 @@ test_backends_SOURCES = \
         tests/glib-backports.c \
         tests/glib-backports.h \
 	$(NULL)
-nodist_test_backends_SOURCES = src/xdp-impl-dbus.c
+nodist_tests_test_backends_SOURCES = src/xdp-impl-dbus.c
 
-noinst_PROGRAMS += \
-	test-backends \
+# We build this in a tests/ subdirectory so that it can be accessed
+# via G_TEST_BUILT
+test_extra_programs += \
+	tests/test-backends \
 	$(NULL)

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -156,8 +156,13 @@ global_setup (void)
   g_subprocess_launcher_setenv (launcher, "XDG_DESKTOP_PORTAL_DIR", portal_dir, TRUE);
   g_subprocess_launcher_setenv (launcher, "XDG_DATA_HOME", outdir, TRUE);
   g_subprocess_launcher_setenv (launcher, "PATH", g_getenv ("PATH"), TRUE);
- 
-  argv[0] = "xdg-desktop-portal";
+
+  /* When running uninstalled we rely on this being added to PATH */
+  if (g_getenv ("XDP_UNINSTALLED") != NULL)
+    argv[0] = "xdg-desktop-portal";
+  else
+    argv[0] = LIBEXECDIR "/xdg-desktop-portal";
+
   argv[1] = g_test_verbose () ? "--verbose" : NULL;
   argv[2] = NULL;
 
@@ -190,8 +195,13 @@ global_setup (void)
   g_subprocess_launcher_setenv (launcher, "DBUS_SESSION_BUS_ADDRESS", g_test_dbus_get_bus_address (dbus), TRUE);
   g_subprocess_launcher_setenv (launcher, "XDG_DATA_HOME", outdir, TRUE);
   g_subprocess_launcher_setenv (launcher, "PATH", g_getenv ("PATH"), TRUE);
- 
-  argv[0] = "xdg-permission-store";
+
+  /* When running uninstalled we rely on this being added to PATH */
+  if (g_getenv ("XDP_UNINSTALLED") != NULL)
+    argv[0] = "xdg-permission-store";
+  else
+    argv[0] = LIBEXECDIR "/xdg-permission-store";
+
   argv[1] = "--replace";
   argv[2] = g_test_verbose () ? "--verbose" : NULL;
   argv[3] = NULL;

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -76,6 +76,7 @@ static void
 global_setup (void)
 {
   GError *error = NULL;
+  g_autofree gchar *backends_executable = NULL;
   g_autofree gchar *services = NULL;
   g_autofree gchar *portal_dir = NULL;
   g_autoptr(GSubprocessLauncher) launcher = NULL;
@@ -118,7 +119,8 @@ global_setup (void)
   g_subprocess_launcher_setenv (launcher, "XDG_DATA_HOME", outdir, TRUE);
   g_subprocess_launcher_setenv (launcher, "PATH", g_getenv ("PATH"), TRUE);
  
-  argv[0] = "test-backends";
+  backends_executable = g_test_build_filename (G_TEST_BUILT, "test-backends", NULL);
+  argv[0] = backends_executable;
   argv[1] = g_test_verbose () ? "--verbose" : NULL;
   argv[2] = NULL;
 


### PR DESCRIPTION
* tests: Install test-backends
    
    This is necessary for test-portals to work when run as an installed-test.

* tests: When installed, look for executables in libexecdir
    
    They won't normally be in the PATH when installed.

* tests: Install test.portal for installed-tests
    
    Otherwise, when running installed-tests, xdg-desktop-portal will
    find a real installed backend such as xdg-desktop-portals-gtk (if any),
    rather than using the intended test backend. Fixes: #431