### PR TITLE
Don't use AppArmor to detect snap confined clients

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -207,10 +207,27 @@ xdp_app_info_load_app_info (XdpAppInfo *app_info)
 
   g_return_val_if_fail (app_info != NULL, NULL);
 
-  if (app_info->id[0] == '\0')
-    return NULL;
+  switch (app_info->kind)
+    {
+    case XDP_APP_INFO_KIND_FLATPAK:
+      desktop_id = g_strconcat (app_info->id, ".desktop", NULL);
+      break;
 
-  desktop_id = g_strconcat (app_info->id, ".desktop", NULL);
+    case XDP_APP_INFO_KIND_SNAP:
+      desktop_id = g_key_file_get_string (app_info->u.snap.keyfile,
+                                          SNAP_METADATA_GROUP_INFO,
+                                          SNAP_METADATA_KEY_DESKTOP_FILE,
+                                          NULL);
+      break;
+
+    case XDP_APP_INFO_KIND_HOST:
+    default:
+      desktop_id = NULL;
+      break;
+    }
+
+  if (desktop_id == NULL)
+    return NULL;
 
   return G_APP_INFO (g_desktop_app_info_new (desktop_id));
 }

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -339,7 +339,9 @@ xdp_app_info_has_network (XdpAppInfo *app_info)
       break;
 
     case XDP_APP_INFO_KIND_SNAP:
-      has_network = TRUE; /* FIXME */
+      has_network = g_key_file_get_boolean (app_info->u.snap.keyfile,
+                                            SNAP_METADATA_GROUP_INFO,
+                                            SNAP_METADATA_KEY_NETWORK, NULL);
       break;
 
     case XDP_APP_INFO_KIND_HOST:

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -37,6 +37,11 @@
 #define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
 #define FLATPAK_METADATA_KEY_INSTANCE_ID "instance-id"
 
+#define SNAP_METADATA_GROUP_INFO "Snap Info"
+#define SNAP_METADATA_KEY_INSTANCE_NAME "InstanceName"
+#define SNAP_METADATA_KEY_DESKTOP_FILE "DesktopFile"
+#define SNAP_METADATA_KEY_NETWORK "HasNetworkStatus"
+
 gint xdp_mkstempat (int    dir_fd,
                     gchar *tmpl,
                     int    flags,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -178,6 +179,11 @@ gboolean xdp_spawnv     (GFile                *dir,
 char * xdp_canonicalize_filename (const char *path);
 gboolean  xdp_has_path_prefix (const char *str,
                                const char *prefix);
+
+/* exposed for the benefit of tests */
+int _xdp_parse_cgroup_file (FILE     *f,
+                            gboolean *is_snap);
+
 
 #if !GLIB_CHECK_VERSION (2, 58, 0)
 static inline gboolean

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -86,6 +86,12 @@ nodist_test_permission_store_SOURCES = document-portal/permission-store-dbus.c s
 
 EXTRA_test_permission_store_DEPENDENCIES = tests/services/org.freedesktop.impl.portal.PermissionStore.service tests/services/org.freedesktop.portal.Documents.service
 
+test_programs += test-xdp-utils
+test_xdp_utils_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
+test_xdp_utils_LDADD = $(AM_LD_ADD) $(BASE_LIBS)
+test_xdp_utils_SOURCES = tests/test-xdp-utils.c src/xdp-utils.c
+
+
 tests/services/org.freedesktop.portal.Documents.service: document-portal/org.freedesktop.portal.Documents.service.in
 	mkdir -p tests/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" $< > $@

--- a/tests/test-xdp-utils.c
+++ b/tests/test-xdp-utils.c
@@ -1,0 +1,106 @@
+#include "config.h"
+
+#include <glib.h>
+
+#include "src/xdp-utils.h"
+
+static void
+test_parse_cgroup_unified (void)
+{
+  char data[] = "0::/user.slice/user-1000.slice/user@1000.service/apps.slice/snap.something.scope\n";
+  FILE *f;
+  int res;
+  gboolean is_snap = FALSE;
+
+  f = fmemopen(data, sizeof(data), "r");
+
+  res = _xdp_parse_cgroup_file (f, &is_snap);
+  g_assert_cmpint (res, ==, 0);
+  g_assert_true (is_snap);
+  fclose(f);
+}
+
+static void
+test_parse_cgroup_freezer (void)
+{
+  char data[] =
+    "12:pids:/user.slice/user-1000.slice/user@1000.service\n"
+    "11:perf_event:/\n"
+    "10:net_cls,net_prio:/\n"
+    "9:cpuset:/\n"
+    "8:memory:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-228ae109-a869-4533-8988-65ea4c10b492.scope\n"
+    "7:rdma:/\n"
+    "6:devices:/user.slice\n"
+    "5:blkio:/user.slice\n"
+    "4:hugetlb:/\n"
+    "3:freezer:/snap.portal-test\n"
+    "2:cpu,cpuacct:/user.slice\n"
+    "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-228ae109-a869-4533-8988-65ea4c10b492.scope\n"
+    "0::/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-228ae109-a869-4533-8988-65ea4c10b492.scope\n";
+  FILE *f;
+  int res;
+  gboolean is_snap = FALSE;
+
+  f = fmemopen(data, sizeof(data), "r");
+
+  res = _xdp_parse_cgroup_file (f, &is_snap);
+  g_assert_cmpint (res, ==, 0);
+  g_assert_true (is_snap);
+  fclose(f);
+}
+
+static void
+test_parse_cgroup_systemd (void)
+{
+  char data[] = "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/snap.something.scope\n";
+  FILE *f;
+  int res;
+  gboolean is_snap = FALSE;
+
+  f = fmemopen(data, sizeof(data), "r");
+
+  res = _xdp_parse_cgroup_file (f, &is_snap);
+  g_assert_cmpint (res, ==, 0);
+  g_assert_true (is_snap);
+  fclose(f);
+}
+
+static void
+test_parse_cgroup_not_snap (void)
+{
+  char data[] =
+    "12:pids:/\n"
+    "11:perf_event:/\n"
+    "10:net_cls,net_prio:/\n"
+    "9:cpuset:/\n"
+    "8:memory:/\n"
+    "7:rdma:/\n"
+    "6:devices:/\n"
+    "5:blkio:/\n"
+    "4:hugetlb:/\n"
+    "3:freezer:/\n"
+    "2:cpu,cpuacct:/\n"
+    "1:name=systemd:/\n"
+    "0::/\n";
+
+  FILE *f;
+  int res;
+  gboolean is_snap = FALSE;
+
+  f = fmemopen(data, sizeof(data), "r");
+
+  res = _xdp_parse_cgroup_file (f, &is_snap);
+  g_assert_cmpint (res, ==, 0);
+  g_assert_false (is_snap);
+  fclose(f);
+}
+
+int main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/parse-cgroup/unified", test_parse_cgroup_unified);
+  g_test_add_func ("/parse-cgroup/freezer", test_parse_cgroup_freezer);
+  g_test_add_func ("/parse-cgroup/systemd", test_parse_cgroup_systemd);
+  g_test_add_func ("/parse-cgroup/not-snap", test_parse_cgroup_not_snap);
+  return g_test_run ();
+}


### PR DESCRIPTION
At the moment, we detect snaps by checking the AppArmor label, which works well on systems that have AppArmor loaded but fails elsewhere.  This branch attempts to fix that and also provide more information about the snap to xdg-desktop-portal.

The new strategy is as follows:

1. Perform a quick check to see whether the process is snap confined.  At present, this is checking whether the freezer cgroup membership is something snapd would place the process in.  This currently doesn't work for systems with a unified cgroup hierarchy, so will need some changes before landing.

2. If we think the process is a snap, shell out to `snap routine portal-info $pid` to identify the snap.  This will return metadata about the snap in keyfile format.  This means that the exact method of determining the metadata can change with snapd itself, and we can easily add more metadata as needed.

As with the old method, there is minimal overhead for systems not running snap confined processes, and no extra build dependencies.