### PR TITLE
background: Skip check where app_id is NULL

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -664,6 +664,9 @@ check_background_apps (void)
       app_id = flatpak_instance_get_app (instance);
       idata = g_hash_table_lookup (applications, id);
 
+      if (!app_id)
+        continue;
+
       if (!idata)
         {
           is_new = TRUE;


### PR DESCRIPTION
`flatpak_instance_get_app` returns NULL for sandboxes that don't have an application, but `get_one_app_state` expects a non-NULL app_id. This causes a segfault if a flatpak runtime is being run directly (eg. "flatpak run org.freedesktop.Platform/x86_64/19.08") during `check_background_apps`.

Fixes: 0ad363fe6d8 ("background: Monitor running apps")
Closes: #433