### PR TITLE
src, document-portal: add AssumedAppArmorLabel key to D-Bus service files

### DIFF
--- a/document-portal/org.freedesktop.portal.Documents.service.in
+++ b/document-portal/org.freedesktop.portal.Documents.service.in
@@ -2,3 +2,4 @@
 Name=org.freedesktop.portal.Documents
 Exec=@libexecdir@/xdg-document-portal
 SystemdService=xdg-document-portal.service
+AssumedAppArmorLabel=unconfined

--- a/src/org.freedesktop.portal.Desktop.service.in
+++ b/src/org.freedesktop.portal.Desktop.service.in
@@ -2,3 +2,4 @@
 Name=org.freedesktop.portal.Desktop
 Exec=@libexecdir@/xdg-desktop-portal
 SystemdService=xdg-desktop-portal.service
+AssumedAppArmorLabel=unconfined


### PR DESCRIPTION
Snapd's confinement rules grant access to xdg-desktop-portal through an AppArmor rule that uses the `peer=(label=unconfined)` restriction to indicate that we expect the service to be running outside of the sandbox.  This allows access if xdg-desktop-portal is already running, but fails if it needs to be activated since dbus-daemon doesn't know what security label the service will run as, as described here:

https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-starting-services-apparmor

This branch adds the `AssumedAppArmorLabel=unconfined` key to the service files.  The key is ignored on systems that are not using AppArmor, or where dbus-daemon has been compiled without AppArmor mediation support, so it probably isn't worth making this optional.