### PR TITLE
tests: Fix race condition in various Lockdown tests

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -59,6 +59,8 @@ test_portals_SOURCES += \
 	tests/trash.h \
 	tests/wallpaper.c \
 	tests/wallpaper.h \
+	tests/utils.c \
+	tests/utils.h \
         tests/glib-backports.c \
         tests/glib-backports.h \
 	$(NULL)

--- a/tests/camera.c
+++ b/tests/camera.c
@@ -6,6 +6,8 @@
 #include "src/xdp-utils.h"
 #include "src/xdp-impl-dbus.h"
 
+#include "utils.h"
+
 extern char outdir[];
 
 static int got_info;
@@ -238,7 +240,13 @@ test_camera_lockdown (void)
 
   require_pipewire ();
   reset_camera_permissions ();
-  xdp_impl_lockdown_set_disable_camera (lockdown, TRUE);
+
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-camera",
+                           g_variant_new_boolean (TRUE),
+                           &error);
+  g_assert_no_error (error);
 
   keyfile = g_key_file_new ();
 
@@ -261,7 +269,12 @@ test_camera_lockdown (void)
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
 
-  xdp_impl_lockdown_set_disable_camera (lockdown, FALSE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-camera",
+                           g_variant_new_boolean (FALSE),
+                           &error);
+  g_assert_no_error (error);
 }
 
 /* Test the effect of the user denying the access dialog */

--- a/tests/filechooser.c
+++ b/tests/filechooser.c
@@ -8,6 +8,8 @@
 #include "src/xdp-utils.h"
 #include "src/xdp-impl-dbus.h"
 
+#include "utils.h"
+
 extern XdpImplLockdown *lockdown;
 
 extern char outdir[];
@@ -872,7 +874,12 @@ test_save_file_lockdown (void)
     NULL
   };
 
-  xdp_impl_lockdown_set_disable_save_to_disk (lockdown, TRUE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-save-to-disk",
+                           g_variant_new_boolean (TRUE),
+                           &error);
+  g_assert_no_error (error);
 
   keyfile = g_key_file_new ();
 
@@ -895,7 +902,12 @@ test_save_file_lockdown (void)
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
 
-  xdp_impl_lockdown_set_disable_save_to_disk (lockdown, FALSE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-save-to-disk",
+                           g_variant_new_boolean (FALSE),
+                           &error);
+  g_assert_no_error (error);
 }
 
 void

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -6,6 +6,8 @@
 #include "src/xdp-utils.h"
 #include "src/xdp-impl-dbus.h"
 
+#include "utils.h"
+
 extern XdpImplLockdown *lockdown;
 extern XdpImplPermissionStore *permission_store;
 
@@ -365,7 +367,12 @@ test_open_uri_lockdown (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
-  xdp_impl_lockdown_set_disable_application_handlers (lockdown, TRUE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-application-handlers",
+                           g_variant_new_boolean (TRUE),
+                           &error);
+  g_assert_no_error (error);
 
   keyfile = g_key_file_new ();
 
@@ -387,7 +394,12 @@ test_open_uri_lockdown (void)
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
 
-  xdp_impl_lockdown_set_disable_application_handlers (lockdown, FALSE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-application-handlers",
+                           g_variant_new_boolean (FALSE),
+                           &error);
+  g_assert_no_error (error);
 }
 
 static void

--- a/tests/print.c
+++ b/tests/print.c
@@ -6,6 +6,8 @@
 #include "src/xdp-utils.h"
 #include "src/xdp-impl-dbus.h"
 
+#include "utils.h"
+
 extern XdpImplLockdown *lockdown;
 
 extern char outdir[];
@@ -186,7 +188,12 @@ test_prepare_print_lockdown (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
-  xdp_impl_lockdown_set_disable_printing (lockdown, TRUE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-printing",
+                           g_variant_new_boolean (TRUE),
+                           &error);
+  g_assert_no_error (error);
 
   keyfile = g_key_file_new ();
 
@@ -208,7 +215,12 @@ test_prepare_print_lockdown (void)
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
 
-  xdp_impl_lockdown_set_disable_printing (lockdown, FALSE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-printing",
+                           g_variant_new_boolean (FALSE),
+                           &error);
+  g_assert_no_error (error);
 }
 
 void
@@ -426,7 +438,12 @@ test_print_lockdown (void)
   g_autofree char *path = NULL;
   g_autoptr(GDBusConnection) session_bus = NULL;
 
-  xdp_impl_lockdown_set_disable_printing (lockdown, TRUE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-printing",
+                           g_variant_new_boolean (TRUE),
+                           &error);
+  g_assert_no_error (error);
 
   keyfile = g_key_file_new ();
 
@@ -448,7 +465,12 @@ test_print_lockdown (void)
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
 
-  xdp_impl_lockdown_set_disable_printing (lockdown, FALSE);
+  tests_set_property_sync (G_DBUS_PROXY (lockdown),
+                           "org.freedesktop.impl.portal.Lockdown",
+                           "disable-printing",
+                           g_variant_new_boolean (FALSE),
+                           &error);
+  g_assert_no_error (error);
 }
 
 void

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -1,0 +1,28 @@
+#include <config.h>
+
+#include "utils.h"
+
+/*
+ * Set a property. Unlike gdbus-codegen-generated wrapper functions, this
+ * waits for the property change to take effect.
+ *
+ * If @value is floating, ownership is taken.
+ */
+gboolean
+tests_set_property_sync (GDBusProxy *proxy,
+                         const char *iface,
+                         const char *property,
+                         GVariant *value,
+                         GError **error)
+{
+  g_autoptr (GVariant) res = NULL;
+
+  res = g_dbus_proxy_call_sync (proxy,
+                                "org.freedesktop.DBus.Properties.Set",
+                                g_variant_new ("(ssv)", iface, property, value),
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                error);
+  return (res != NULL);
+}

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <gio/gio.h>
+
+gboolean tests_set_property_sync (GDBusProxy *proxy,
+                                  const char *iface,
+                                  const char *property,
+                                  GVariant *value,
+                                  GError **error);


### PR DESCRIPTION
On the client side, functions like xdp_impl_lockdown_set_disable_printing
initiate an asynchronous property-set operation but do not wait for it
to finish. As a result, if we want other modules to have caught up with
the change, we have to wait for the set to succeed.

Fixes: #394

---

I'm not 100% sure that this fixes the race completely (I'd have to draw a sequence diagram to be sure), but it certainly helps.