### PR TITLE
New document-portal fuse backend with directory support

### DIFF
--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -50,7 +50,7 @@
       bus name org.freedesktop.portal.Documents and the object path
       /org/freedesktop/portal/documents.
  
-      This documentation describes version 3 of this interface.
+      This documentation describes version 4 of this interface.
   -->
   <interface name='org.freedesktop.portal.Documents'>
     <property name="version" type="u" access="read"/>
@@ -107,7 +107,7 @@
     <!--
         AddFull:
         @o_path_fds: open file descriptors for the files to export
-        @flags: flags, 1 == reuse_existing, 2 == persistent, 4 == as-needed-by-app
+        @flags: flags, 1 == reuse_existing, 2 == persistent, 4 == as-needed-by-app, 8 = export directory
         @app_id: an application ID, or empty string
         @permissions: the permissions to grant, possible values are 'read', 'write', 'grant-permissions' and 'delete'
         @doc_ids: the IDs of the files in the document store
@@ -130,6 +130,8 @@
         fuse mountpoint of the document portal.
 
         This method was added in version 2 of the org.freedesktop.portal.Documents interface.
+
+        Support for exporting directories were added in version 4 of the org.freedesktop.portal.Documents interface.
     -->
     <method name="AddFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>

--- a/document-portal/document-enums.h
+++ b/document-portal/document-enums.h
@@ -16,8 +16,9 @@ typedef enum {
   DOCUMENT_ADD_FLAGS_REUSE_EXISTING             = (1 << 0),
   DOCUMENT_ADD_FLAGS_PERSISTENT                 = (1 << 1),
   DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP           = (1 << 2),
+  DOCUMENT_ADD_FLAGS_DIRECTORY                  = (1 << 3),
 
-  DOCUMENT_ADD_FLAGS_FLAGS_ALL                  = ((1 << 3) - 1)
+  DOCUMENT_ADD_FLAGS_FLAGS_ALL                  = ((1 << 4) - 1)
 } DocumentAddFullFlags;
 
 G_END_DECLS

--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -15,6 +15,10 @@
 #include <gio/gio.h>
 #include <pthread.h>
 #include <sys/statfs.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include "document-portal-fuse.h"
 #include "document-store.h"
@@ -23,861 +27,129 @@
 #define NON_DOC_DIR_PERMS 0500
 #define DOC_DIR_PERMS 0700
 
-/* TODO: What do we put here */
-#define ATTR_CACHE_TIME 60.0
-#define ENTRY_CACHE_TIME 60.0
-
-/* We pretend that the file is hardlinked. This causes most apps to do
-   a truncating overwrite, which suits us better, as we do the atomic
-   rename ourselves anyway. */
-#define DOC_FILE_NLINK 2
-
-typedef enum {
-  XDP_INODE_ROOT,
-  XDP_INODE_BY_APP,
-  XDP_INODE_APP_DIR, /* app id */
-  XDP_INODE_APP_DOC_DIR, /* app_id + doc id */
-  XDP_INODE_DOC_DIR, /* doc id */
-  XDP_INODE_DOC_FILE, /* doc id (NULL if tmp), name (== basename) */
-} XdpInodeType;
-
-typedef struct _XdpInode XdpInode;
-
-/*
- * Inode Ownership model:
- *
- * XdpInodes are refcounted to track ownership. Anywhere in the code where we keep
- * an inode alive for use we take a ref. These refs are atomic because inodes are
- * threadsafe.
- *
- * In addition to the standard ref-while-using, Some refs are longer-running:
- *  * A single ref is kept on / by root_inode
- *  * A single ref is kept on /by-app by by_app_inode
- *  * Each Inode refs its parent
- *  * Each open file (XdpFile) keeps a ref to the inode, as we need to be able
- *    to read it even if its unlinked.
- *  * Every time we return an inode nr to the kernel in a fuse request (currently only in
- *    lookup() and create()) we take a ref to ensure that the inode is alive while as the kernel
- *    expects it to be. This is freed when the kernel no longer needs it, by the kernel calling
- *    out to xdp_fuse_forget(), or implicitly for all outstanding ones on unmount.
- *  * Inodes for temp files in document dirs have an extra ref to keep them alive until
- *    the corresponding filename is unlinked. See below for details.
- *
- *  Child inode keep their parent alive, so the entire tree from the top to an outstanding inode
- *  is always alive. However, inodes only keep track of the set of children that have a live inode,
- *  using essentially a weak ref. This lazy tracking of the entire fs tree is possible because we
- *  can at any time reconstruct inodes from persistant info we have (i.e. from the document db and
- *  on-disk file info).
- *
- *  However, there are some information that doesn't persist. If you create a file in a document directory
- *  that has a different name than the basename of the document, then that is considered to be a "temp file"
- *  (typically used for a tmpfile which is to be renamed on top of the basename for atomic replace). This file
- *  is backed by a mkstemp file that we keep the fd around for writing. Neither the fd or the backing filename
- *  is persistent, so to avoid forgetting these (which are stored in the inode) we take an extra ref on the
- *  inode that is released when the tmpfile is unlinked.
- */
-struct _XdpInode
-{
-  gint ref_count; /* atomic */
-  gint kernel_ref_count; /* atomic */
-
-  /* These are all immutable */
-  fuse_ino_t   ino;
-  XdpInodeType type;
-  XdpInode    *parent;
-  char        *app_id;
-  char        *doc_id;
-
-  /* For doc dirs */
-  char *basename;
-  char *dirname;
-  dev_t dir_dev;
-  ino_t dir_ino;
-
-  /* mutable data */
-
-  GList   *children; /* lazily filled, protected by inodes lock */
-  char    *filename; /* variable (for non-dirs), null if deleted,
-                        protected by inodes lock *and* mutex */
-  gboolean is_doc; /* True if this is the document file for this dir */
-
-  /* Used when the file is open, protected by mutex */
-  GMutex   mutex; /* Always lock inodes lock (if needed) before mutex */
-  GList   *open_files;
-  int      dir_fd;
-  int      fd; /* RW fd for tempfiles, RO fd for doc files */
-  char    *backing_filename;
-  char    *trunc_filename;
-  int      trunc_fd;
-  gboolean truncated;
-};
-
-typedef struct _XdpFile XdpFile;
-
-struct _XdpFile
-{
-  XdpInode *inode;
-  int       open_mode;
-};
-
-#define ROOT_INODE 1
-#define BY_APP_INODE 2
-#define BY_APP_NAME "by-app"
-
-static GHashTable *dir_to_inode_nr;
-
-static GHashTable *inodes; /* The in memory XdpInode:s, protected by inodes lock */
-static XdpInode *root_inode;
-static XdpInode *by_app_inode;
-static fuse_ino_t next_inode_nr = 3;
-
-G_LOCK_DEFINE (inodes);
-
 static GThread *fuse_thread = NULL;
 static struct fuse_session *session = NULL;
 static struct fuse_chan *main_ch = NULL;
 static char *mount_path = NULL;
 static pthread_t fuse_pthread = 0;
+static uid_t my_uid;
+static gid_t my_gid;
 
-static int
-reopen_fd (int fd, int flags)
-{
-  g_autofree char *path = g_strdup_printf ("/proc/self/fd/%d", fd);
+/* from libfuse */
+#define FUSE_UNKNOWN_INO 0xffffffff
 
-  return open (path, flags | O_CLOEXEC);
-}
+#define BY_APP_NAME "by-app"
 
-/* Call with inodes lock held */
-static fuse_ino_t
-allocate_inode_unlocked (void)
-{
-  fuse_ino_t next = next_inode_nr++;
+typedef struct {
+  ino_t ino;
+  dev_t dev;
+} DevIno;
 
-  /* Bail out on overflow, to avoid reuse */
-  if (next <= 0)
-    g_assert_not_reached ();
+typedef enum {
+ XDP_DOMAIN_ROOT,
+ XDP_DOMAIN_BY_APP,
+ XDP_DOMAIN_APP,
+ XDP_DOMAIN_DOCUMENT,
+} XdpDomainType;
 
-  return next;
-}
+typedef struct _XdpDomain XdpDomain;
 
-static fuse_ino_t
-get_dir_inode_nr_unlocked (const char *app_id, const char *doc_id)
-{
-  gpointer res;
-  fuse_ino_t allocated;
-  g_autofree char *dir = NULL;
+struct _XdpDomain {
+  gint ref_count; /* atomic */
+  XdpDomainType type;
 
-  if (app_id == NULL)
-    {
-      dir = g_strdup (doc_id);
-    }
-  else
-    {
-      if (doc_id == NULL)
-        dir = g_strconcat (app_id, "/", NULL);
-      else
-        dir = g_build_filename (app_id, doc_id, NULL);
-    }
+  XdpDomain *parent;
 
-  res = g_hash_table_lookup (dir_to_inode_nr, dir);
-  if (res != NULL)
-    return (fuse_ino_t) (gsize) res;
+  char *doc_id; /* NULL for root, by-app, app */
+  char *app_id; /* NULL for root, by-app, non-app id */
 
-  allocated = allocate_inode_unlocked ();
-  g_hash_table_insert (dir_to_inode_nr, g_strdup (dir), (gpointer) allocated);
-  return allocated;
-}
+  /* root: by docid
+   * app: by docid
+   * by_app: by app
+   * document: by physical
+   */
+  GHashTable *inodes; /* Protected by domain_inodes */
 
-static fuse_ino_t
-get_dir_inode_nr (const char *app_id, const char *doc_id)
-{
-  XDP_AUTOLOCK (inodes);
-  return get_dir_inode_nr_unlocked (app_id, doc_id);
-}
+  /* Below only used for XDP_DOMAIN_DOCUMENT */
 
-static void
-allocate_app_dir_inode_nr (char **app_ids)
-{
-  int i;
+  char *doc_path; /* path to the directory the files are in */
+  char *doc_file; /* != NULL for non-directory documents */
+  guint64 doc_dir_device;
+  guint64 doc_dir_inode;
+  guint32 doc_flags;
 
-  XDP_AUTOLOCK (inodes);
-  for (i = 0; app_ids[i] != NULL; i++)
-    get_dir_inode_nr_unlocked (app_ids[i], NULL);
-}
+  /* Below is mutable, protected by mutex */
+  GMutex  tempfile_mutex;
+  GHashTable *tempfiles; /* Name -> physical */
+};
 
-static char **
-get_allocated_app_dirs (void)
-{
-  GHashTableIter iter;
-  gpointer key, value;
-  GPtrArray *array = g_ptr_array_new ();
+static void xdp_domain_unref (XdpDomain *domain);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpDomain, xdp_domain_unref)
 
-  XDP_AUTOLOCK (inodes);
-  g_hash_table_iter_init (&iter, dir_to_inode_nr);
-  while (g_hash_table_iter_next (&iter, &key, &value))
-    {
-      const char *name = key;
+G_LOCK_DEFINE (domain_inodes);
 
-      if (g_str_has_suffix (name, "/"))
-        {
-          char *app = strndup (name, strlen (name) - 1);
-          g_ptr_array_add (array, app);
-        }
-    }
-  g_ptr_array_add (array, NULL);
-  return (char **) g_ptr_array_free (array, FALSE);
-}
+typedef struct {
+  gint ref_count; /* atomic */
+  DevIno backing_devino;
+  int fd; /* O_PATH fd */
+} XdpPhysicalInode;
 
-static void xdp_inode_unref_internal (XdpInode *inode,
-                                      gboolean  locked);
+static XdpPhysicalInode *xdp_physical_inode_ref   (XdpPhysicalInode *inode);
+static void              xdp_physical_inode_unref (XdpPhysicalInode *inode);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpPhysicalInode, xdp_physical_inode_unref)
+
+typedef struct {
+  gint ref_count; /* atomic */
+
+  char *name;      /* This changes over time (i.e. in renames)
+                      protected by domain->tempfile_mutex,
+                      used as key in domain->tempfiles */
+  char *tempname;  /* Real filename on disk.
+                      This can be NULLed to avoid unlink at finalize */
+  XdpPhysicalInode *physical;
+  XdpDomain *domain;
+} XdpTempfile;
+
+static XdpTempfile *xdp_tempfile_ref   (XdpTempfile *tempfile);
+static void         xdp_tempfile_unref (XdpTempfile *tempfile);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpTempfile, xdp_tempfile_unref)
+
+typedef struct {
+  gint ref_count; /* atomic, includes kernel_ref_count */
+  gint kernel_ref_count; /* atomic */
+
+  XdpDomain *domain;
+
+  /* The below are only used for XDP_DOMAIN_DOCUMENT inodes */
+  XdpPhysicalInode *physical;
+
+} XdpInode;
+
+typedef struct {
+  int fd;
+} XdpFile;
+
+
+typedef struct {
+  DIR *dir;
+  struct dirent *entry;
+  off_t offset;
+
+  char *dirbuf;
+  gsize dirbuf_size;
+} XdpDir;
+
+XdpInode *root_inode;
+XdpInode *by_app_inode;
+
+static XdpInode *xdp_inode_ref (XdpInode *inode);
 static void xdp_inode_unref (XdpInode *inode);
 
+/* Lookup by inode for verification */
+static GHashTable *all_inodes;
+G_LOCK_DEFINE (all_inodes);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpInode, xdp_inode_unref)
-
-static void
-xdp_inode_destroy (XdpInode *inode, gboolean locked)
-{
-  g_assert (inode->dir_fd == -1);
-  g_assert (inode->fd == -1);
-  g_assert (inode->trunc_fd == -1);
-  g_assert (inode->trunc_filename == NULL);
-  g_assert (inode->children == NULL);
-  xdp_inode_unref_internal (inode->parent, locked);
-  g_free (inode->backing_filename);
-  g_free (inode->filename);
-  g_free (inode->dirname);
-  g_free (inode->app_id);
-  g_free (inode->doc_id);
-  g_free (inode);
-}
-
-static XdpInode *
-xdp_inode_ref (XdpInode *inode)
-{
-  if (inode)
-    g_atomic_int_inc (&inode->ref_count);
-  return inode;
-}
-
-static void
-xdp_inode_unref_internal (XdpInode *inode, gboolean locked)
-{
-  gint old_ref;
-
-  if (inode == NULL)
-    return;
-
-  /* here we want to atomically do: if (ref_count>1) { ref_count--; return; } */
-retry_atomic_decrement1:
-  old_ref = g_atomic_int_get (&inode->ref_count);
-  if (old_ref > 1)
-    {
-      if (!g_atomic_int_compare_and_exchange ((int *) &inode->ref_count, old_ref, old_ref - 1))
-        goto retry_atomic_decrement1;
-    }
-  else
-    {
-      if (old_ref <= 0)
-        {
-          g_warning ("Can't unref dead inode");
-          return;
-        }
-      /* Protect against revival from xdp_inode_lookup() */
-      if (!locked)
-        G_LOCK (inodes);
-      if (!g_atomic_int_compare_and_exchange ((int *) &inode->ref_count, old_ref, old_ref - 1))
-        {
-          if (!locked)
-            G_UNLOCK (inodes);
-          goto retry_atomic_decrement1;
-        }
-
-      g_hash_table_remove (inodes, (gpointer) inode->ino);
-      if (inode->parent)
-        inode->parent->children = g_list_remove (inode->parent->children, inode);
-
-      if (!locked)
-        G_UNLOCK (inodes);
-
-      xdp_inode_destroy (inode, locked);
-    }
-}
-
-static void
-xdp_inode_unref (XdpInode *inode)
-{
-  return xdp_inode_unref_internal (inode, FALSE);
-}
-
-static XdpInode *
-xdp_inode_kernel_ref (XdpInode *inode)
-{
-  if (inode)
-    g_atomic_int_inc (&inode->kernel_ref_count);
-  return xdp_inode_ref (inode);
-}
-
-static void
-xdp_inode_kernel_unref (XdpInode *inode)
-{
-  if (inode)
-    {
-      gint old_ref;
-
-    retry_atomic_decrement1:
-      old_ref = g_atomic_int_get (&inode->kernel_ref_count);
-      if (old_ref <= 0)
-        {
-          g_warning ("Can't kernel_unref inode with no kernel refs");
-          return;
-        }
-      if (!g_atomic_int_compare_and_exchange (&inode->kernel_ref_count, old_ref, old_ref - 1))
-        goto retry_atomic_decrement1;
-    }
-  xdp_inode_unref (inode);
-}
-
-static XdpInode *
-xdp_inode_new_unlocked (fuse_ino_t   ino,
-                        XdpInodeType type,
-                        XdpInode    *parent,
-                        const char  *filename,
-                        const char  *app_id,
-                        const char  *doc_id)
-{
-  XdpInode *inode;
-
-  inode = g_new0 (XdpInode, 1);
-  inode->ino = ino;
-  inode->type = type;
-  inode->parent = xdp_inode_ref (parent);
-  inode->filename = g_strdup (filename);
-  inode->app_id = g_strdup (app_id);
-  inode->doc_id = g_strdup (doc_id);
-  inode->ref_count = 1;
-  inode->dir_fd = -1;
-  inode->fd = -1;
-  inode->trunc_fd = -1;
-
-  if (parent)
-    parent->children = g_list_prepend (parent->children, inode);
-  g_hash_table_insert (inodes, (gpointer) ino, inode);
-
-  return inode;
-}
-
-static XdpInode *
-xdp_inode_new (fuse_ino_t   ino,
-               XdpInodeType type,
-               XdpInode    *parent,
-               const char  *filename,
-               const char  *app_id,
-               const char  *doc_id)
-{
-  XDP_AUTOLOCK (inodes);
-  return xdp_inode_new_unlocked (ino, type, parent, filename, app_id, doc_id);
-}
-
-static void
-xdp_inode_get_path_helper (XdpInode *inode, GString *s)
-{
-  if (inode->parent != NULL)
-    {
-      xdp_inode_get_path_helper (inode->parent, s);
-      if (inode->parent->parent != NULL)
-        g_string_append (s, "/");
-    }
-  if (inode->filename)
-    g_string_append (s, inode->filename);
-  else
-    g_string_append (s, "[deleted]");
-}
-
-static char *
-xdp_inode_get_path (XdpInode *inode)
-{
-  GString *s = g_string_new ("");
-  xdp_inode_get_path_helper (inode, s);
-  return g_string_free (s, FALSE);
-}
-
-static XdpInode *
-xdp_inode_lookup_unlocked (fuse_ino_t inode_nr)
-{
-  XdpInode *inode;
-
-  inode = g_hash_table_lookup (inodes, (gpointer) inode_nr);
-  if (inode != NULL)
-    return xdp_inode_ref (inode);
-  return NULL;
-}
-
-static GList *
-xdp_inode_list_children (XdpInode *inode)
-{
-  GList *list = NULL, *l;
-
-  XDP_AUTOLOCK (inodes);
-  for (l = inode->children; l != NULL; l = l->next)
-    {
-      XdpInode *child = l->data;
-
-      list = g_list_prepend (list, xdp_inode_ref (child));
-    }
-
-  return g_list_reverse (list);
-}
-
-static XdpInode *
-xdp_inode_lookup_child_unlocked (XdpInode *inode, const char *filename)
-{
-  GList *l;
-
-  for (l = inode->children; l != NULL; l = l->next)
-    {
-      XdpInode *child = l->data;
-      if (child->filename != NULL && strcmp (child->filename, filename) == 0)
-        return xdp_inode_ref (child);
-    }
-
-  return NULL;
-}
-
-static XdpInode *
-xdp_inode_lookup_child (XdpInode *inode, const char *filename)
-{
-  XDP_AUTOLOCK (inodes);
-  return xdp_inode_lookup_child_unlocked (inode, filename);
-}
-
-static int
-xdp_inode_open_dir_fd (XdpInode *dir)
-{
-  struct stat st_buf;
-  xdp_autofd int fd = -1;
-
-  g_assert (dir->dirname != NULL);
-
-  fd = open (dir->dirname, O_CLOEXEC | O_PATH | O_DIRECTORY);
-  if (fd == -1)
-    return -1;
-
-  if (fstat (fd, &st_buf) < 0)
-    {
-      errno = ENOENT;
-      return -1;
-    }
-
-  if (st_buf.st_ino != dir->dir_ino ||
-      st_buf.st_dev != dir->dir_dev)
-    {
-      errno = ENOENT;
-      return -1;
-    }
-
-  return xdp_steal_fd (&fd);
-}
-
-static void
-xdp_inode_unlink_backing_files (XdpInode *child_inode, int dir_fd)
-{
-  if (dir_fd == -1)
-    {
-      g_debug ("Can't unlink child inode due to no dir_fd");
-      return;
-    }
-
-  if (child_inode->is_doc)
-    {
-      g_debug ("unlinking doc file %s", child_inode->filename);
-      unlinkat (dir_fd, child_inode->filename, 0);
-      if (child_inode->trunc_filename != NULL)
-        {
-          g_debug ("unlinking doc trunc_file %s", child_inode->trunc_filename);
-          unlinkat (dir_fd, child_inode->trunc_filename, 0);
-        }
-    }
-  else
-    {
-      g_debug ("unlinking tmp_file %s", child_inode->backing_filename);
-      unlinkat (dir_fd, child_inode->backing_filename, 0);
-    }
-}
-
-static void
-xdp_inode_do_unlink (XdpInode *child_inode, int dir_fd, gboolean unlink_backing)
-{
-  if (unlink_backing)
-    xdp_inode_unlink_backing_files (child_inode, dir_fd);
-
-  /* Zero out filename to mark it deleted */
-  g_free (child_inode->filename);
-  child_inode->filename = NULL;
-
-  /* Drop keep-alive-until-unlink ref */
-  if (!child_inode->is_doc)
-    xdp_inode_unref (child_inode);
-}
-
-static XdpInode *
-xdp_inode_unlink_child (XdpInode *dir, const char *filename)
-{
-  XdpInode *child_inode;
-  xdp_autofd int dir_fd = -1;
-
-  XDP_AUTOLOCK (inodes);
-  child_inode = xdp_inode_lookup_child_unlocked (dir, filename);
-  if (child_inode == NULL)
-    return NULL;
-
-  g_assert (child_inode->type == XDP_INODE_DOC_FILE);
-  g_assert (child_inode->filename != NULL);
-
-  /* Here we take *both* the inodes lock and the mutex.
-     The inodes lock is to make this safe against concurrent lookups,
-     but the mutex is to make it safe to access inode->filename inside
-     a mutex-only lock */
-  g_mutex_lock (&child_inode->mutex);
-
-  dir_fd = xdp_inode_open_dir_fd (dir);
-
-  xdp_inode_do_unlink (child_inode, dir_fd, TRUE);
-
-  g_mutex_unlock (&child_inode->mutex);
-
-  return child_inode;
-}
-
-/* Sets errno */
-static int
-xdp_inode_rename_child (XdpInode   *dir,
-                        const char *src_filename,
-                        const char *dst_filename)
-{
-  g_autoptr(XdpInode) src_inode = NULL;
-  g_autoptr(XdpInode) dst_inode = NULL;
-  xdp_autofd int dir_fd = -1;
-  int res;
-
-  XDP_AUTOLOCK (inodes);
-  src_inode = xdp_inode_lookup_child_unlocked (dir, src_filename);
-  if (src_inode == NULL)
-    {
-      errno = ENOENT;
-      return -1;
-    }
-
-  g_assert (src_inode->type == XDP_INODE_DOC_FILE);
-  g_assert (src_inode->filename != NULL);
-
-  dst_inode = xdp_inode_lookup_child_unlocked (dir, dst_filename);
-  if (dst_inode)
-    {
-      g_assert (dst_inode->type == XDP_INODE_DOC_FILE);
-      g_assert (dst_inode->filename != NULL);
-    }
-
-  /* Here we take *both* the inodes lock and the mutex.
-     The inodes lock is to make this safe against concurrent lookups,
-     but the mutex is to make it safe to access inode->filename inside
-     a mutex-only lock */
-  g_mutex_lock (&src_inode->mutex);
-  if (dst_inode)
-    g_mutex_lock (&dst_inode->mutex);
-
-  dir_fd = xdp_inode_open_dir_fd (dir);
-  res = 0;
-
-  if (src_inode->is_doc)
-    {
-      /* doc -> tmp */
-
-      /* We don't want to allow renaming an exiting doc file, because
-         doing so would make a tmpfile of the real doc-file which some
-         host-side app may have open. You have to make a copy and
-         remove instead. */
-      errno = EACCES;
-      res = -1;
-    }
-  else if (strcmp (dst_filename, dir->basename) != 0)
-    {
-      /* tmp -> tmp */
-
-      if (dst_inode)
-        xdp_inode_do_unlink (dst_inode, dir_fd, TRUE);
-
-      g_free (src_inode->filename);
-      src_inode->filename = g_strdup (dst_filename);
-    }
-  else
-    {
-      /* tmp -> doc */
-
-      g_debug ("atomic renaming %s to %s", src_inode->backing_filename, dst_filename);
-      res = renameat (dir_fd, src_inode->backing_filename,
-                      dir_fd, dst_filename);
-      if (res == 0)
-        {
-          if (dst_inode != NULL)
-            {
-              /* Unlink, but don't remove backing files, which are now the new one */
-              xdp_inode_do_unlink (dst_inode, dir_fd, FALSE);
-
-              /* However, unlink trunc_file if its there */
-              if (dst_inode->trunc_filename)
-                unlinkat (dir_fd, dst_inode->trunc_filename, 0);
-            }
-
-          src_inode->is_doc = TRUE;
-          /* Drop keep-alive-until-unlink ref, since we're now is_doc */
-          xdp_inode_unref (src_inode);
-
-          g_free (src_inode->filename);
-          src_inode->filename = g_strdup (dst_filename);
-          g_free (src_inode->backing_filename);
-          src_inode->backing_filename = g_strdup (dst_filename);
-
-          /* Convert ->fd to read-only */
-          if (src_inode->fd != -1)
-            {
-              int new_fd = reopen_fd (src_inode->fd, O_RDONLY);
-              close (src_inode->fd);
-              src_inode->fd = new_fd;
-            }
-
-          /* This neuters any outstanding write files, since we have no trunc_fd at this point.
-             However, that is not really a problem, we would not support them well anyway as
-             a newly opened trunc file would have to have a truncate operation initially for
-             it to work anyway */
-        }
-    }
-
-  g_mutex_unlock (&src_inode->mutex);
-  if (dst_inode)
-    g_mutex_unlock (&dst_inode->mutex);
-
-  return res;
-}
-
-/* NULL if removed */
-static char *
-xdp_inode_get_filename (XdpInode *inode)
-{
-  XDP_AUTOLOCK (inodes);
-  return g_strdup (inode->filename);
-}
-
-static XdpInode *
-xdp_inode_ensure_document_file (XdpInode *dir)
-{
-  XdpInode *inode;
-
-  g_assert (dir->type == XDP_INODE_APP_DOC_DIR || dir->type == XDP_INODE_DOC_DIR);
-
-  XDP_AUTOLOCK (inodes);
-
-  inode = xdp_inode_lookup_child_unlocked (dir, dir->basename);
-  if (inode == NULL)
-    {
-      inode = xdp_inode_new_unlocked (allocate_inode_unlocked (),
-                                      XDP_INODE_DOC_FILE,
-                                      dir,
-                                      dir->basename,
-                                      dir->app_id,
-                                      dir->doc_id);
-      inode->backing_filename = g_strdup (dir->basename);
-      inode->is_doc = TRUE;
-    }
-
-  return inode;
-}
-
-static char *
-create_tmp_for_doc (XdpInode *dir, int dir_fd, int flags, mode_t mode, int *fd_out)
-{
-  g_autofree char *template = g_strconcat (".xdp_", dir->basename, ".XXXXXX", NULL);
-  int fd;
-
-  fd = xdp_mkstempat (dir_fd, template, flags | O_CLOEXEC, mode);
-  if (fd == -1)
-    return NULL;
-
-  g_debug ("Created temp file %s", template);
-  *fd_out = fd;
-  return g_steal_pointer (&template);
-}
-
-/* sets errno */
-static XdpInode *
-xdp_inode_create_file (XdpInode   *dir,
-                       const char *filename,
-                       mode_t      mode,
-                       gboolean    truncate,
-                       gboolean    exclusive)
-{
-  g_autoptr(XdpInode) inode = NULL;
-  g_autofree char *backing_filename = NULL;
-  g_autofree char *trunc_filename = NULL;
-  gboolean is_doc;
-  xdp_autofd int dir_fd = -1;
-  xdp_autofd int fd = -1;
-  xdp_autofd int trunc_fd = -1;
-
-  g_assert (dir->type == XDP_INODE_APP_DOC_DIR || dir->type == XDP_INODE_DOC_DIR);
-
-  XDP_AUTOLOCK (inodes);
-
-  inode = xdp_inode_lookup_child_unlocked (dir, filename);
-  if (inode != NULL)
-    {
-      if (exclusive)
-        {
-          errno = EEXIST;
-          return NULL;
-        }
-
-      if (truncate)
-        {
-          /* TODO: Handle extra truncate for existing file */
-          errno = ENOSYS;
-          return NULL;
-        }
-
-      return g_steal_pointer (&inode);
-    }
-
-  dir_fd = xdp_inode_open_dir_fd (dir);
-  if (dir_fd == -1)
-    return NULL;
-
-  is_doc = strcmp (dir->basename, filename) == 0;
-
-  if (is_doc)
-    {
-      backing_filename = g_strdup (filename);
-      int flags = O_CREAT | O_RDONLY | O_NOFOLLOW | O_CLOEXEC;
-
-      if (exclusive)
-        flags |= O_EXCL;
-
-      g_debug ("Creating doc file %s", dir->basename);
-      fd = openat (dir_fd, dir->basename, flags, mode & 0777);
-      if (fd < 0)
-        return NULL;
-
-      trunc_filename = create_tmp_for_doc (dir, dir_fd, O_RDWR, mode & 0777, &trunc_fd);
-      if (trunc_filename == NULL)
-        return NULL;
-    }
-  else
-    {
-      backing_filename = create_tmp_for_doc (dir, dir_fd, O_RDWR, mode & 0777, &fd);
-      if (backing_filename == NULL)
-        return NULL;
-    }
-
-  inode = xdp_inode_new_unlocked (allocate_inode_unlocked (),
-                                  XDP_INODE_DOC_FILE,
-                                  dir,
-                                  filename,
-                                  dir->app_id,
-                                  dir->doc_id);
-  inode->backing_filename = g_steal_pointer (&backing_filename);
-  inode->trunc_filename = g_steal_pointer (&trunc_filename);
-  inode->is_doc = is_doc;
-  inode->dir_fd = xdp_steal_fd (&dir_fd);
-  inode->fd = xdp_steal_fd (&fd);
-  inode->trunc_fd = xdp_steal_fd (&trunc_fd);
-  if (inode->trunc_fd != -1 && (truncate || exclusive))
-    {
-      inode->truncated = TRUE;
-      g_free (inode->backing_filename);
-      inode->backing_filename = g_strdup (inode->trunc_filename);
-    }
-
-  /* We add an extra ref for tmp files to keep them alive until unlink */
-  if (!is_doc)
-    xdp_inode_ref (inode);
-
-  return g_steal_pointer (&inode);
-}
-
-static XdpInode *
-xdp_inode_lookup (fuse_ino_t inode_nr)
-{
-  XDP_AUTOLOCK (inodes);
-  return xdp_inode_lookup_unlocked (inode_nr);
-}
-
-static XdpInode *
-xdp_inode_get_dir_unlocked (const char *app_id, const char *doc_id, PermissionDbEntry *entry)
-{
-  fuse_ino_t ino;
-  XdpInode *inode;
-  XdpInode *parent = NULL;
-  XdpInodeType type;
-  const char *filename;
-
-  ino = get_dir_inode_nr_unlocked (app_id, doc_id);
-
-  inode = xdp_inode_lookup_unlocked (ino);
-  if (inode)
-    return inode;
-
-  if (app_id == NULL)
-    {
-      g_assert (doc_id != NULL);
-      parent = xdp_inode_ref (root_inode);
-      type = XDP_INODE_DOC_DIR;
-      filename = doc_id;
-    }
-  else
-    {
-      if  (doc_id == NULL)
-        {
-          parent = xdp_inode_ref (by_app_inode);
-          filename = app_id;
-          type = XDP_INODE_APP_DIR;
-        }
-      else
-        {
-          parent = xdp_inode_get_dir_unlocked (app_id, NULL, NULL);
-          filename = doc_id;
-          type = XDP_INODE_APP_DOC_DIR;
-        }
-    }
-
-  inode = xdp_inode_new_unlocked (ino, type, parent, filename, app_id, doc_id);
-  xdp_inode_unref_internal (parent, TRUE);
-
-  if (entry)
-    {
-      inode->basename = document_entry_dup_basename (entry);
-      inode->dirname = document_entry_dup_dirname (entry);
-      inode->dir_ino = document_entry_get_inode (entry);
-      inode->dir_dev = document_entry_get_device (entry);
-    }
-
-  return inode;
-}
-
-static XdpInode *
-xdp_inode_get_dir (const char *app_id, const char *doc_id, PermissionDbEntry *entry)
-{
-  XDP_AUTOLOCK (inodes);
-  return xdp_inode_get_dir_unlocked (app_id, doc_id, entry);
-}
-
-/********************************************************************** \
-* FUSE Implementation
-\***********************************************************************/
-
-static int
-get_user_perms (const struct stat *stbuf)
-{
-  /* Strip out exec and setuid bits */
-  return stbuf->st_mode & 0666;
-}
 
 static gboolean
 app_can_write_doc (PermissionDbEntry *entry, const char *app_id)
@@ -903,959 +175,1033 @@ app_can_see_doc (PermissionDbEntry *entry, const char *app_id)
   return FALSE;
 }
 
-/* Call with mutex held! */
-static int
-xdp_inode_locked_get_fd (XdpInode *inode)
+static char *
+fd_to_path (int fd)
 {
-  if (inode->truncated)
-    return inode->trunc_fd;
-
-  return inode->fd;
+  return g_strdup_printf ("/proc/self/fd/%d", fd);
 }
 
-/* Call with mutex held! */
-static int
-xdp_inode_locked_get_write_fd (XdpInode *inode)
+static char *
+open_flags_to_string (int flags)
 {
-  if (inode->is_doc)
+  GString *s;
+  const char *mode;
+
+  switch (flags & O_ACCMODE)
     {
-      if (!inode->truncated)
-        {
-          errno = ENOSYS;
-          return -1;
-        }
-      return inode->trunc_fd;
-    }
-
-  return inode->fd;
-}
-
-static int
-xdp_inode_stat (XdpInode    *inode,
-                struct stat *stbuf)
-{
-  stbuf->st_ino = inode->ino;
-  stbuf->st_uid = getuid ();
-  stbuf->st_gid = getgid ();
-
-  switch (inode->type)
-    {
-    case XDP_INODE_ROOT:
-    case XDP_INODE_BY_APP:
-    case XDP_INODE_APP_DIR:
-      stbuf->st_mode = S_IFDIR | NON_DOC_DIR_PERMS;
-      stbuf->st_nlink = 2;
+    case O_RDONLY:
+      mode = "RDONLY";
       break;
-
-    case XDP_INODE_DOC_DIR:
-    case XDP_INODE_APP_DOC_DIR:
-      stbuf->st_mode = S_IFDIR | DOC_DIR_PERMS;
-      stbuf->st_nlink = 2;
+    case O_WRONLY:
+      mode = "WRONLY";
       break;
-
-    case XDP_INODE_DOC_FILE:
-      {
-        g_autoptr(PermissionDbEntry) entry = NULL;
-        struct stat tmp_stbuf;
-        gboolean can_see, can_write;
-        int fd, res, errsv;
-
-        entry = xdp_lookup_doc (inode->doc_id);
-        if (entry == NULL)
-          {
-            errno = ENOENT;
-            return -1;
-          }
-
-        can_see = app_can_see_doc (entry, inode->app_id);
-        can_write = app_can_write_doc (entry, inode->app_id);
-
-        if (!can_see)
-          {
-            errno = ENOENT;
-            return -1;
-          }
-
-        g_mutex_lock (&inode->mutex);
-
-        fd = xdp_inode_locked_get_fd (inode);
-        if (fd != -1)
-          {
-            res = fstat (fd, &tmp_stbuf);
-          }
-        else
-          {
-            xdp_autofd int dir_fd = xdp_inode_open_dir_fd (inode->parent);
-
-            if (dir_fd == -1)
-              res = -1;
-            else
-              res = fstatat (dir_fd, inode->backing_filename,
-                             &tmp_stbuf, AT_SYMLINK_NOFOLLOW);
-          }
-        errsv = errno;
-
-        g_mutex_unlock (&inode->mutex);
-
-        if (res != 0)
-          {
-            errno = errsv;
-            return -1;
-          }
-
-        stbuf->st_mode = S_IFREG | get_user_perms (&tmp_stbuf);
-        if (!can_write)
-          stbuf->st_mode &= ~(0222);
-        stbuf->st_size = tmp_stbuf.st_size;
-        stbuf->st_uid = tmp_stbuf.st_uid;
-        stbuf->st_gid = tmp_stbuf.st_gid;
-        stbuf->st_blksize = tmp_stbuf.st_blksize;
-        stbuf->st_blocks = tmp_stbuf.st_blocks;
-        stbuf->st_atim = tmp_stbuf.st_atim;
-        stbuf->st_mtim = tmp_stbuf.st_mtim;
-        stbuf->st_ctim = tmp_stbuf.st_ctim;
-        stbuf->st_nlink = 1;
-      }
-      break;
-
+    case O_RDWR:
     default:
-      g_assert_not_reached ();
+      mode = "RDWR";
+      break;
     }
 
-  return 0;
+  s = g_string_new (mode);
+
+  if (flags & O_NONBLOCK)
+    g_string_append (s, ",NONBLOCK");
+  if (flags & O_APPEND)
+    g_string_append (s, ",APPEND");
+  if (flags & O_SYNC)
+    g_string_append (s, ",SYNC");
+  if (flags & O_ASYNC)
+    g_string_append (s, ",ASYNC");
+  if (flags & O_FSYNC)
+    g_string_append (s, ",FSYNC");
+  if (flags & O_DSYNC)
+    g_string_append (s, ",DSYNC");
+  if (flags & O_CREAT)
+    g_string_append (s, ",CREAT");
+  if (flags & O_TRUNC)
+    g_string_append (s, ",TRUNC");
+  if (flags & O_EXCL)
+    g_string_append (s, ",EXCL");
+  if (flags & O_CLOEXEC)
+    g_string_append (s, ",CLOEXEC");
+  if (flags & O_DIRECT)
+    g_string_append (s, ",DIRECT");
+  if (flags & O_LARGEFILE)
+    g_string_append (s, ",LARGEFILE");
+  if (flags & O_NOATIME)
+    g_string_append (s, ",NOATIME");
+  if (flags & O_NOCTTY)
+    g_string_append (s, ",NOCTTY");
+  if (flags & O_PATH)
+    g_string_append (s, ",PATH");
+  if (flags & O_TMPFILE)
+    g_string_append (s, ",TMPFILE");
+
+  return g_string_free (s, FALSE);
 }
 
-static void
-xdp_fuse_lookup (fuse_req_t  req,
-                 fuse_ino_t  parent,
-                 const char *name)
+
+static char *
+setattr_flags_to_string (int flags)
 {
-  g_autoptr(XdpInode) parent_inode = NULL;
-  struct fuse_entry_param e = {0};
-  g_autoptr(XdpInode) child_inode = NULL;
-  g_autoptr(PermissionDbEntry) entry = NULL;
+  GString *s = g_string_new ("");
 
-  g_debug ("xdp_fuse_lookup %lx/%s -> ", parent, name);
+  if (flags & FUSE_SET_ATTR_MODE)
+    g_string_append (s, "MODE,");
 
-  parent_inode = xdp_inode_lookup (parent);
-  if (parent_inode == NULL)
-    {
-      g_debug ("xdp_fuse_lookup <- error parent ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
+  if (flags & FUSE_SET_ATTR_UID)
+    g_string_append (s, "UID,");
 
-  /* Default */
-  e.attr_timeout = ATTR_CACHE_TIME;
-  e.entry_timeout = ENTRY_CACHE_TIME;
+  if (flags & FUSE_SET_ATTR_GID)
+    g_string_append (s, "GID,");
 
-  switch (parent_inode->type)
-    {
-    case XDP_INODE_ROOT:
-      if (strcmp (name, BY_APP_NAME) == 0)
-        {
-          child_inode = xdp_inode_ref (by_app_inode);
-        }
-      else
-        {
-          entry = xdp_lookup_doc (name);
-          if (entry != NULL)
-            child_inode = xdp_inode_get_dir (NULL, name, entry);
-        }
-      break;
+  if (flags & FUSE_SET_ATTR_SIZE)
+    g_string_append (s, "SIZE,");
 
-    case XDP_INODE_BY_APP:
-      /* This lazily creates the app dir */
-      if (xdp_is_valid_app_id (name))
-        child_inode = xdp_inode_get_dir (name, NULL, NULL);
-      break;
+  if (flags & FUSE_SET_ATTR_ATIME)
+    g_string_append (s, "ATIME,");
 
-    case XDP_INODE_APP_DIR:
-      entry = xdp_lookup_doc (name);
-      if (entry != NULL &&
-          app_can_see_doc (entry, parent_inode->app_id))
-        child_inode = xdp_inode_get_dir (parent_inode->app_id, name, entry);
-      break;
+  if (flags & FUSE_SET_ATTR_MTIME)
+    g_string_append (s, "MTIME,");
 
-    case XDP_INODE_APP_DOC_DIR:
-    case XDP_INODE_DOC_DIR:
-      {
-        g_autoptr(XdpInode) doc_inode = NULL;
-        entry = xdp_lookup_doc (parent_inode->doc_id);
-        if (entry == NULL)
-          {
-            g_debug ("xdp_fuse_lookup <- error no parent entry ENOENT");
-            fuse_reply_err (req, ENOENT);
-            return;
-          }
+  if (flags & FUSE_SET_ATTR_ATIME_NOW)
+    g_string_append (s, "ATIME_NOW,");
 
-        /* Ensure it is alive at least during lookup_child () */
-        doc_inode = xdp_inode_ensure_document_file (parent_inode);
+  if (flags & FUSE_SET_ATTR_MTIME_NOW)
+    g_string_append (s, "MTIME_NOW,");
 
-        child_inode = xdp_inode_lookup_child (parent_inode, name);
+  /* Remove last comma */
+  if (s->len > 0)
+    g_string_truncate (s, s->len - 1);
 
-        /* We verify in the stat below if the backing file exists */
-
-        /* Files can be changed from outside the fuse fs, so don't cache any data */
-        e.attr_timeout = 0;
-        e.entry_timeout = 0;
-      }
-      break;
-
-    case XDP_INODE_DOC_FILE:
-      g_debug ("xdp_fuse_lookup <- ENOTDIR");
-      fuse_reply_err (req, ENOTDIR);
-      return;
-
-    default:
-      break;
-    }
-
-  if (child_inode == NULL)
-    {
-      g_debug ("xdp_fuse_lookup <- error child ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  if (xdp_inode_stat (child_inode, &e.attr) != 0)
-    {
-      int errsv = errno;
-      g_debug ("xdp_fuse_lookup <- errno from stat %s", strerror (errsv));
-      fuse_reply_err (req, errsv);
-      return;
-    }
-
-  e.ino = child_inode->ino;
-
-  g_debug ("xdp_fuse_lookup <- inode %lx", (long) e.ino);
-  xdp_inode_kernel_ref (child_inode); /* Ref given to the kernel, returned in xdp_fuse_forget() */
-  fuse_reply_entry (req, &e);
+  return g_string_free (s, FALSE);
 }
 
-static void
-xdp_fuse_forget (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup)
+static guint
+devino_hash  (gconstpointer  key)
 {
-  g_autoptr(XdpInode) inode = NULL;
-  g_debug ("xdp_fuse_forget %lx %ld -> ", ino, nlookup);
+  DevIno *devino = (DevIno *)key;
 
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
+  return (devino->ino >> 2) ^ devino->dev;
+}
+
+static gboolean
+devino_equal (gconstpointer  _a,
+              gconstpointer  _b)
+{
+  DevIno *a = (DevIno *)_a;
+  DevIno *b = (DevIno *)_b;
+  return a->ino == b->ino && a->dev == b->dev;
+}
+
+/* Lookup by physical backing devino */
+static GHashTable *physical_inodes;
+G_LOCK_DEFINE (physical_inodes);
+
+
+/* Takes ownership of the o_path fd if passed in */
+static XdpPhysicalInode *
+ensure_physical_inode (dev_t dev, ino_t ino, int o_path_fd)
+{
+  DevIno devino = {ino, dev};
+  XdpPhysicalInode *inode = NULL;
+
+  G_LOCK (physical_inodes);
+
+  inode = g_hash_table_lookup (physical_inodes, &devino);
+  if (inode != NULL)
     {
-      g_warning ("xdp_fuse_forget, unknown inode");
+      inode = xdp_physical_inode_ref (inode);
+      close (o_path_fd);
     }
   else
     {
-      while (nlookup > 0)
-        {
-          xdp_inode_kernel_unref (inode);
-          nlookup--;
-        }
+      /* Takes ownership of fd */
+      inode = g_new0 (XdpPhysicalInode, 1);
+      inode->ref_count = 1;
+      inode->fd = o_path_fd;
+      inode->backing_devino = devino;
+      g_hash_table_insert (physical_inodes, &inode->backing_devino, inode);
     }
 
-  fuse_reply_none (req);
+  G_UNLOCK (physical_inodes);
+
+  return inode;
 }
 
-struct dirbuf
+static XdpPhysicalInode *
+xdp_physical_inode_ref (XdpPhysicalInode *inode)
 {
-  char  *p;
-  size_t size;
-};
-
-static void
-dirbuf_add (fuse_req_t     req,
-            struct dirbuf *b,
-            const char    *name,
-            fuse_ino_t     ino,
-            mode_t         mode)
-{
-  struct stat stbuf;
-
-  size_t oldsize = b->size;
-
-  b->size += fuse_add_direntry (req, NULL, 0, name, NULL, 0);
-  b->p = (char *) g_realloc (b->p, b->size);
-  memset (&stbuf, 0, sizeof (stbuf));
-  stbuf.st_ino = ino;
-  stbuf.st_mode = mode;
-  fuse_add_direntry (req, b->p + oldsize,
-                     b->size - oldsize,
-                     name, &stbuf,
-                     b->size);
+  g_atomic_int_inc (&inode->ref_count);
+  return inode;
 }
 
 static void
-dirbuf_add_docs (fuse_req_t     req,
-                 struct dirbuf *b,
-                 const char    *app_id)
+xdp_physical_inode_unref (XdpPhysicalInode *inode)
 {
-  g_auto(GStrv) docs = NULL;
-  fuse_ino_t ino;
-  int i;
+  gint old_ref;
 
-  docs = xdp_list_docs ();
-  for (i = 0; docs[i] != NULL; i++)
+  /* here we want to atomically do: if (ref_count>1) { ref_count--; return; } */
+retry_atomic_decrement1:
+  old_ref = g_atomic_int_get (&inode->ref_count);
+  if (old_ref > 1)
     {
-      if (app_id)
-        {
-          g_autoptr(PermissionDbEntry) entry = xdp_lookup_doc (docs[i]);
-          if (entry == NULL ||
-              !app_can_see_doc (entry, app_id))
-            continue;
-        }
-      ino = get_dir_inode_nr (app_id, docs[i]);
-      dirbuf_add (req, b, docs[i], ino, S_IFDIR);
-    }
-}
-
-static int
-reply_buf_limited (fuse_req_t  req,
-                   const char *buf,
-                   size_t      bufsize,
-                   off_t       off,
-                   size_t      maxsize)
-{
-  if (off < bufsize)
-    return fuse_reply_buf (req, buf + off,
-                           MIN (bufsize - off, maxsize));
-  else
-    return fuse_reply_buf (req, NULL, 0);
-}
-
-static void
-xdp_fuse_readdir (fuse_req_t req, fuse_ino_t ino, size_t size,
-                  off_t off, struct fuse_file_info *fi)
-{
-  struct dirbuf *b = (struct dirbuf *) (gsize) (fi->fh);
-
-  reply_buf_limited (req, b->p, b->size, off, size);
-}
-
-static void
-xdp_fuse_opendir (fuse_req_t             req,
-                  fuse_ino_t             ino,
-                  struct fuse_file_info *fi)
-{
-  g_autoptr(XdpInode) inode = NULL;
-  struct dirbuf b = {0};
-
-  g_debug ("xdp_fuse_opendir %lx", ino);
-
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
-    {
-      g_debug ("xdp_fuse_opendir <- error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  switch (inode->type)
-    {
-    case XDP_INODE_ROOT:
-      dirbuf_add (req, &b, ".", ROOT_INODE, S_IFDIR);
-      dirbuf_add (req, &b, "..", ROOT_INODE, S_IFDIR);
-      dirbuf_add (req, &b, BY_APP_NAME, BY_APP_INODE, S_IFDIR);
-      dirbuf_add_docs (req, &b, NULL);
-      break;
-
-    case XDP_INODE_BY_APP:
-      {
-        g_auto(GStrv) db_app_ids = NULL;
-        g_auto(GStrv) app_ids = NULL;
-        int i;
-
-        dirbuf_add (req, &b, ".", BY_APP_INODE, S_IFDIR);
-        dirbuf_add (req, &b, "..", ROOT_INODE, S_IFDIR);
-
-        /* Ensure that all apps from db are allocated */
-        db_app_ids = xdp_list_apps ();
-        allocate_app_dir_inode_nr (db_app_ids);
-
-        /* But return all allocated dirs. We might have app dirs
-           that have no permissions, and are thus not in the db */
-        app_ids = get_allocated_app_dirs ();
-        for (i = 0; app_ids[i] != NULL; i++)
-          dirbuf_add (req, &b, app_ids[i],
-                      get_dir_inode_nr (app_ids[i], NULL), S_IFDIR);
-      }
-      break;
-
-    case XDP_INODE_APP_DIR:
-      dirbuf_add (req, &b, ".", inode->ino, S_IFDIR);
-      dirbuf_add (req, &b, "..", BY_APP_INODE, S_IFDIR);
-      dirbuf_add_docs (req, &b, inode->app_id);
-      break;
-
-    case XDP_INODE_DOC_FILE:
-      fuse_reply_err (req, ENOTDIR);
-      break;
-
-    case XDP_INODE_APP_DOC_DIR:
-    case XDP_INODE_DOC_DIR:
-      {
-        GList *children, *l;
-        g_autoptr(XdpInode) doc_inode = NULL;
-        g_autoptr(PermissionDbEntry) entry = NULL;
-
-        entry = xdp_lookup_doc (inode->doc_id);
-        if (entry == NULL)
-          {
-            fuse_reply_err (req, ENOENT);
-            break;
-          }
-
-        dirbuf_add (req, &b, ".", inode->ino, S_IFDIR);
-        dirbuf_add (req, &b, "..", inode->parent->ino, S_IFDIR);
-
-        /* Ensure it is alive at least during list_children () */
-        doc_inode = xdp_inode_ensure_document_file (inode);
-
-        children = xdp_inode_list_children (inode);
-
-        for (l = children; l != NULL; l = l->next)
-          {
-            struct stat stbuf;
-            XdpInode *child = l->data;
-            g_autofree char *filename = xdp_inode_get_filename (child);
-            if (filename != NULL && xdp_inode_stat (child, &stbuf) == 0)
-              dirbuf_add (req, &b, filename, child->ino, stbuf.st_mode);
-            xdp_inode_unref (child);
-          }
-        g_list_free (children);
-      }
-      break;
-
-    default:
-      g_assert_not_reached ();
-    }
-
-  if (b.p != NULL)
-    {
-      fi->fh = (gsize) g_memdup (&b, sizeof (b));
-      if (fuse_reply_open (req, fi) == -ENOENT)
-        {
-          g_free (b.p);
-          g_free ((gpointer) (gsize) (fi->fh));
-        }
-    }
-}
-
-static void
-xdp_fuse_releasedir (fuse_req_t             req,
-                     fuse_ino_t             ino,
-                     struct fuse_file_info *fi)
-{
-  struct dirbuf *b = (struct dirbuf *) (gsize) (fi->fh);
-
-  g_free (b->p);
-  g_free (b);
-  fuse_reply_err (req, 0);
-}
-
-
-
-static void
-xdp_fuse_getattr (fuse_req_t             req,
-                  fuse_ino_t             ino,
-                  struct fuse_file_info *fi)
-{
-  g_autoptr(XdpInode) inode = NULL;
-  struct stat stbuf = { 0 };
-
-  g_debug ("xdp_fuse_getattr %lx (fi=%p)", ino, fi);
-
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
-    {
-      g_debug ("xdp_fuse_getattr <- lookup error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  if (xdp_inode_stat (inode,  &stbuf) != 0)
-    {
-      int errsv = errno;
-      g_debug ("xdp_fuse_getattr <- stat error %s", g_strerror (errsv));
-      fuse_reply_err (req, errsv);
-      return;
-    }
-
-  g_debug ("xdp_fuse_getattr <- OK");
-  fuse_reply_attr (req, &stbuf, ATTR_CACHE_TIME);
-}
-
-static void
-xdp_fuse_fsyncdir (fuse_req_t             req,
-                   fuse_ino_t             ino,
-                   int                    datasync,
-                   struct fuse_file_info *fi)
-{
-  g_autoptr(XdpInode) inode = NULL;
-
-  g_debug ("xdp_fuse_fsyncdir %lx %p", ino, fi);
-
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
-    {
-      g_debug ("xdp_fuse_fsyncdir <- error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  if (inode->type == XDP_INODE_APP_DOC_DIR ||
-      inode->type == XDP_INODE_DOC_DIR)
-    {
-      g_autoptr(PermissionDbEntry) entry =  xdp_lookup_doc (inode->doc_id);
-      if (entry != NULL)
-        {
-          g_autofree char *dirname = document_entry_dup_dirname (entry);
-          int fd = open (dirname, O_DIRECTORY | O_RDONLY);
-          if (fd >= 0)
-            {
-              if (datasync)
-                fdatasync (fd);
-              else
-                fsync (fd);
-              close (fd);
-            }
-        }
-    }
-
-  fuse_reply_err (req, 0);
-}
-
-static XdpFile *
-xdp_file_new (XdpInode *inode,
-              int       open_mode)
-{
-  XdpFile *file = g_new (XdpFile, 1);
-
-  file->inode = xdp_inode_ref (inode);
-  file->open_mode = open_mode;
-
-  return file;
-}
-
-/* Call with mutex held */
-static void
-xdp_inode_locked_close_unneeded_fds (XdpInode *inode)
-{
-  gboolean has_open_for_write = FALSE;
-  GList *l;
-
-  for (l = inode->open_files; l != NULL; l = l->next)
-    {
-      XdpFile *file = l->data;
-
-      if (file->open_mode != O_RDONLY)
-        {
-          has_open_for_write = TRUE;
-          break;
-        }
-    }
-
-  if (!has_open_for_write)
-    {
-      if (inode->truncated)
-        {
-          if (inode->open_files != NULL && inode->fd != -1)
-            {
-              /* We're not going to close the ->fd, so we repoint it to the trunc_fd, but reopened O_RDONLY */
-              close (inode->fd);
-              inode->fd = reopen_fd (inode->trunc_fd, O_RDONLY);
-            }
-
-          if (inode->filename != NULL)
-            {
-              /* not removed, replace original */
-              fsync (inode->trunc_fd);
-              g_free (inode->backing_filename);
-              inode->backing_filename = g_strdup (inode->filename);
-              g_debug ("moving %s to %s", inode->trunc_filename, inode->backing_filename);
-              if (renameat (inode->dir_fd, inode->trunc_filename,
-                            inode->dir_fd, inode->backing_filename) != 0)
-                g_warning ("Unable to replace truncated document: %s", g_strerror (errno));
-            }
-
-          inode->truncated = FALSE;
-        }
-      else if (inode->trunc_filename != NULL)
-        {
-          unlinkat (inode->dir_fd, inode->trunc_filename, 0);
-          g_debug ("unlinked truc_filename %s", inode->trunc_filename);
-        }
-
-      if (inode->trunc_fd != -1)
-        {
-          close (inode->trunc_fd);
-          inode->trunc_fd = -1;
-          g_free (inode->trunc_filename);
-          inode->trunc_filename = NULL;
-        }
-    }
-
-  if (inode->open_files == NULL)
-    {
-      if (inode->fd != -1)
-        {
-          close (inode->fd);
-          inode->fd = -1;
-        }
-
-      if (inode->dir_fd != -1)
-        {
-          close (inode->dir_fd);
-          inode->dir_fd = -1;
-        }
-    }
-}
-
-static void
-xdp_file_free (XdpFile *file)
-{
-  XdpInode *inode = file->inode;
-
-  g_mutex_lock (&inode->mutex);
-  inode->open_files = g_list_remove (inode->open_files, file);
-
-  xdp_inode_locked_close_unneeded_fds (inode);
-
-  g_mutex_unlock (&inode->mutex);
-  xdp_inode_unref (inode);
-  g_free (file);
-}
-
-/* sets errno */
-static int
-xdp_inode_locked_ensure_fd_open (XdpInode       *inode,
-                                 PermissionDbEntry *entry,
-                                 gboolean        for_write)
-{
-  /* Ensure all fds are open */
-  if (inode->dir_fd == -1)
-    {
-      inode->dir_fd = xdp_inode_open_dir_fd (inode->parent);
-      if (inode->dir_fd == -1)
-        return -1;
-    }
-
-  if (for_write)
-    {
-      if (faccessat (inode->dir_fd, inode->backing_filename, W_OK, 0) != 0)
-        return -1;
-    }
-
-  if (inode->fd == -1)
-    {
-      int mode = O_NOFOLLOW | O_CLOEXEC;
-
-      if (inode->is_doc)
-        mode |= O_RDONLY;
-      else
-        mode |= O_RDWR;
-
-      inode->fd = openat (inode->dir_fd, inode->backing_filename, mode);
-      if (inode->fd < 0)
-        return -1;
-    }
-
-  if (inode->is_doc && for_write && inode->trunc_fd == -1)
-    {
-      struct stat st_buf;
-      mode_t mode = 0600;
-
-      if (fstat (inode->fd, &st_buf) == 0)
-        mode = get_user_perms (&st_buf);
-
-      g_assert (inode->trunc_filename == NULL);
-      inode->trunc_filename = create_tmp_for_doc (inode->parent, inode->dir_fd, O_RDWR, mode,
-                                                  &inode->trunc_fd);
-      if (inode->trunc_filename == NULL)
-        return -1;
-    }
-
-  return 0;
-}
-
-static void
-xdp_fuse_open (fuse_req_t             req,
-               fuse_ino_t             ino,
-               struct fuse_file_info *fi)
-{
-  g_autoptr(XdpInode) inode = NULL;
-  g_autoptr(PermissionDbEntry) entry = NULL;
-  gboolean can_write;
-  int open_mode;
-  XdpFile *file = NULL;
-  int errsv;
-
-  g_debug ("xdp_fuse_open %lx flags %o", ino, fi->flags);
-
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
-    {
-      g_debug ("xdp_fuse_open <- no inode error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  if (inode->type != XDP_INODE_DOC_FILE)
-    {
-      g_debug ("xdp_fuse_open <- error EISDIR");
-      fuse_reply_err (req, EISDIR);
-      return;
-    }
-
-  entry = xdp_lookup_doc (inode->doc_id);
-  if (entry == NULL ||
-      !app_can_see_doc (entry, inode->app_id))
-    {
-      g_debug ("xdp_fuse_open <- no entry error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  can_write = app_can_write_doc (entry, inode->app_id);
-
-  open_mode = fi->flags & 3;
-
-  if (open_mode != O_RDONLY && !can_write)
-    {
-      g_debug ("xdp_fuse_open <- no write EACCES");
-      fuse_reply_err (req, EACCES);
-      return;
-    }
-
-  g_mutex_lock (&inode->mutex);
-
-  if (xdp_inode_locked_ensure_fd_open (inode, entry,
-                                       open_mode != O_RDONLY) == 0)
-    {
-      file = xdp_file_new (inode, open_mode);
-      inode->open_files = g_list_prepend (inode->open_files, file);
-      errsv = 0;
+      if (!g_atomic_int_compare_and_exchange ((int *) &inode->ref_count, old_ref, old_ref - 1))
+        goto retry_atomic_decrement1;
     }
   else
     {
-      errsv = errno;
-      xdp_inode_locked_close_unneeded_fds (inode);
-    }
-
-  g_mutex_unlock (&inode->mutex);
-
-  if (file != NULL)
-    {
-      fi->fh = (gsize) file;
-      g_debug ("xdp_fuse_open <- OK");
-      if (fuse_reply_open (req, fi) != 0)
-        xdp_file_free (file);
-    }
-  else
-    {
-      g_debug ("xdp_fuse_open <- errno %s", strerror (errsv));
-      fuse_reply_err (req, errsv);
-    }
-}
-
-
-static void
-xdp_fuse_create (fuse_req_t             req,
-                 fuse_ino_t             parent,
-                 const char            *filename,
-                 mode_t                 mode,
-                 struct fuse_file_info *fi)
-{
-  g_autoptr(XdpInode) parent_inode = NULL;
-  g_autoptr(PermissionDbEntry) entry = NULL;
-  struct fuse_entry_param e = {0};
-  gboolean can_see, can_write;
-  int open_mode;
-  XdpFile *file = NULL;
-  g_autoptr(XdpInode) inode = NULL;
-  int errsv;
-
-  g_debug ("xdp_fuse_create %lx/%s, flags %o", parent, filename, fi->flags);
-
-  parent_inode = xdp_inode_lookup (parent);
-  if (parent_inode == NULL)
-    {
-      g_debug ("xdp_fuse_create <- error parent ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  if (parent_inode->type == XDP_INODE_DOC_FILE)
-    {
-      g_debug ("xdp_fuse_create <- error parent ENOTDIR");
-      fuse_reply_err (req, ENOTDIR);
-      return;
-    }
-
-  if (parent_inode->type != XDP_INODE_APP_DOC_DIR &&
-      parent_inode->type != XDP_INODE_DOC_DIR)
-    {
-      g_debug ("xdp_fuse_create <- error parent EACCES");
-      fuse_reply_err (req, EACCES);
-      return;
-    }
-
-  entry = xdp_lookup_doc (parent_inode->doc_id);
-  if (entry == NULL)
-    {
-      g_debug ("xdp_fuse_create <- error no document ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  can_see = app_can_see_doc (entry, parent_inode->app_id);
-  if (!can_see)
-    {
-      g_debug ("xdp_fuse_create <- error can't see ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  can_write = app_can_write_doc (entry, parent_inode->app_id);
-  if (!can_write)
-    {
-      g_debug ("xdp_fuse_create <- error can't write EACCESS");
-      fuse_reply_err (req, EACCES);
-      return;
-    }
-
-  inode = xdp_inode_create_file (parent_inode, filename,
-                                 mode,
-                                 (fi->flags & O_TRUNC) != 0,
-                                 (fi->flags & O_EXCL) != 0);
-  if (inode == NULL)
-    {
-      int errsv = errno;
-      g_debug ("xdp_fuse_create <- error create_file %s", strerror (errsv));
-      fuse_reply_err (req, errsv);
-      return;
-    }
-
-  g_mutex_lock (&inode->mutex);
-
-  open_mode = fi->flags & 3;
-
-  if (xdp_inode_locked_ensure_fd_open (inode, entry,
-                                       open_mode != O_RDONLY) == 0)
-    {
-      file = xdp_file_new (inode, open_mode);
-      inode->open_files = g_list_prepend (inode->open_files, file);
-      errsv = 0;
-    }
-  else
-    {
-      errsv = errno;
-      xdp_inode_locked_close_unneeded_fds (inode);
-    }
-
-  g_mutex_unlock (&inode->mutex);
-
-  if (file != NULL)
-    {
-      if (xdp_inode_stat (inode, &e.attr) != 0)
+      if (old_ref <= 0)
         {
-          int errsv = errno;
-          g_debug ("xdp_fuse_create <- error inode_stat %s", strerror (errsv));
-          xdp_file_free (file);
-          fuse_reply_err (req, errsv);
+          g_warning ("Can't unref dead inode");
           return;
         }
 
-      e.ino = inode->ino;
-      e.attr_timeout = 0;
-      e.entry_timeout = 0;
+      /* Might be revived from physical_inodes hash by this time, so protect by lock */
+      G_LOCK (physical_inodes);
 
-      xdp_inode_kernel_ref (inode); /* Ref given to the kernel, returned in xdp_fuse_forget() */
-
-      g_debug ("xdp_fuse_create <- OK inode %lx", e.ino);
-
-      fi->fh = (gsize) file;
-      if (fuse_reply_create (req, &e, fi) != 0)
+      if (!g_atomic_int_compare_and_exchange ((int *) &inode->ref_count, old_ref, old_ref - 1))
         {
-          g_debug ("xdp_fuse_create - failed to send reply");
-          xdp_file_free (file);
-          xdp_inode_unref (inode);
+          G_UNLOCK (physical_inodes);
+          goto retry_atomic_decrement1;
         }
-    }
-  else
-    {
-      g_debug ("xdp_fuse_create <- error ensure_fd_open %s", strerror (errsv));
-      fuse_reply_err (req, errsv);
+      g_hash_table_remove (physical_inodes, &inode->backing_devino);
+
+      G_UNLOCK (physical_inodes);
+
+      close (inode->fd);
+      g_free (inode);
     }
 }
 
-static void
-xdp_fuse_read (fuse_req_t             req,
-               fuse_ino_t             ino,
-               size_t                 size,
-               off_t                  off,
-               struct fuse_file_info *fi)
+static XdpDomain *
+xdp_domain_ref (XdpDomain *domain)
 {
-  XdpFile *file = (gpointer) (gsize) fi->fh;
-  XdpInode *inode = file->inode;
-  struct fuse_bufvec bufv = FUSE_BUFVEC_INIT (size);
-  int fd;
-
-  g_debug ("xdp_fuse_read %lx %ld %ld", ino, (long) size, (long) off);
-
-  g_mutex_lock (&inode->mutex);
-
-  fd = xdp_inode_locked_get_fd (inode);
-  if (fd == -1)
-    {
-      static char c = 'x';
-      bufv.buf[0].flags = 0;
-      bufv.buf[0].mem = &c;
-      bufv.buf[0].size = 0;
-
-      fuse_reply_data (req, &bufv, FUSE_BUF_NO_SPLICE);
-    }
-  else
-    {
-      bufv.buf[0].flags = FUSE_BUF_IS_FD | FUSE_BUF_FD_SEEK;
-      bufv.buf[0].fd = fd;
-      bufv.buf[0].pos = off;
-
-      fuse_reply_data (req, &bufv, FUSE_BUF_SPLICE_MOVE);
-    }
-
-  g_mutex_unlock (&inode->mutex);
+  g_atomic_int_inc (&domain->ref_count);
+  return domain;
 }
 
 static void
-xdp_fuse_release (fuse_req_t             req,
-                  fuse_ino_t             ino,
-                  struct fuse_file_info *fi)
+xdp_domain_unref (XdpDomain *domain)
 {
-  XdpFile *file = (gpointer) (gsize) fi->fh;
+  if (g_atomic_int_dec_and_test (&domain->ref_count))
+    {
+      g_free (domain->doc_id);
+      g_free (domain->app_id);
+      g_free (domain->doc_path);
+      g_free (domain->doc_file);
+      if (domain->inodes)
+        g_assert (g_hash_table_size (domain->inodes) == 0);
+      g_clear_pointer (&domain->inodes, g_hash_table_unref);
+      g_clear_pointer (&domain->parent, xdp_domain_unref);
+      g_clear_pointer (&domain->tempfiles, g_hash_table_unref);
+      g_mutex_clear (&domain->tempfile_mutex);
+      g_free (domain);
+    }
+}
 
-  g_debug ("xdp_fuse_release %lx (fi=%p)", ino, fi);
+static gboolean
+xdp_domain_is_virtual_type (XdpDomain *domain)
+{
+  return
+    domain->type == XDP_DOMAIN_ROOT ||
+    domain->type == XDP_DOMAIN_BY_APP ||
+    domain->type == XDP_DOMAIN_APP;
+}
 
-  xdp_file_free (file);
-  fuse_reply_err (req, 0);
+static XdpDomain *
+_xdp_domain_new (XdpDomainType type)
+{
+  XdpDomain *domain = g_new0 (XdpDomain, 1);
+  domain->ref_count = 1;
+  domain->type = type;
+  g_mutex_init (&domain->tempfile_mutex);
+  return domain;
+}
+
+static XdpDomain *
+xdp_domain_new_root (void)
+{
+  XdpDomain *domain = _xdp_domain_new (XDP_DOMAIN_ROOT);
+  domain->inodes = g_hash_table_new (g_str_hash, g_str_equal);
+  return domain;
+}
+
+static XdpDomain *
+xdp_domain_new_by_app (XdpDomain *root_domain)
+{
+  XdpDomain *domain = _xdp_domain_new (XDP_DOMAIN_BY_APP);
+  domain->parent = xdp_domain_ref (root_domain);
+  domain->inodes = g_hash_table_new (g_str_hash, g_str_equal);
+  return domain;
+}
+
+static XdpDomain *
+xdp_domain_new_app (XdpDomain *parent,
+                    const char *app_id)
+{
+  XdpDomain *domain = _xdp_domain_new (XDP_DOMAIN_APP);
+  domain->parent = xdp_domain_ref (parent);
+  domain->app_id = g_strdup (app_id);
+  domain->inodes = g_hash_table_new (g_str_hash, g_str_equal);
+  return domain;
+}
+
+static XdpDomain *
+xdp_domain_new_document (XdpDomain *parent,
+                         const char *doc_id,
+                         PermissionDbEntry *doc_entry)
+{
+  XdpDomain *domain = _xdp_domain_new (XDP_DOMAIN_DOCUMENT);
+  const char *db_path;
+
+  domain->parent = xdp_domain_ref (parent);
+  domain->doc_id = g_strdup (doc_id);
+  domain->app_id = g_strdup (parent->app_id);
+  domain->inodes = g_hash_table_new (g_direct_hash, g_direct_equal);
+
+  domain->doc_flags = document_entry_get_flags (doc_entry);
+  domain->doc_dir_device = document_entry_get_device (doc_entry);
+  domain->doc_dir_inode =  document_entry_get_inode (doc_entry);
+
+  db_path = document_entry_get_path (doc_entry);
+  if (domain->doc_flags & DOCUMENT_ENTRY_FLAG_DIRECTORY)
+    domain->doc_path = g_strdup (db_path);
+  else
+    {
+      domain->doc_path = g_path_get_dirname (db_path);
+      domain->doc_file = g_path_get_basename (db_path);
+    }
+
+  domain->tempfiles = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, (GDestroyNotify)xdp_tempfile_unref);
+
+  return domain;
+}
+
+static gboolean
+xdp_document_domain_can_see (XdpDomain *domain)
+{
+  if (domain->app_id != NULL)
+    {
+      g_autoptr(PermissionDbEntry) entry = xdp_lookup_doc (domain->doc_id);
+
+      if (entry == NULL ||
+          !app_can_see_doc (entry, domain->app_id))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+xdp_document_domain_can_write (XdpDomain *domain)
+{
+  if (domain->app_id != NULL)
+    {
+      g_autoptr(PermissionDbEntry) entry = xdp_lookup_doc (domain->doc_id);
+
+      if (entry == NULL ||
+          !app_can_write_doc (entry, domain->app_id))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static char **
+xdp_domain_get_inode_keys_as_string (XdpDomain *domain)
+{
+  char **res;
+  guint length, i;
+
+  g_assert (domain->type == XDP_DOMAIN_BY_APP);
+
+  G_LOCK (domain_inodes);
+
+  res = (char **)g_hash_table_get_keys_as_array (domain->inodes, &length);
+  for (i = 0; i < length; i++)
+    res[i] = g_strdup (res[i]);
+
+  G_UNLOCK (domain_inodes);
+
+  return res;
+}
+
+static XdpTempfile *
+xdp_tempfile_ref (XdpTempfile *tempfile)
+{
+  g_atomic_int_inc (&tempfile->ref_count);
+  return tempfile;
+}
+
+static XdpTempfile *
+xdp_tempfile_new (XdpDomain  *domain,
+                  const char *name,
+                  const char *tempname)
+{
+  XdpTempfile *tempfile = g_new0 (XdpTempfile, 1);
+
+  tempfile->ref_count = 1;
+  tempfile->domain = xdp_domain_ref (domain);
+  tempfile->name = g_strdup (name);
+  tempfile->tempname = g_strdup (tempname);
+
+  return tempfile;
+}
+
+static void
+xdp_tempfile_unref (XdpTempfile *tempfile)
+{
+  if (g_atomic_int_dec_and_test (&tempfile->ref_count))
+    {
+      if (tempfile->tempname)
+        {
+          g_autofree char *temppath = g_build_filename (tempfile->domain->doc_path, tempfile->tempname, NULL);
+          (void)unlink (temppath);
+        }
+      g_free (tempfile->name);
+      g_free (tempfile->tempname);
+      xdp_domain_unref (tempfile->domain);
+      g_clear_pointer (&tempfile->physical, xdp_physical_inode_unref);
+      g_free (tempfile);
+    }
+}
+
+static XdpInode *
+_xdp_inode_new (void)
+{
+  XdpInode *inode = g_new0 (XdpInode, 1);
+  inode->ref_count = 1;
+  inode->kernel_ref_count = 0;
+
+  G_LOCK (all_inodes);
+  g_hash_table_insert (all_inodes, inode, inode);
+  G_UNLOCK (all_inodes);
+  return inode;
+}
+
+/* takes ownership of fd */
+static XdpInode *
+xdp_inode_new (XdpDomain *domain,
+               XdpPhysicalInode *physical)
+{
+  XdpInode *inode = _xdp_inode_new ();
+  inode->domain = xdp_domain_ref (domain);
+
+  if (physical)
+    inode->physical = xdp_physical_inode_ref (physical);
+
+  return inode;
+}
+
+static ino_t
+xdp_inode_to_ino (XdpInode *inode)
+{
+  if (inode == root_inode)
+    return FUSE_ROOT_ID;
+  return (ino_t)(gsize) inode;
+}
+
+/* Use if we don't know that the inode exists (i.e. when we didn't get
+   it from the kernel fuse apis) after this you need to verify with
+   all_inodes lookup */
+static XdpInode *
+_xdp_inode_from_maybe_ino (ino_t ino)
+{
+  XdpInode *inode;
+
+  if (ino == FUSE_ROOT_ID)
+    inode = root_inode;
+  else
+    inode = (XdpInode *)ino;
+
+  return inode;
+}
+
+static XdpInode *
+xdp_inode_from_ino (ino_t ino)
+{
+  XdpInode *inode = _xdp_inode_from_maybe_ino (ino);
+
+  return xdp_inode_ref (inode);
+}
+
+static XdpInode *
+xdp_inode_ref (XdpInode *inode)
+{
+  g_atomic_int_inc (&inode->ref_count);
+  return inode;
+}
+
+static void
+xdp_inode_unref (XdpInode *inode)
+{
+  gint old_ref;
+  XdpDomain *domain;
+
+  /* here we want to atomically do: if (ref_count>1) { ref_count--; return; } */
+retry_atomic_decrement1:
+  old_ref = g_atomic_int_get (&inode->ref_count);
+  if (old_ref > 1)
+    {
+      if (!g_atomic_int_compare_and_exchange ((int *) &inode->ref_count, old_ref, old_ref - 1))
+        goto retry_atomic_decrement1;
+    }
+  else
+    {
+      if (old_ref <= 0)
+        {
+          g_warning ("Can't unref dead inode");
+          return;
+        }
+
+      /* Might be revived from domain->inodes hash by this time, so protect by lock */
+      G_LOCK (domain_inodes);
+
+      if (!g_atomic_int_compare_and_exchange ((int *) &inode->ref_count, old_ref, old_ref - 1))
+        {
+          G_UNLOCK (domain_inodes);
+          goto retry_atomic_decrement1;
+        }
+
+      domain = inode->domain;
+
+      if (domain->type == XDP_DOMAIN_APP)
+        g_hash_table_remove (domain->parent->inodes, domain->app_id);
+      else if (domain->type == XDP_DOMAIN_DOCUMENT)
+        {
+          if (inode->physical)
+            g_hash_table_remove (domain->inodes, inode->physical);
+          else
+            g_hash_table_remove (domain->parent->inodes, domain->doc_id);
+        }
+
+      G_UNLOCK (domain_inodes);
+
+      /* This doesn't allow ressurection (but can read inode data) */
+      G_LOCK (all_inodes);
+      g_hash_table_remove (all_inodes, inode);
+      G_UNLOCK (all_inodes);
+
+      g_clear_pointer (&inode->physical, xdp_physical_inode_unref);
+      xdp_domain_unref (inode->domain);
+      g_free (inode);
+    }
+
+}
+
+static XdpInode *
+xdp_inode_kernel_ref (XdpInode *inode)
+{
+  g_atomic_int_inc (&inode->kernel_ref_count);
+  return xdp_inode_ref (inode);
+}
+
+static void
+xdp_inode_kernel_unref (XdpInode *inode)
+{
+  gint old_ref;
+
+ retry_atomic_decrement1:
+  old_ref = g_atomic_int_get (&inode->kernel_ref_count);
+  if (old_ref <= 0)
+    {
+      g_warning ("Can't kernel_unref inode with no kernel refs");
+      return;
+    }
+  if (!g_atomic_int_compare_and_exchange (&inode->kernel_ref_count, old_ref, old_ref - 1))
+    goto retry_atomic_decrement1;
+
+  xdp_inode_unref (inode);
 }
 
 static int
-truncateat (int dir_fd, const char *filename, int size)
+verify_doc_dir_devino (int dirfd, XdpDomain *doc_domain)
+{
+  struct stat buf;
+
+  if (fstat (dirfd, &buf) != 0)
+    return -errno;
+
+  if (buf.st_ino != doc_domain->doc_dir_inode ||
+      buf.st_dev != doc_domain->doc_dir_device)
+    return -ENOENT;
+
+  return 0;
+ }
+
+/* Only for toplevel dirs */
+static int
+xdp_nonphysical_document_inode_opendir (XdpInode *inode)
+{
+  XdpDomain *domain = inode->domain;
+  xdp_autofd int dirfd = -1;
+  int res;
+
+  g_assert (domain->type == XDP_DOMAIN_DOCUMENT);
+  g_assert (inode->physical == NULL);
+
+  dirfd = open (domain->doc_path, O_PATH | O_DIRECTORY);
+  if (dirfd < 0)
+    return -errno;
+
+  res = verify_doc_dir_devino (dirfd, domain);
+  if (res != 0)
+    return res;
+
+  return xdp_steal_fd (&dirfd);
+}
+
+static int
+xdp_document_inode_ensure_dirfd (XdpInode *inode,
+                                 int *close_fd_out)
+{
+  int close_fd;
+
+  g_assert (inode->domain->type == XDP_DOMAIN_DOCUMENT);
+
+  *close_fd_out = -1;
+
+  if (inode->physical)
+    return inode->physical->fd;
+  else
+    {
+      close_fd = xdp_nonphysical_document_inode_opendir (inode);
+      if (close_fd < 0)
+        return close_fd;
+
+      *close_fd_out = close_fd;
+      return close_fd;
+    }
+}
+
+static int
+xdp_document_inode_open_self_fd (XdpInode *inode, int open_flags, mode_t mode)
+{
+  XdpDomain *domain = inode->domain;
+  int dirfd, fd;
+  xdp_autofd int close_fd = -1;
+
+  g_assert (domain->type == XDP_DOMAIN_DOCUMENT);
+
+  dirfd = xdp_document_inode_ensure_dirfd (inode, &close_fd);
+  if (dirfd < 0)
+    return dirfd;
+
+  fd = openat (dirfd, ".", open_flags, mode);
+  if (fd < 0)
+    return -errno;
+
+  return fd;
+}
+
+static gboolean
+open_flags_has_write (int open_flags)
+{
+  return
+    (open_flags & O_ACCMODE) == O_WRONLY ||
+    (open_flags & O_ACCMODE) == O_RDWR ||
+    open_flags & O_TRUNC;
+}
+
+static void
+gen_temp_name (gchar *tmpl)
+{
+  g_return_if_fail (tmpl != NULL);
+  const size_t len = strlen (tmpl);
+  g_return_if_fail (len >= 6);
+
+  static const char letters[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  static const int NLETTERS = sizeof (letters) - 1;
+
+  char *XXXXXX = tmpl + (len - 6);
+  for (int i = 0; i < 6; i++)
+    XXXXXX[i] = letters[g_random_int_range(0, NLETTERS)];
+}
+
+static int
+open_temp_at (int    dirfd,
+              const char *orig_name,
+              char **name_out,
+              mode_t mode)
 {
   int fd;
-  int errsv, res;
+  int errsv;
+  const guint count_max = 100;
+  g_autofree char *tmp = g_strconcat (".xdp-", orig_name, "-XXXXXX", NULL);
 
-  fd = openat (dir_fd, filename, O_RDWR);
-  if (fd == -1)
-    return -1;
+  for (int count = 0; count < count_max; count++)
+    {
+      gen_temp_name (tmp);
 
-  res = ftruncate (fd, size);
-  errsv = errno;
+      fd = openat (dirfd, tmp, O_CREAT|O_EXCL|O_NOFOLLOW|O_NOCTTY|O_RDWR, mode);
+      errsv = errno;
+      if (fd < 0)
+        {
+          if (errsv == EEXIST)
+            continue;
+          else
+            return -errsv;
+        }
 
-  close (fd);
+      *name_out = g_steal_pointer (&tmp);
+      return fd;
+    }
 
-  errno = errsv;
-  return res;
+  return -EEXIST;
+}
+
+
+/* allocates tempfile for existing file,
+   Called with tempfile lock held, sets errno */
+static int
+get_tempfile_for (XdpDomain *domain,
+                  const char *name,
+                  int dirfd,
+                  const char *tmpname,
+                  XdpTempfile **tempfile_out)
+{
+  g_autoptr(XdpTempfile) tempfile = NULL;
+  struct stat buf;
+  xdp_autofd int o_path_fd = -1;
+  int res;
+
+  if (tempfile_out != NULL)
+    *tempfile_out = NULL;
+
+  o_path_fd = openat (dirfd, tmpname, O_PATH, 0);
+  if (o_path_fd == -1)
+    return -errno;
+
+  res = fstatat (o_path_fd, "", &buf, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
+  if (res == -1)
+    return -errno;
+
+  tempfile = xdp_tempfile_new (domain, name, tmpname);
+  tempfile->physical = ensure_physical_inode (buf.st_dev, buf.st_ino, xdp_steal_fd (&o_path_fd)); /* passed ownership of o_path_fd */
+
+  /* This is atomic, because we're called with the lock held */
+  g_hash_table_replace (domain->tempfiles, tempfile->name, xdp_tempfile_ref (tempfile));
+
+  if (tempfile_out)
+    *tempfile_out = g_steal_pointer (&tempfile);
+  return 0;
+}
+
+/* Creates a new file on disk,
+   Called with tempfile lock held, sets errno */
+static int
+create_tempfile (XdpDomain *domain,
+                 const char *name,
+                 int dirfd,
+                 mode_t mode,
+                  XdpTempfile **tempfile_out)
+{
+  struct stat buf;
+  g_autofree char *real_fd_path = NULL;
+  xdp_autofd int real_fd = -1;
+  xdp_autofd int o_path_fd = -1;
+  g_autoptr(XdpTempfile) tempfile = NULL;
+  g_autofree char *tmpname = NULL;
+
+  if (tempfile_out != NULL)
+    *tempfile_out = NULL;
+
+  real_fd = open_temp_at (dirfd, name, &tmpname, mode);
+  if (real_fd < 0)
+    return real_fd;
+
+  real_fd_path = fd_to_path (real_fd);
+  o_path_fd = open (real_fd_path, O_PATH, 0);
+  if (o_path_fd == -1)
+    return -errno;
+
+  /* We can close the tmpfd early */
+  close (xdp_steal_fd (&real_fd));
+
+  if (fstatat (o_path_fd, "", &buf, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW) != 0)
+    return -errno;
+
+  tempfile = xdp_tempfile_new (domain, name, tmpname);
+  tempfile->physical = ensure_physical_inode (buf.st_dev, buf.st_ino, xdp_steal_fd (&o_path_fd)); /* passed ownership of o_path_fd */
+
+  /* This is atomic, because we're called with the lock held */
+  g_hash_table_replace (domain->tempfiles, tempfile->name, xdp_tempfile_ref (tempfile));
+
+  if (tempfile_out)
+    *tempfile_out = g_steal_pointer (&tempfile);
+  return 0;
+}
+
+static int
+xdp_document_inode_open_child_fd (XdpInode *inode, const char *name, int open_flags, mode_t mode)
+{
+  XdpDomain *domain = inode->domain;
+  XdpTempfile *tempfile_lookup = NULL;
+  g_autoptr(XdpTempfile) tempfile = NULL;
+  int tempfile_res = 0;
+  xdp_autofd int fd = -1;
+
+  g_assert (domain->type == XDP_DOMAIN_DOCUMENT);
+
+  if (!xdp_document_domain_can_write (domain) &&
+      (open_flags_has_write (open_flags) ||
+       (open_flags & O_CREAT) != 0))
+      return -EACCES;
+
+  if (inode->physical)
+    {
+      fd = openat (inode->physical->fd, name, open_flags, mode);
+      if (fd == -1)
+        return -errno;
+
+      return xdp_steal_fd (&fd);
+    }
+  else
+    {
+      xdp_autofd int dirfd = -1;
+
+      dirfd = xdp_nonphysical_document_inode_opendir (inode);
+      if (dirfd < 0)
+        return dirfd;
+
+      if (domain->doc_flags & DOCUMENT_ENTRY_FLAG_DIRECTORY ||
+          strcmp (name, domain->doc_file) == 0)
+        {
+          fd = openat (dirfd, name, open_flags, mode);
+          if (fd == -1)
+            return -errno;
+          return xdp_steal_fd (&fd);
+        }
+
+      /* Not directory and not main file, maybe a temporary file? */
+
+      g_mutex_lock (&domain->tempfile_mutex);
+
+      tempfile_lookup = g_hash_table_lookup (domain->tempfiles, name);
+      if (tempfile_lookup)
+        {
+          if ((open_flags & O_CREAT) && (open_flags & O_EXCL))
+            tempfile_res = -EEXIST;
+          else
+            tempfile = xdp_tempfile_ref (tempfile_lookup);
+        }
+      else if (open_flags & O_CREAT)
+        {
+          tempfile_res = create_tempfile (domain, name, dirfd, mode, &tempfile);
+        }
+
+      g_mutex_unlock (&domain->tempfile_mutex);
+
+      if (tempfile)
+        {
+          g_autofree char *fd_path = fd_to_path (tempfile->physical->fd);
+          fd = open (fd_path, open_flags & ~(O_CREAT|O_EXCL|O_NOFOLLOW), mode);
+          if (fd == -1)
+            return -errno;
+
+          return xdp_steal_fd (&fd);
+        }
+      else
+        {
+          if (tempfile_res != 0)
+            return tempfile_res;
+          return -ENOENT;
+        }
+    }
+
+  return -ENOSYS;
+}
+
+/* Returns /proc/self/fds/$fd path for O_PATH fd or toplevel path */
+static char *
+xdp_document_inode_get_self_as_path (XdpInode *inode)
+{
+  g_assert (inode->domain->type == XDP_DOMAIN_DOCUMENT);
+
+  if (inode->physical)
+    return fd_to_path (inode->physical->fd);
+  else
+    return g_strdup (inode->domain->doc_path);
+}
+
+static void
+tweak_statbuf_for_document_inode (XdpInode *inode,
+                                  struct stat *buf)
+{
+  XdpDomain   *domain = inode->domain;
+
+  g_assert (domain->type == XDP_DOMAIN_DOCUMENT);
+
+  buf->st_ino = xdp_inode_to_ino (inode);
+
+  /* Remove setuid/setgid/sticky flags */
+  buf->st_mode &= ~(S_ISUID|S_ISGID|S_ISVTX);
+
+  if (!xdp_document_domain_can_write (domain))
+    buf->st_mode &= ~(0222);
+}
+
+static void
+xdp_reply_err (const char *op, fuse_req_t req, int err)
+{
+  if (err != 0)
+    {
+      const char *errname = NULL;
+      switch (err)
+        {
+        case ESTALE:
+          errname = "ESTALE";
+          break;
+        case EEXIST:
+          errname = "EEXIST";
+          break;
+        case ENOENT:
+          errname = "ENOENT";
+          break;
+        case EPERM:
+          errname = "EPERM";
+          break;
+        case EACCES:
+          errname = "EACCES";
+          break;
+        case EINVAL:
+          errname = "EINVAL";
+          break;
+        default:
+          errname = NULL;
+        }
+      if (errname != NULL)
+        g_debug ("%s -> error %s", op, errname);
+      else
+        g_debug ("%s -> error %d", op, err);
+    }
+  fuse_reply_err (req, err);
+}
+
+typedef enum {
+      CHECK_CAN_WRITE = 1 << 0,
+      CHECK_IS_DIRECTORY = 1 << 1,
+      CHECK_IS_PHYSICAL = 1 << 2,
+} XdpDocumentChecks;
+
+static gboolean
+xdp_document_inode_checks (const char *op,
+                           fuse_req_t  req,
+                           XdpInode *inode,
+                           XdpDocumentChecks checks)
+{
+  XdpDomain *domain = inode->domain;
+
+  if (domain->type != XDP_DOMAIN_DOCUMENT)
+    {
+      xdp_reply_err (op, req, EPERM);
+      return FALSE;
+    }
+
+  /* We allowed the inode lookup to succeed, but maybe the permissions changed since then */
+  if (!xdp_document_domain_can_see (domain))
+    {
+      xdp_reply_err (op, req, EACCES);
+      return FALSE;
+    }
+
+  if ((checks & CHECK_IS_DIRECTORY) != 0 &&
+      (domain->doc_flags & DOCUMENT_ENTRY_FLAG_DIRECTORY) == 0)
+    {
+      xdp_reply_err (op, req, EPERM);
+      return FALSE;
+    }
+
+  if ((checks & CHECK_CAN_WRITE) != 0 &&
+      !xdp_document_domain_can_write (domain))
+    {
+      xdp_reply_err (op, req, EACCES);
+      return FALSE;
+    }
+
+  if ((checks & CHECK_IS_PHYSICAL) != 0 &&
+      inode->physical == NULL)
+    {
+      xdp_reply_err (op, req, EPERM);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+stat_virtual_inode (XdpInode *inode,
+                    struct stat *buf)
+{
+  memset (buf, 0, sizeof (struct stat));
+  buf->st_ino = xdp_inode_to_ino (inode);
+  buf->st_uid = my_uid;
+  buf->st_gid = my_gid;
+
+  switch (inode->domain->type)
+    {
+    case XDP_DOMAIN_ROOT:
+    case XDP_DOMAIN_BY_APP:
+    case XDP_DOMAIN_APP:
+      buf->st_mode = S_IFDIR | NON_DOC_DIR_PERMS;
+      buf->st_nlink = 2;
+      break;
+    case XDP_DOMAIN_DOCUMENT:
+      buf->st_mode = S_IFDIR | DOC_DIR_PERMS;
+      buf->st_nlink = 2;
+
+      /* Remove perms if not writable */
+      if (inode->domain->app_id != NULL)
+        {
+          g_autoptr(PermissionDbEntry) entry = xdp_lookup_doc (inode->domain->doc_id);
+          if (entry == NULL || !app_can_write_doc (entry, inode->domain->app_id))
+            buf->st_mode &= ~(0222);
+        }
+      break;
+
+    default:
+      g_assert_not_reached ();
+      break;
+    }
+}
+
+static void
+xdp_fuse_getattr (fuse_req_t req,
+                  fuse_ino_t ino,
+                  struct fuse_file_info *fi)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  XdpDomain *domain = inode->domain;
+  struct stat buf;
+  int res;
+  double attr_valid_time = 0.0;/* Time in secs for attribute validation */
+  const char *op = "GETATTR";
+
+  g_debug ("GETATTR %lx", ino);
+
+  if (xdp_domain_is_virtual_type (domain))
+    {
+      stat_virtual_inode (inode, &buf);
+      fuse_reply_attr (req, &buf, attr_valid_time);
+      return;
+    }
+
+  g_assert (domain->type == XDP_DOMAIN_DOCUMENT);
+
+  if (inode->physical)
+    res = fstatat (inode->physical->fd, "", &buf, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
+  else
+    {
+      stat_virtual_inode (inode, &buf);
+      res = 0;
+    }
+  if (res == -1)
+    return xdp_reply_err (op, req, errno);
+
+  tweak_statbuf_for_document_inode (inode, &buf);
+
+  fuse_reply_attr (req, &buf, attr_valid_time);
 }
 
 static void
@@ -1865,129 +1211,464 @@ xdp_fuse_setattr (fuse_req_t             req,
                   int                    to_set,
                   struct fuse_file_info *fi)
 {
-  g_autoptr(XdpInode) inode = NULL;
-  g_autoptr(PermissionDbEntry) entry = NULL;
-  double attr_cache_time = ATTR_CACHE_TIME;
-  struct stat newattr = {0};
-  gboolean can_write;
-  int res = 0;
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  g_autofree char *to_set_string = setattr_flags_to_string (to_set);
+  struct stat buf;
+  double attr_valid_time = 0.0;/* Time in secs for attribute validation */
+  int res;
+  const char *op = "SETATTR";
 
-  g_debug ("xdp_fuse_setattr %lx %x %p", ino, to_set, fi);
+  g_debug ("SETATTR %lx %s", ino, to_set_string);
 
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
+  if (!xdp_document_inode_checks (op, req, inode,
+                                  CHECK_CAN_WRITE | CHECK_IS_PHYSICAL))
+    return;
+
+  /* Truncate */
+  if (to_set & FUSE_SET_ATTR_SIZE)
     {
-      g_debug ("xdp_fuse_setattr <- error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
+      g_autofree char *path = NULL;
+      XdpFile *file = (XdpFile *)fi->fh;
 
-  if (inode->type != XDP_INODE_DOC_FILE)
-    {
-      g_debug ("xdp_fuse_setattr <- not file ENOSYS");
-      fuse_reply_err (req, ENOSYS);
-      return;
-    }
-
-  entry = xdp_lookup_doc (inode->doc_id);
-  if (entry == NULL ||
-      !app_can_see_doc (entry, inode->app_id))
-    {
-      g_debug ("xdp_fuse_setattr <- no entry error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  can_write = app_can_write_doc (entry, inode->app_id);
-
-  if (to_set == FUSE_SET_ATTR_SIZE)
-    {
-      g_mutex_lock (&inode->mutex);
-
-      if (!can_write)
+      if (file)
         {
-          res = EACCES;
+          res = ftruncate (file->fd, attr->st_size);
+          if (res == -1)
+            res = -errno;
         }
-      else if (inode->is_doc)
+      else if (inode->physical)
         {
-          /* Only allow ftruncate with the file open for write. We could
-           * allow a truncate, but it would have to be implemented as
-           * an atomic-replace-with-empty-file to not affect other apps
-           * having the file open.
-           * Also, only support truncate-to-zero on first truncation, to
-           * avoid having to copy lots of data from the old file to the
-           * trunc_fd.
-           */
-          if (inode->trunc_fd == -1)
-            {
-              res = EACCES;
-            }
-          else if (!inode->truncated && attr->st_size != 0)
-            {
-              res = ENOSYS;
-            }
-          else
-            {
-              if (ftruncate (inode->trunc_fd, attr->st_size) != 0)
-                {
-                  res = errno;
-                }
-              else if (!inode->truncated)
-                {
-                  inode->truncated = TRUE;
-                  g_free (inode->backing_filename);
-                  inode->backing_filename = g_strdup (inode->trunc_filename);
-                }
-            }
+          path = fd_to_path (inode->physical->fd);
+          res = truncate (path, attr->st_size);
+          if (res == -1)
+            res = -errno;
         }
       else
         {
-          if (inode->fd)
-            {
-              if (ftruncate (inode->fd, attr->st_size) != 0)
-                res = errno;
-            }
-          else
-            {
-              xdp_autofd int dir_fd = xdp_inode_open_dir_fd (inode->parent);
-              if (dir_fd == -1 ||
-                  truncateat (dir_fd, inode->backing_filename, attr->st_size) != 0)
-                res = errno;
-            }
+          res = -EISDIR;
         }
-      g_mutex_unlock (&inode->mutex);
+
+      if (res != 0)
+        return xdp_reply_err (op, req, -res);
     }
-  else if (to_set == FUSE_SET_ATTR_MODE)
+
+  if (to_set & (FUSE_SET_ATTR_ATIME | FUSE_SET_ATTR_MTIME))
     {
-      if (!can_write)
+      struct timespec times[2] = { {0, UTIME_OMIT}, {0, UTIME_OMIT} }; /* 0 = atime, 1 = mtime */
+      g_autofree char *path = NULL;
+
+      if (to_set & FUSE_SET_ATTR_ATIME_NOW)
+        times[0].tv_nsec = UTIME_NOW;
+      else if (to_set & FUSE_SET_ATTR_ATIME)
+        times[0] = attr->st_atim;
+
+      if (to_set & FUSE_SET_ATTR_MTIME_NOW)
+        times[1].tv_nsec = UTIME_NOW;
+      else if (to_set & FUSE_SET_ATTR_MTIME)
+        times[1] = attr->st_mtim;
+
+      if (inode->physical)
         {
-          res = EACCES;
+          path = fd_to_path (inode->physical->fd);
+          res = utimensat (AT_FDCWD, path, times, 0);
+        }
+      else
+        res = utimensat (AT_FDCWD, inode->domain->doc_path, times, 0); /* follow symlink here */
+
+      if (res != 0)
+        return xdp_reply_err (op, req, errno);
+    }
+
+  if (to_set & (FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID))
+    {
+      g_autofree char *path = NULL;
+      uid_t uid = -1;
+      gid_t gid = -1;
+
+      if (to_set & FUSE_SET_ATTR_UID)
+        uid = attr->st_uid;
+
+      if (to_set & FUSE_SET_ATTR_GID)
+        gid = attr->st_gid;
+
+      if (inode->physical)
+        {
+          path = fd_to_path (inode->physical->fd);
+          res = chown (path, uid, gid);
+          if (res == -1)
+            res = -errno;
         }
       else
         {
-          int fd = xdp_inode_locked_get_write_fd (inode);
-          if (fd == -1 ||
-              fchmod (fd, get_user_perms (attr)) != 0)
-            res = errno;
+          res = -EACCES;
         }
+
+      if (res != 0)
+        return xdp_reply_err (op, req, -res);
     }
+
+  if (to_set & (FUSE_SET_ATTR_MODE))
+    {
+      g_autofree char *path = NULL;
+
+      if (inode->physical)
+        {
+          path = fd_to_path (inode->physical->fd);
+          res = chmod (path, attr->st_mode);
+          if (res == -1)
+            res = -errno;
+        }
+      else
+        {
+          res = -EACCES;
+        }
+
+      if (res != 0)
+        return xdp_reply_err (op, req, -res);
+    }
+
+  if (inode->physical)
+    res = fstatat (inode->physical->fd, "", &buf, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
   else
-    {
-      res = ENOSYS;
-    }
+    res = stat (inode->domain->doc_path, &buf); /* Follow symlinks here */
 
   if (res != 0)
+    return xdp_reply_err (op, req, errno);
+
+  tweak_statbuf_for_document_inode (inode, &buf);
+
+  fuse_reply_attr (req, &buf, attr_valid_time);
+}
+
+static void
+prepare_reply_entry (XdpInode *inode,
+                     struct stat *buf,
+                     struct fuse_entry_param *e)
+{
+  xdp_inode_kernel_ref (inode); /* Ref given to the kernel, returned in xdp_forget() */
+  e->ino = xdp_inode_to_ino (inode);
+  e->generation = 1;
+  e->attr = *buf;
+  e->attr_timeout = 0.0; /* attribute timeout */
+  e->entry_timeout = 0.0; /* dentry timeout */
+}
+
+static void
+prepare_reply_virtual_entry (XdpInode *inode,
+                             struct fuse_entry_param *e)
+{
+  stat_virtual_inode (inode, &e->attr);
+
+  xdp_inode_kernel_ref (inode); /* Ref given to the kernel, returned in xdp_forget() */
+  e->ino = xdp_inode_to_ino (inode);
+  e->generation = 1;
+
+  /* Cache virtual dirs */
+  e->attr_timeout = 60.0; /* attribute timeout */
+  e->entry_timeout = 60.0; /* dentry timeout */
+}
+
+static void
+abort_reply_entry (struct fuse_entry_param *e)
+{
+  XdpInode *inode = xdp_inode_from_ino (e->ino);
+  xdp_inode_kernel_unref (inode);
+}
+
+static int
+ensure_docdir_inode (XdpDomain *domain,
+                     int o_path_fd_in, /* Takes ownership */
+                     struct fuse_entry_param *e)
+{
+  g_autoptr(XdpPhysicalInode) physical = NULL;
+  g_autoptr(XdpInode) inode = NULL;
+  xdp_autofd int o_path_fd = o_path_fd_in;
+  struct stat buf;
+  int res;
+
+  res = fstatat (o_path_fd, "", &buf, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
+  if (res == -1)
+    return -errno;
+
+  /* non-directory documents only support regular files */
+  if ((domain->doc_flags & DOCUMENT_ENTRY_FLAG_DIRECTORY) == 0 &&
+      !S_ISREG(buf.st_mode))
+    return -ENOENT;
+
+  physical = ensure_physical_inode (buf.st_dev, buf.st_ino, xdp_steal_fd (&o_path_fd)); /* passed ownership of fd */
+
+  G_LOCK(domain_inodes);
+  inode = g_hash_table_lookup (domain->inodes, physical);
+  if (inode != NULL)
+    inode = xdp_inode_ref (inode);
+  else
     {
-      fuse_reply_err (req, res);
+      inode = xdp_inode_new (domain, physical);
+      g_hash_table_insert (domain->inodes, physical, inode);
+    }
+  G_UNLOCK(domain_inodes);
+
+  tweak_statbuf_for_document_inode (inode, &buf);
+
+  prepare_reply_entry (inode, &buf, e);
+
+  return 0;
+}
+
+static int
+ensure_docdir_inode_by_name (XdpDomain *domain,
+                             int dirfd,
+                             const char *name,
+                             struct fuse_entry_param *e)
+{
+  int o_path_fd;
+
+  o_path_fd = openat (dirfd, name, O_PATH|O_NOFOLLOW, 0);
+  if (o_path_fd == -1)
+      return -errno;
+
+  return ensure_docdir_inode (domain, o_path_fd, e); /* Takes ownershif of o_path_fd */
+}
+
+
+static XdpInode *
+ensure_by_app_inode (XdpDomain *by_app_domain,
+                     const char *app_id)
+{
+  g_autoptr(XdpInode) inode = NULL;
+
+  if (!xdp_is_valid_app_id (app_id))
+    return NULL;
+
+  G_LOCK(domain_inodes);
+  inode = g_hash_table_lookup (by_app_domain->inodes, app_id);
+  if (inode != NULL)
+    inode = xdp_inode_ref (inode);
+  else
+    {
+      g_autoptr(XdpDomain) app_domain = xdp_domain_new_app (by_app_domain, app_id);
+      inode = xdp_inode_new (app_domain, NULL);
+      g_hash_table_insert (by_app_domain->inodes, app_domain->app_id, inode);
+    }
+  G_UNLOCK(domain_inodes);
+
+  return g_steal_pointer (&inode);
+}
+
+static XdpInode *
+ensure_doc_inode (XdpDomain *parent_domain,
+                  const char *doc_id)
+{
+  g_autoptr(XdpInode) inode = NULL;
+  g_autoptr(PermissionDbEntry) doc_entry = NULL;
+
+  doc_entry = xdp_lookup_doc (doc_id);
+
+  if (doc_entry == NULL ||
+      (parent_domain->app_id &&
+       !app_can_see_doc (doc_entry, parent_domain->app_id)))
+    return NULL;
+
+  G_LOCK(domain_inodes);
+  inode = g_hash_table_lookup (parent_domain->inodes, doc_id);
+  if (inode != NULL)
+    inode = xdp_inode_ref (inode);
+  else
+    {
+      g_autoptr(XdpDomain) doc_domain = xdp_domain_new_document (parent_domain, doc_id, doc_entry);
+      inode = xdp_inode_new (doc_domain, NULL);
+      g_hash_table_insert (parent_domain->inodes, doc_domain->doc_id, inode);
+    }
+  G_UNLOCK(domain_inodes);
+
+  return g_steal_pointer (&inode);
+}
+
+static void
+xdp_fuse_lookup (fuse_req_t req,
+                 fuse_ino_t parent_ino,
+                 const char *name)
+{
+  g_autoptr(XdpInode) parent = xdp_inode_from_ino (parent_ino);
+  XdpDomain *parent_domain = parent->domain;
+  g_autoptr(XdpInode) inode = NULL;
+  struct fuse_entry_param e;
+  int res, fd;
+  int open_flags = O_PATH|O_NOFOLLOW;
+  const char *op = "LOOKUP";
+
+  g_debug ("LOOKUP %lx:%s", parent_ino, name);
+
+  if (strcmp (name, ".") == 0 || strcmp (name, "..") == 0)
+    {
+      /* We don't set FUSE_CAP_EXPORT_SUPPORT, so should not get
+       * here. But lets make sure we never ever resolve them as that
+       * could be a security issue by escaping the root. */
+      return xdp_reply_err (op, req, ESTALE);
+    }
+
+  if (xdp_domain_is_virtual_type (parent_domain))
+    {
+      switch (parent_domain->type)
+        {
+        case XDP_DOMAIN_ROOT:
+          if (strcmp (name, BY_APP_NAME) == 0)
+            inode = xdp_inode_ref (by_app_inode);
+          else
+            inode = ensure_doc_inode (parent_domain, name);
+          break;
+        case XDP_DOMAIN_BY_APP:
+          inode = ensure_by_app_inode (parent_domain, name);
+          break;
+        case XDP_DOMAIN_APP:
+          inode = ensure_doc_inode (parent_domain, name);
+          break;
+        default:
+          g_assert_not_reached ();
+        }
+
+      if (inode == NULL)
+        return xdp_reply_err (op, req, ENOENT);
+
+      prepare_reply_virtual_entry (inode, &e);
     }
   else
     {
-      if (xdp_inode_stat (inode, &newattr) != 0)
-        fuse_reply_err (req, errno);
-      else
-        fuse_reply_attr (req, &newattr, attr_cache_time);
+      g_assert (parent_domain->type == XDP_DOMAIN_DOCUMENT);
+
+      fd = xdp_document_inode_open_child_fd (parent, name, open_flags, 0);
+      if (fd < 0)
+        return xdp_reply_err (op, req, -fd);
+
+      res = ensure_docdir_inode (parent->domain, fd, &e); /* Takes ownershif of fd */
+      if (res != 0)
+        return xdp_reply_err (op, req, -res);
+    }
+
+  if (fuse_reply_entry (req, &e) == -ENOENT)
+    abort_reply_entry (&e);
+}
+
+static XdpFile *
+xdp_file_new (int fd)
+{
+  XdpFile *file = g_new0 (XdpFile, 1);
+  file->fd = fd;
+  return file;
+}
+
+static void
+xdp_file_free (XdpFile *file)
+{
+  close (file->fd);
+  g_free (file);
+}
+
+static void
+xdp_fuse_open (fuse_req_t req,
+               fuse_ino_t ino,
+               struct fuse_file_info *fi)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  int open_flags = fi->flags;
+  g_autofree char *open_flags_string = open_flags_to_string (open_flags);
+  int fd;
+  g_autofree char *path = NULL;
+  XdpFile *file = NULL;
+  XdpDocumentChecks checks;
+  const char *op = "OPEN";
+
+  g_debug ("OPEN %lx %s", ino, open_flags_string);
+
+  checks = CHECK_IS_PHYSICAL;
+  if (open_flags_has_write (open_flags))
+    checks |= CHECK_CAN_WRITE;
+
+  /* Note: open_flags guaranteed to exclude O_CREAT, O_EXCL */
+  if (!xdp_document_inode_checks (op, req, inode, checks))
+    return;
+
+  path = fd_to_path (inode->physical->fd);
+  fd = open (path, open_flags, 0);
+  if (fd == -1)
+    return xdp_reply_err (op, req, errno);
+
+  file = xdp_file_new (fd);
+
+  fi->fh = (gsize)file;
+  if (fuse_reply_open (req, fi) == -ENOENT)
+    {
+      /* The open syscall was interrupted, so it  must be cancelled */
+      xdp_file_free (file);
     }
 }
+
+static void
+xdp_fuse_create (fuse_req_t             req,
+                 fuse_ino_t             parent_ino,
+                 const char            *filename,
+                 mode_t                 mode,
+                 struct fuse_file_info *fi)
+{
+  g_autoptr(XdpInode) parent = xdp_inode_from_ino (parent_ino);
+  int open_flags = fi->flags;
+  g_autofree char *open_flags_string = open_flags_to_string (open_flags);
+  struct fuse_entry_param e;
+  int res;
+  xdp_autofd int fd = -1;
+  xdp_autofd int o_path_fd = -1;
+  g_autofree char *fd_path = NULL;
+  XdpFile *file = NULL;
+  const char *op = "CREATE";
+
+  g_debug ("CREATE %lx %s %s, 0%o", parent_ino, filename, open_flags_string, mode);
+
+  if (!xdp_document_inode_checks (op, req, parent, CHECK_CAN_WRITE))
+    return;
+
+  fd = xdp_document_inode_open_child_fd (parent, filename, open_flags, mode);
+  if (fd < 0)
+    return xdp_reply_err (op, req, -fd);
+
+  fd_path = fd_to_path (fd);
+  o_path_fd = open (fd_path, O_PATH, 0);
+  if (o_path_fd < 0)
+    return xdp_reply_err (op, req, errno);
+
+  res = ensure_docdir_inode (parent->domain, xdp_steal_fd (&o_path_fd), &e); /* Takes ownershif of o_path_fd */
+  if (res != 0)
+    return xdp_reply_err (op, req, -res);
+
+  file = xdp_file_new (xdp_steal_fd (&fd)); /* Takes ownership of fd */
+
+  fi->fh = (gsize)file;
+  if (fuse_reply_create (req, &e, fi) == -ENOENT)
+    {
+      /* The open syscall was interrupted, so it  must be cancelled */
+      xdp_file_free (file);
+      abort_reply_entry (&e);
+    }
+}
+
+static void
+xdp_fuse_read (fuse_req_t req,
+               fuse_ino_t ino,
+               size_t size,
+               off_t off,
+               struct fuse_file_info *fi)
+{
+  struct fuse_bufvec buf = FUSE_BUFVEC_INIT(size);
+  XdpFile *file = (XdpFile *)fi->fh;
+
+  g_debug ("READ %lx size %ld off %ld", ino, size, off);
+
+  buf.buf[0].flags = FUSE_BUF_IS_FD | FUSE_BUF_FD_SEEK;
+  buf.buf[0].fd = file->fd;
+  buf.buf[0].pos = off;
+
+  fuse_reply_data (req, &buf, FUSE_BUF_SPLICE_MOVE);
+}
+
 
 static void
 xdp_fuse_write (fuse_req_t             req,
@@ -1997,30 +1678,18 @@ xdp_fuse_write (fuse_req_t             req,
                 off_t                  off,
                 struct fuse_file_info *fi)
 {
-  XdpFile *file = (gpointer) (gsize) fi->fh;
-  XdpInode *inode = file->inode;
-  int fd;
-  int res;
+  XdpFile *file = (XdpFile *)fi->fh;
+  ssize_t res;
+  const char *op = "WRITE";
 
-  g_debug ("xdp_fuse_write %lx %ld %ld", ino, (long) size, (long) off);
+  g_debug ("WRITE %lx size %ld off %ld", ino, size, off);
 
-  g_mutex_lock (&inode->mutex);
+  res = pwrite (file->fd, buf, size, off);
 
-  fd = xdp_inode_locked_get_write_fd (inode);
-  if (fd < 0)
-    {
-      fuse_reply_err (req, errno);
-    }
+  if (res >= 0)
+    fuse_reply_write (req, res);
   else
-    {
-      res = pwrite (fd, buf, size, off);
-      if (res < 0)
-        fuse_reply_err (req, errno);
-      else
-        fuse_reply_write (req, res);
-    }
-
-  g_mutex_unlock (&inode->mutex);
+    xdp_reply_err (op, req, errno);
 }
 
 static void
@@ -2030,36 +1699,22 @@ xdp_fuse_write_buf (fuse_req_t             req,
                     off_t                  off,
                     struct fuse_file_info *fi)
 {
-  XdpFile *file = (gpointer) (gsize) fi->fh;
-  struct fuse_bufvec dst = FUSE_BUFVEC_INIT (fuse_buf_size (bufv));
-  XdpInode *inode = file->inode;
-  int fd;
-  int res;
+  XdpFile *file = (XdpFile *)fi->fh;
+  struct fuse_bufvec dst = FUSE_BUFVEC_INIT(fuse_buf_size(bufv));
+  ssize_t res;
+  const char *op = "WRITEBUF";
 
-  g_debug ("xdp_fuse_write_buf %lx %ld", ino, (long) off);
+  g_debug ("WRITEBUF %lx off %ld", ino, off);
 
-  g_mutex_lock (&inode->mutex);
+  dst.buf[0].flags = FUSE_BUF_IS_FD | FUSE_BUF_FD_SEEK;
+  dst.buf[0].fd = file->fd;
+  dst.buf[0].pos = off;
 
-  fd = xdp_inode_locked_get_write_fd (inode);
-  if (fd == -1)
-    {
-      g_debug ("xdp_fuse_write_buf <- error %s", strerror (errno));
-      fuse_reply_err (req, errno);
-    }
+  res = fuse_buf_copy (&dst, bufv, FUSE_BUF_SPLICE_NONBLOCK);
+  if (res >= 0)
+    fuse_reply_write (req, res);
   else
-    {
-      dst.buf[0].flags = FUSE_BUF_IS_FD | FUSE_BUF_FD_SEEK;
-      dst.buf[0].fd = fd;
-      dst.buf[0].pos = off;
-
-      res = fuse_buf_copy (&dst, bufv, FUSE_BUF_SPLICE_NONBLOCK);
-      if (res < 0)
-        fuse_reply_err (req, -res);
-      else
-        fuse_reply_write (req, res);
-    }
-
-  g_mutex_unlock (&inode->mutex);
+    xdp_reply_err (op, req, errno);
 }
 
 static void
@@ -2068,231 +1723,1047 @@ xdp_fuse_fsync (fuse_req_t             req,
                 int                    datasync,
                 struct fuse_file_info *fi)
 {
-  g_autoptr(XdpInode) inode = NULL;
-  int fd;
-  int res = 0;
+  XdpFile *file = (XdpFile *)fi->fh;
+  int res;
+  const char *op = "FSYNC";
 
-  g_debug ("xdp_fuse_fsync %lx", ino);
+  g_debug ("FSYNC %lx", ino);
 
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
+  if (datasync)
+    res = fdatasync (file->fd);
+  else
+    res = fsync (file->fd);
+  if (res == 0)
+    xdp_reply_err (op, req, 0);
+  else
+    xdp_reply_err (op, req, errno);
+}
+
+static void
+xdp_fuse_fallocate (fuse_req_t req,
+                    fuse_ino_t ino,
+                    int mode,
+                    off_t offset,
+                    off_t length,
+                    struct fuse_file_info *fi)
+{
+  XdpFile *file = (XdpFile *)fi->fh;
+  int res;
+  const char *op = "FALLOCATE";
+
+  g_debug ("FALLOCATE %lx", ino);
+
+  res = fallocate (file->fd, mode, offset, length);
+
+  if (res == 0)
+    xdp_reply_err (op, req, 0);
+  else
+    xdp_reply_err (op, req, errno);
+}
+
+static void
+xdp_fuse_flush (fuse_req_t req,
+                fuse_ino_t ino,
+                struct fuse_file_info *fi)
+{
+  const char *op = "FLUSH";
+
+  g_debug ("FLUSH %lx", ino);
+  xdp_reply_err (op, req, 0);
+}
+
+static void
+xdp_fuse_release (fuse_req_t             req,
+                  fuse_ino_t             ino,
+                  struct fuse_file_info *fi)
+{
+  XdpFile *file = (XdpFile *)fi->fh;
+  const char *op = "RELEASE";
+
+  g_debug ("RELEASE %lx", ino);
+
+  xdp_file_free (file);
+
+  xdp_reply_err (op, req, 0);
+}
+
+static void
+forget_one (fuse_ino_t ino,
+            unsigned long nlookup)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+
+  while (nlookup > 0)
     {
-      g_debug ("xdp_fuse_setattr <- error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
+      xdp_inode_kernel_unref (inode);
+      nlookup--;
+    }
+}
+
+static void
+xdp_fuse_forget (fuse_req_t req,
+                 fuse_ino_t ino,
+                 unsigned long nlookup)
+{
+  g_debug ("FORGET %lx %ld", ino, nlookup);
+  forget_one (ino, nlookup);
+  fuse_reply_none (req);
+}
+
+static void
+xdp_fuse_forget_multi (fuse_req_t req,
+                       size_t count,
+                       struct fuse_forget_data *forgets)
+{
+  size_t i;
+
+  g_debug ("FORGET_MULTI %ld", count);
+
+  for (i = 0; i < count; i++)
+    forget_one (forgets[i].ino, forgets[i].nlookup);
+
+  fuse_reply_none (req);
+}
+
+static void
+xdp_dir_free (XdpDir *d)
+{
+  if (d->dir)
+    closedir (d->dir);
+  g_free (d->dirbuf);
+  g_free (d);
+}
+
+static void
+xdp_dir_add (XdpDir        *d,
+             fuse_req_t     req,
+             const char    *name,
+             mode_t         mode)
+{
+  struct stat stbuf;
+
+  size_t oldsize = d->dirbuf_size;
+
+  d->dirbuf_size += fuse_add_direntry (req, NULL, 0, name, NULL, 0);
+  d->dirbuf = (char *) g_realloc (d->dirbuf, d->dirbuf_size);
+  memset (&stbuf, 0, sizeof (stbuf));
+  stbuf.st_ino = FUSE_UNKNOWN_INO;
+  stbuf.st_mode = mode;
+  fuse_add_direntry (req, d->dirbuf + oldsize,
+                     d->dirbuf_size - oldsize,
+                     name, &stbuf,
+                     d->dirbuf_size);
+}
+
+static XdpDir *
+xdp_dir_new_physical (DIR *dir)
+{
+  XdpDir *d = g_new0 (XdpDir, 1);
+  d->dir = dir;
+  d->offset = 0;
+  d->entry = NULL;
+  return d;
+}
+
+static XdpDir *
+xdp_dir_new_buffered (fuse_req_t  req)
+{
+  XdpDir *d = g_new0 (XdpDir, 1);
+  xdp_dir_add (d, req, ".", S_IFDIR);
+  xdp_dir_add (d, req, "..", S_IFDIR);
+  return d;
+}
+
+static void
+xdp_dir_add_docs (XdpDir     *d,
+                  fuse_req_t  req,
+                  const char *for_app_id)
+{
+  g_auto(GStrv) docs = NULL;
+  int i;
+
+  docs = xdp_list_docs ();
+  for (i = 0; docs[i] != NULL; i++)
+    {
+      if (for_app_id)
+        {
+          g_autoptr(PermissionDbEntry) entry = xdp_lookup_doc (docs[i]);
+          if (entry == NULL ||
+              !app_can_see_doc (entry, for_app_id))
+            continue;
+        }
+
+      xdp_dir_add (d, req, docs[i], S_IFDIR);
+    }
+}
+
+static void
+xdp_dir_add_apps (XdpDir     *d,
+                  XdpDomain  *domain,
+                  fuse_req_t  req,
+                  const char *for_app_id)
+{
+  g_auto(GStrv) apps = NULL;
+  g_auto(GStrv) names = NULL;
+  int i;
+
+  /* First all pre-used apps as these can be created on demand */
+  names = xdp_domain_get_inode_keys_as_string (domain);
+  for (i = 0; names[i] != NULL; i++)
+    xdp_dir_add (d, req, names[i], S_IFDIR);
+
+  /* Then all in the db (that don't already have inodes) */
+  apps = xdp_list_apps ();
+  for (i = 0; apps[i] != NULL; i++)
+    {
+      const char *app = apps[i];
+      if (!g_strv_contains ((const gchar * const *)names, app))
+        xdp_dir_add (d, req, app, S_IFDIR);
+    }
+}
+
+static void
+xdp_fuse_opendir (fuse_req_t             req,
+                  fuse_ino_t             ino,
+                  struct fuse_file_info *fi)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  XdpDomain *domain = inode->domain;
+  XdpDir *d = NULL;
+  int open_flags = O_RDONLY | O_DIRECTORY;
+  DIR *dir;
+  const char *op = "OPENDIR";
+
+  g_debug ("OPENDIR %lx domain %d", ino, inode->domain->type);
+
+  if (xdp_domain_is_virtual_type (domain))
+    {
+      d = xdp_dir_new_buffered (req);
+      switch (domain->type)
+        {
+        case XDP_DOMAIN_ROOT:
+          xdp_dir_add (d, req, BY_APP_NAME, S_IFDIR);
+          xdp_dir_add_docs (d, req, NULL);
+          break;
+        case XDP_DOMAIN_APP:
+          xdp_dir_add_docs (d, req, domain->app_id);
+          break;
+        case XDP_DOMAIN_BY_APP:
+          xdp_dir_add_apps (d, inode->domain, req, NULL);
+          break;
+        default:
+          g_assert_not_reached ();
+        }
+    }
+  else
+    {
+      g_assert (domain->type == XDP_DOMAIN_DOCUMENT);
+
+      if (domain->doc_flags & DOCUMENT_ENTRY_FLAG_DIRECTORY)
+        {
+          int fd = xdp_document_inode_open_self_fd (inode, open_flags, 0);
+          if (fd < 0)
+            return xdp_reply_err (op, req, -fd);
+
+          dir = fdopendir (fd);
+          if (dir == NULL)
+            {
+              xdp_reply_err (op, req, errno);
+              close (fd);
+              return;
+            }
+
+          d = xdp_dir_new_physical (dir);
+        }
+      else
+        {
+          g_autofree char *main_path = g_build_filename (domain->doc_path, domain->doc_file, NULL);
+          struct stat buf;
+          GHashTableIter iter;
+          gpointer key, value;
+
+          d = xdp_dir_new_buffered (req);
+
+          if (stat (main_path, &buf) == 0)
+            xdp_dir_add (d, req, domain->doc_file, buf.st_mode);
+
+          g_mutex_lock (&domain->tempfile_mutex);
+
+          g_hash_table_iter_init (&iter, domain->tempfiles);
+          while (g_hash_table_iter_next (&iter, &key, &value))
+            {
+              const char *tempname = key;
+              xdp_dir_add (d, req, tempname, S_IFREG);
+            }
+
+          g_mutex_unlock (&domain->tempfile_mutex);
+        }
     }
 
-  if (inode->type == XDP_INODE_DOC_FILE)
+   fi->fh = (gsize)d;
+
+  if (fuse_reply_open (req, fi) == -ENOENT)
     {
-      g_mutex_lock (&inode->mutex);
-
-      fd = xdp_inode_locked_get_write_fd (inode);
-      if (fd != -1 && fsync (fd) != 0)
-        res = errno;
-
-      g_mutex_unlock (&inode->mutex);
+      /* The opendir syscall was interrupted, so it  must be cancelled */
+      xdp_dir_free (d);
     }
+}
 
-  fuse_reply_err (req, res);
+static void
+xdp_fuse_readdir (fuse_req_t req,
+                  fuse_ino_t ino,
+                  size_t size,
+                  off_t off,
+                  struct fuse_file_info *fi)
+{
+  XdpDir *d = (XdpDir *)fi->fh;
+  char *p;
+  size_t rem;
+  const char *op = "READDIR";
+
+  g_debug ("READDIR %lx %ld %ld", ino, size, off);
+
+  if (d->dir)
+    {
+      g_autofree char *buf = g_try_malloc (size);
+
+      if (buf == NULL)
+        {
+          xdp_reply_err (op, req, ENOMEM);
+          return;
+        }
+
+      /* If offset is not same, need to seek it */
+      if (off != d->offset)
+        {
+          seekdir (d->dir, off);
+          d->entry = NULL;
+          d->offset = off;
+        }
+
+      p = buf;
+      rem = size;
+      while (TRUE)
+        {
+          size_t entsize;
+          off_t nextoff;
+
+          if (!d->entry)
+            {
+              errno = 0;
+              d->entry = readdir (d->dir);
+              if (!d->entry)
+                {
+                  if (errno && rem == size)
+                    {
+                      xdp_reply_err (op, req, errno);
+                      return;
+                    }
+                  break;
+                }
+            }
+          nextoff = telldir (d->dir);
+
+          struct stat st = {
+            .st_ino = FUSE_UNKNOWN_INO,
+            .st_mode = d->entry->d_type << 12,
+          };
+          entsize = fuse_add_direntry (req, p, rem,
+                                       d->entry->d_name, &st, nextoff);
+          /* The above function returns the size of the entry size even though
+           * the copy failed due to smaller buf size, so I'm checking after this
+           * function and breaking out incase we exceed the size.
+           */
+          if (entsize > rem)
+            break;
+
+          p += entsize;
+          rem -= entsize;
+
+          d->entry = NULL;
+          d->offset = nextoff;
+        }
+
+      fuse_reply_buf(req, buf, size - rem);
+    }
+  else
+    {
+      if (off < d->dirbuf_size)
+        {
+          gsize reply_size = MIN (d->dirbuf_size - off, size);
+          g_autofree char *buf = g_memdup (d->dirbuf + off, reply_size);
+          fuse_reply_buf (req, buf, reply_size);
+        }
+      else
+        fuse_reply_buf (req, NULL, 0);
+    }
+}
+
+static void
+xdp_fuse_releasedir (fuse_req_t             req,
+                     fuse_ino_t             ino,
+                     struct fuse_file_info *fi)
+{
+  XdpDir *d = (XdpDir *)fi->fh;
+  const char *op = "RELEASEDIR";
+
+  g_debug ("RELEASEDIR %lx", ino);
+
+  xdp_dir_free (d);
+
+  xdp_reply_err (op, req, 0);
+}
+
+static void
+xdp_fuse_fsyncdir (fuse_req_t             req,
+                   fuse_ino_t             ino,
+                   int                    datasync,
+                   struct fuse_file_info *fi)
+{
+  XdpDir *dir = (XdpDir *)fi->fh;
+  int fd, res;
+  const char *op = "FSYNCDIR";
+
+  g_debug ("FSYNCDIR %lx", ino);
+
+  if (dir->dir)
+    {
+      fd = dirfd (dir->dir);
+      if (datasync)
+        res = fdatasync (fd);
+      else
+        res = fsync (fd);
+    }
+  else
+    res = 0;
+
+  if (res == 0)
+    xdp_reply_err (op, req, 0);
+  else
+    xdp_reply_err (op, req, errno);
+}
+
+static void
+xdp_fuse_mkdir (fuse_req_t  req,
+                fuse_ino_t parent_ino,
+                const char *name,
+                mode_t mode)
+{
+  g_autoptr(XdpInode) parent = xdp_inode_from_ino (parent_ino);
+  struct fuse_entry_param e;
+  int res;
+  xdp_autofd int close_fd = -1;
+  int dirfd;
+  const char *op = "MKDIR";
+
+  g_debug ("MKDIR %lx %s", parent_ino, name);
+
+  if (!xdp_document_inode_checks (op, req, parent,
+                                  CHECK_CAN_WRITE |
+                                  CHECK_IS_DIRECTORY))
+    return;
+
+  dirfd = xdp_document_inode_ensure_dirfd (parent, &close_fd);
+  if (dirfd < 0)
+    return xdp_reply_err (op, req, -dirfd);
+
+  res = mkdirat (dirfd, name, mode);
+  if (res != 0)
+    return xdp_reply_err (op, req, errno);
+
+  res = ensure_docdir_inode_by_name (parent->domain, dirfd, name, &e); /* Takes ownershif of o_path_fd */
+  if (res != 0)
+    return xdp_reply_err (op, req, -res);
+
+  if (fuse_reply_entry (req, &e) == -ENOENT)
+    abort_reply_entry (&e);
 }
 
 static void
 xdp_fuse_unlink (fuse_req_t  req,
-                 fuse_ino_t  parent,
+                 fuse_ino_t  parent_ino,
                  const char *filename)
 {
-  g_autoptr(XdpInode) parent_inode = NULL;
-  g_autoptr(XdpInode) child_inode = NULL;
+  g_autoptr(XdpInode) parent = xdp_inode_from_ino (parent_ino);
+  XdpDomain *parent_domain = parent->domain;
+  int res = -1;
+  const char * op = "UNLINK";
 
-  g_debug ("xdp_fuse_unlink %lx/%s", parent, filename);
+  g_debug ("UNLINK %lx %s", parent_ino, filename);
 
-  parent_inode = xdp_inode_lookup (parent);
-  if (parent_inode == NULL)
+  if (!xdp_document_inode_checks (op, req, parent,
+                                  CHECK_CAN_WRITE))
+    return;
+
+  if (parent->physical)
     {
-      g_debug ("xdp_fuse_lookup <- error parent ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
+      res = unlinkat (parent->physical->fd, filename, 0);
+      if (res != 0)
+        return xdp_reply_err (op, req, errno);
+    }
+  else
+    {
+      xdp_autofd int dirfd = -1;
+
+      dirfd = xdp_nonphysical_document_inode_opendir (parent);
+      if (dirfd < 0)
+        xdp_reply_err (op, req, -dirfd);
+
+      if (parent_domain->doc_flags & DOCUMENT_ENTRY_FLAG_DIRECTORY ||
+          strcmp (filename, parent_domain->doc_file) == 0)
+        {
+          res = unlinkat (dirfd, filename, 0);
+          if (res != 0)
+            return xdp_reply_err (op, req, errno);
+        }
+      else
+        {
+          gboolean removed = FALSE;
+
+          /* Not directory and not main file, maybe a temporary file? */
+          g_mutex_lock (&parent_domain->tempfile_mutex);
+          removed = g_hash_table_remove (parent_domain->tempfiles, filename);
+          g_mutex_unlock (&parent_domain->tempfile_mutex);
+
+          if (!removed)
+            return xdp_reply_err (op, req, ENOENT);
+        }
     }
 
-  if (parent_inode->type == XDP_INODE_DOC_FILE)
-    {
-      fuse_reply_err (req, ENOTDIR);
-      return;
-    }
-
-  if (parent_inode->type != XDP_INODE_APP_DOC_DIR &&
-      parent_inode->type != XDP_INODE_DOC_DIR)
-    {
-      fuse_reply_err (req, EACCES);
-      return;
-    }
-
-  child_inode = xdp_inode_unlink_child (parent_inode, filename);
-  if (child_inode == NULL)
-    {
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  fuse_reply_err (req, 0);
+  xdp_reply_err (op, req, 0);
 }
 
 static void
 xdp_fuse_rename (fuse_req_t  req,
-                 fuse_ino_t  parent,
+                 fuse_ino_t  parent_ino,
                  const char *name,
-                 fuse_ino_t  newparent,
+                 fuse_ino_t  newparent_ino,
                  const char *newname)
 {
-  g_autoptr(XdpInode) parent_inode = NULL;
-  g_autoptr(PermissionDbEntry) entry = NULL;
-  gboolean can_see, can_write;
+  g_autoptr(XdpInode) parent = xdp_inode_from_ino (parent_ino);
+  g_autoptr(XdpInode) newparent = xdp_inode_from_ino (newparent_ino);
+  XdpDomain *domain;
+  int res, errsv;
+  int olddirfd, newdirfd, dirfd;
+  xdp_autofd int close_fd1 = -1;
+  xdp_autofd int close_fd2 = -1;
+  const char *op = "RENAME";
 
-  g_debug ("xdp_fuse_rename %lx/%s -> %lx/%s", parent, name, newparent, newname);
+  g_debug ("RENAME %lx %s -> %lx %s", parent_ino, name, newparent_ino, newname);
 
-  parent_inode = xdp_inode_lookup (parent);
-  if (parent_inode == NULL)
+  if (!xdp_document_inode_checks (op, req, parent,
+                                  CHECK_CAN_WRITE))
+    return;
+
+  /* Don't allow cross-domain renames */
+  if (parent->domain != newparent->domain)
+    return xdp_reply_err (op, req, EXDEV);
+
+  domain = parent->domain;
+  if (domain->doc_flags & DOCUMENT_ENTRY_FLAG_DIRECTORY)
     {
-      g_debug ("xdp_fuse_rename <- error parent ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
+      olddirfd = xdp_document_inode_ensure_dirfd (parent, &close_fd1);
+      if (olddirfd < 0)
+        return xdp_reply_err (op, req, -olddirfd);
+
+      newdirfd = xdp_document_inode_ensure_dirfd (newparent, &close_fd2);
+      if (newdirfd < 0)
+        return xdp_reply_err (op, req, -newdirfd);
+
+      res = renameat (olddirfd, name, newdirfd, newname);
+      if (res != 0)
+        return xdp_reply_err (op, req, errno);
+
+      xdp_reply_err (op, req, 0);
     }
-
-  if (parent_inode->type == XDP_INODE_DOC_FILE)
-    {
-      fuse_reply_err (req, ENOTDIR);
-      return;
-    }
-
-  if (parent_inode->type != XDP_INODE_APP_DOC_DIR &&
-      parent_inode->type != XDP_INODE_DOC_DIR)
-    {
-      fuse_reply_err (req, EACCES);
-      return;
-    }
-
-  if (newparent != parent)
-    {
-      g_debug ("xdp_fuse_rename <- error different parents EACCES");
-      fuse_reply_err (req, EACCES);
-      return;
-    }
-
-  if (strcmp (name, newname) == 0)
-    {
-      fuse_reply_err (req, 0);
-      return;
-    }
-
-  entry = xdp_lookup_doc (parent_inode->doc_id);
-  if (entry == NULL)
-    {
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  can_see = app_can_see_doc (entry, parent_inode->app_id);
-  can_write = app_can_write_doc (entry, parent_inode->app_id);
-
-  if (!can_see)
-    {
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
-
-  if (!can_write)
-    {
-      fuse_reply_err (req, EACCES);
-      return;
-    }
-
-  if (xdp_inode_rename_child (parent_inode, name, newname) != 0)
-    fuse_reply_err (req, errno);
   else
-    fuse_reply_err (req, 0);
-}
-
-static void
-xdp_fuse_access (fuse_req_t req, fuse_ino_t ino, int mask)
-{
-  g_autoptr(XdpInode) inode = NULL;
-  g_autoptr(PermissionDbEntry) entry = NULL;
-
-  g_debug ("xdp_fuse_access %lx %d", ino, mask);
-
-  if (mask != F_OK && (mask & ~(R_OK|W_OK|X_OK)) != 0)
     {
-      g_debug ("xdp_fuse_access <- error EINVAL");
-      fuse_reply_err (req, EINVAL);
-      return;
-    }
+      /* For non-directories, only allow renames in toplevel (nonphysical) dir */
+      if (parent != newparent || parent->physical != NULL)
+        return xdp_reply_err (op, req, EACCES);
 
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
-    {
-      g_debug ("xdp_fuse_access <- error ENOENT");
-      fuse_reply_err (req, ENOENT);
-      return;
-    }
+      /* Early exit for same file */
+      if (strcmp (name, newname) == 0)
+        return xdp_reply_err (op, req, 0);
 
-  if (inode->type != XDP_INODE_DOC_FILE)
-    {
-      int dir_mask = 0;
+      dirfd = xdp_nonphysical_document_inode_opendir (parent);
+      if (dirfd < 0)
+        return xdp_reply_err (op, req, -dirfd);
+      close_fd1 = dirfd;
 
-      switch (inode->type)
+      if (strcmp (name, domain->doc_file) == 0)
         {
-        case XDP_INODE_ROOT:
-        case XDP_INODE_BY_APP:
-        case XDP_INODE_APP_DIR:
-          dir_mask = R_OK | X_OK;
-          break;
-        case XDP_INODE_APP_DOC_DIR:
-        case XDP_INODE_DOC_DIR:
-          dir_mask = R_OK | X_OK | W_OK;
-          break;
+          /* Source is (maybe) main file, destination is tempfile */
+          g_autofree char *tmpname = NULL;
+          int tmp_fd;
 
-        default:
-          g_assert_not_reached ();
-        }
+          /* Just use this to get an exclusive name, we will later replace its content */
+          tmp_fd = open_temp_at (dirfd, newname, &tmpname, 0600);
+          if (tmp_fd < 0)
+            return xdp_reply_err (op, req, -tmp_fd);
+          close (tmp_fd);
 
-      if (mask != F_OK && ((mask & dir_mask) != mask))
-        {
-          fuse_reply_err (req, EACCES);
-          return;
-        }
-    }
-  else /* A file */
-    {
-      entry = xdp_lookup_doc (inode->doc_id);
-      if (entry == NULL ||
-          !app_can_see_doc (entry, inode->app_id))
-        {
-          g_debug ("xdp_fuse_access <- no entry error ENOENT");
-          fuse_reply_err (req, ENOENT);
-          return;
-        }
-
-      if (mask == F_OK)
-        {
-          if (!app_can_see_doc (entry, inode->app_id))
+          g_mutex_lock (&domain->tempfile_mutex);
+          res = renameat (dirfd, name, dirfd, tmpname);
+          if (res == -1)
             {
-              fuse_reply_err (req, EACCES);
-              return;
+              res = -errno;
+              /* Remove the temporary file if the move failed */
+              (void) unlinkat (dirfd, tmpname, 0);
             }
+          else
+            {
+              res = get_tempfile_for (domain, newname, dirfd, tmpname, NULL);
+            }
+
+          g_mutex_unlock (&domain->tempfile_mutex);
+
+          if (res != 0)
+            return xdp_reply_err (op, req, -res);
+
+          xdp_reply_err (op, req, 0);
+        }
+      else if (strcmp (newname, domain->doc_file) == 0)
+        {
+          gpointer stolen_value;
+
+          /* source is (maybe) tempfile, Destination is main file */
+
+          g_mutex_lock (&domain->tempfile_mutex);
+          if (g_hash_table_steal_extended (domain->tempfiles, name,
+                                           NULL, &stolen_value))
+            {
+              XdpTempfile *tempfile = stolen_value;
+
+              res = renameat (dirfd, tempfile->tempname, dirfd, newname);
+              errsv = errno;
+
+              if (res == -1) /* Revert tempfile steal */
+                g_hash_table_replace (domain->tempfiles, tempfile->name, tempfile);
+              else
+                {
+                  /* Steal the old tempname so we don't unlink it */
+                  g_free (g_steal_pointer (&tempfile->tempname));
+                  xdp_tempfile_unref (tempfile);
+                }
+            }
+          else
+            {
+              res = -1;
+              errsv = ENOENT;
+            }
+
+          g_mutex_unlock (&domain->tempfile_mutex);
+
+          if (res != 0)
+            return xdp_reply_err (op, req, errsv);
+
+          xdp_reply_err (op, req, 0);
         }
       else
         {
-          if (((mask & R_OK) && !app_can_see_doc (entry, inode->app_id)) ||
-              ((mask & W_OK) && !app_can_write_doc (entry, inode->app_id)) ||
-              (mask & X_OK))
+          /* Source and destinations are both tempfiles, no need to change anything on disk */
+          gboolean found_tempfile = FALSE;
+          gpointer stolen_value;
+
+          /* Renaming temp file to temp file */
+          g_mutex_lock (&domain->tempfile_mutex);
+          if (g_hash_table_steal_extended (domain->tempfiles, name,
+                                            NULL, &stolen_value))
             {
-              fuse_reply_err (req, EACCES);
-              return;
-            }
+              XdpTempfile *tempfile = stolen_value;
+
+              found_tempfile = TRUE;
+
+              g_free (tempfile->name);
+              tempfile->name = g_strdup (newname);
+
+              /* This destroys any pre-existing tempfile with this name */
+              g_hash_table_replace (domain->tempfiles, tempfile->name, tempfile);
+          }
+          g_mutex_unlock (&domain->tempfile_mutex);
+
+          if (!found_tempfile)
+            return xdp_reply_err (op, req, ENOENT);
+
+          xdp_reply_err (op, req, 0);
         }
     }
+}
 
-  fuse_reply_err (req, 0);
+static void
+xdp_fuse_access (fuse_req_t req,
+                 fuse_ino_t ino,
+                 int mask)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  g_autofree char *path = NULL;
+  int res;
+  const char *op = "ACCESS";
+
+  g_debug ("ACCESS %lx", ino);
+
+  if (inode->domain->type != XDP_DOMAIN_DOCUMENT)
+    {
+      if (mask & W_OK)
+        xdp_reply_err (op, req, EPERM);
+      else
+        xdp_reply_err (op, req, 0);
+
+      return;
+    }
+
+  if ((mask & W_OK) != 0 &&
+      !xdp_document_domain_can_write (inode->domain))
+    return xdp_reply_err (op, req, EPERM);
+
+  if (inode->physical)
+    {
+      path = fd_to_path (inode->physical->fd);
+      res = access (path, mask);
+    }
+  else
+    res = access (inode->domain->doc_path, mask);
+
+  if (res == -1)
+    xdp_reply_err (op, req, errno);
+  else
+    xdp_reply_err (op, req, 0);
+}
+
+static void
+xdp_fuse_rmdir (fuse_req_t req,
+                fuse_ino_t parent_ino,
+                const char *filename)
+{
+  g_autoptr(XdpInode) parent = xdp_inode_from_ino (parent_ino);
+  xdp_autofd int close_fd = -1;
+  int dirfd;
+  int res;
+  const char *op = "RMDIR";
+
+  g_debug ("RMDIR %lx %s", parent_ino, filename);
+
+  if (!xdp_document_inode_checks (op, req, parent,
+                                  CHECK_CAN_WRITE | CHECK_IS_DIRECTORY))
+    return;
+
+  dirfd = xdp_document_inode_ensure_dirfd (parent, &close_fd);
+  if (dirfd < 0)
+    return xdp_reply_err (op, req, -dirfd);
+
+  res = unlinkat (dirfd, filename, AT_REMOVEDIR);
+  if (res != 0)
+    xdp_reply_err (op, req, errno);
+
+  xdp_reply_err (op, req, 0);
+}
+
+static void
+xdp_fuse_readlink (fuse_req_t req,
+                   fuse_ino_t ino)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  char linkname[PATH_MAX + 1];
+  ssize_t res;
+  const char *op = "READLINK";
+
+  g_debug ("READLINK %lx", ino);
+
+  if (!xdp_document_inode_checks (op, req, inode,
+                                  CHECK_IS_DIRECTORY))
+    return;
+
+  if (inode->physical == NULL)
+    return xdp_reply_err (op, req, EINVAL);
+
+  res = readlinkat (inode->physical->fd, "", linkname, sizeof(linkname));
+  if (res < 0)
+    return xdp_reply_err (op, req, errno);
+
+  linkname[res] = '\0';
+  fuse_reply_readlink (req, linkname);
+}
+
+static void
+xdp_fuse_symlink (fuse_req_t req,
+                  const char *link,
+                  fuse_ino_t parent_ino,
+                  const char *name)
+{
+  g_autoptr(XdpInode) parent = xdp_inode_from_ino (parent_ino);
+  int res;
+  int dirfd;
+  xdp_autofd int close_fd = -1;
+  struct fuse_entry_param e;
+  const char * op = "SYMLINK";
+
+  g_debug ("SYMLINK %s %lx %s", link, parent_ino, name);
+
+  if (!xdp_document_inode_checks (op, req, parent,
+                                  CHECK_CAN_WRITE | CHECK_IS_DIRECTORY))
+    return;
+
+  dirfd = xdp_document_inode_ensure_dirfd (parent, &close_fd);
+  if (dirfd < 0)
+    return xdp_reply_err (op, req, -dirfd);
+
+  res = symlinkat (link, dirfd, name);
+  if (res != 0)
+    return xdp_reply_err (op, req, errno);
+
+  res = ensure_docdir_inode_by_name (parent->domain, dirfd, name, &e); /* Takes ownershif of o_path_fd */
+  if (res != 0)
+    return xdp_reply_err (op, req, -res);
+
+  if (fuse_reply_entry (req, &e) == -ENOENT)
+    abort_reply_entry (&e);
+}
+
+static void
+xdp_fuse_link (fuse_req_t req,
+               fuse_ino_t ino,
+               fuse_ino_t newparent_ino,
+               const char *newname)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  g_autoptr(XdpInode) newparent = xdp_inode_from_ino (newparent_ino);
+  int res;
+  g_autofree char *proc_path = NULL;
+  int newparent_dirfd;
+  xdp_autofd int close_fd = -1;
+  struct fuse_entry_param e;
+  const char * op = "LINK";
+
+  g_debug ("LINK %lx %lx %s", ino, newparent_ino, newname);
+
+  /* hardlinks only supported in docdirs, and only physical files */
+  if (!xdp_document_inode_checks (op, req, inode,
+                                  CHECK_CAN_WRITE | CHECK_IS_DIRECTORY | CHECK_IS_PHYSICAL))
+    return;
+
+  /* Don't allow linking between domains */
+  if (inode->domain != newparent->domain)
+    return xdp_reply_err (op, req, EXDEV);
+
+  proc_path = fd_to_path (inode->physical->fd);
+  newparent_dirfd = xdp_document_inode_ensure_dirfd (newparent, &close_fd);
+  if (newparent_dirfd < 0)
+    return xdp_reply_err (op, req, -newparent_dirfd);
+
+  res = linkat (AT_FDCWD, proc_path, newparent_dirfd, newname, AT_SYMLINK_FOLLOW);
+  if (res != 0)
+    return xdp_reply_err (op, req, errno);
+
+  res = ensure_docdir_inode_by_name (inode->domain, newparent_dirfd, newname, &e); /* Takes ownership of o_path_fd */
+  if (res != 0)
+    return xdp_reply_err (op, req, -res);
+
+  if (fuse_reply_entry (req, &e) == -ENOENT)
+    abort_reply_entry (&e);
+}
+
+
+static void
+xdp_fuse_statfs (fuse_req_t req,
+                 fuse_ino_t ino)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  struct statvfs buf;
+  int res;
+  const char *op = "STATFS";
+
+  g_debug ("STATFS %lx", ino);
+
+  if (!xdp_document_inode_checks (op, req, inode, 0))
+    return;
+
+  if (inode->physical)
+    res = fstatvfs (inode->physical->fd, &buf);
+  else
+    res = statvfs (inode->domain->doc_path, &buf);
+
+  if (!res)
+    fuse_reply_statfs (req, &buf);
+  else
+    xdp_reply_err (op, req, errno);
+}
+
+static void
+xdp_fuse_setxattr (fuse_req_t req,
+                   fuse_ino_t ino,
+                   const char *name,
+                   const char *value,
+                   size_t size,
+                   int flags)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  ssize_t res;
+  g_autofree char *path = NULL;
+  const char *op = "SETXATTR";
+
+  g_debug ("SETXATTR %lx %s", ino, name);
+
+  if (!xdp_document_inode_checks (op, req, inode,
+                                  CHECK_CAN_WRITE | CHECK_IS_DIRECTORY))
+    return;
+
+  if (inode->physical)
+    {
+      path = fd_to_path (inode->physical->fd);
+      res = setxattr (path, name, value, size, flags);
+    }
+  else
+    res = setxattr (inode->domain->doc_path, name, value, size, flags);
+
+  if (res < 0)
+    return xdp_reply_err (op, req, errno);
+
+  xdp_reply_err (op, req, 0);
+}
+
+static void
+xdp_fuse_getxattr (fuse_req_t req,
+                   fuse_ino_t ino,
+                   const char *name,
+                   size_t size)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  ssize_t res;
+  g_autofree char *buf = NULL;
+  g_autofree char *path = NULL;
+  const char *op = "GETXATTR";
+
+  g_debug ("GETXATTR %lx %s %ld", ino, name, size);
+
+  if (inode->domain->type != XDP_DOMAIN_DOCUMENT)
+    return xdp_reply_err (op, req, ENODATA);
+
+  if (size != 0)
+    buf = g_malloc (size);
+
+  path = xdp_document_inode_get_self_as_path (inode);
+  res = getxattr (path, name, buf, size);
+  if (res < 0)
+    return xdp_reply_err (op, req, errno);
+
+  if (size == 0)
+    fuse_reply_xattr (req, res);
+  else
+    fuse_reply_buf (req, buf, res);
+}
+
+static void
+xdp_fuse_listxattr (fuse_req_t req,
+                    fuse_ino_t ino,
+                    size_t size)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  ssize_t res;
+  g_autofree char *buf = NULL;
+  g_autofree char *path = NULL;
+  const char *op = "LISTXATTR";
+
+  g_debug ("LISTXATTR %lx %ld", ino, size);
+
+  if (inode->domain->type != XDP_DOMAIN_DOCUMENT)
+    return xdp_reply_err (op, req, ENOTSUP);
+
+  if (size != 0)
+    buf = g_malloc (size);
+
+  if (inode->physical)
+    {
+      path = fd_to_path (inode->physical->fd);
+      res = listxattr (path, buf, size);
+    }
+  else
+    res = listxattr (inode->domain->doc_path, buf, size);
+
+  if (res < 0)
+    return xdp_reply_err (op, req, errno);
+
+  if (size == 0)
+    fuse_reply_xattr (req, res);
+  else
+    fuse_reply_buf (req, buf, res);
+}
+
+static void
+xdp_fuse_removexattr (fuse_req_t req,
+                      fuse_ino_t ino,
+                      const char *name)
+{
+  g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
+  g_autofree char *path = NULL;
+  ssize_t res;
+  const char *op = "REMOVEXATTR";
+
+  g_debug ("REMOVEXATTR %lx %s", ino, name);
+
+  if (!xdp_document_inode_checks (op, req, inode,
+                                  CHECK_CAN_WRITE | CHECK_IS_DIRECTORY))
+    return;
+
+  if (inode->physical)
+    {
+      path = fd_to_path (inode->physical->fd);
+      res = removexattr (path, name);
+    }
+  else
+    res = removexattr (inode->domain->doc_path, name);
+
+  if (res < 0)
+    xdp_reply_err (op, req, errno);
+  else
+    xdp_reply_err (op, req, 0);
+}
+
+static void
+xdp_fuse_getlk (fuse_req_t req,
+                fuse_ino_t ino,
+                struct fuse_file_info *fi,
+                struct flock *lock)
+{
+  const char *op = "GETLK";
+
+  g_debug ("GETLK %lx", ino);
+
+  xdp_reply_err (op, req, ENOSYS);
+}
+
+static void
+xdp_fuse_setlk (fuse_req_t req,
+                fuse_ino_t ino,
+                struct fuse_file_info *fi,
+                struct flock *lock,
+                int sleep)
+{
+  const char *op = "SETLK";
+
+  g_debug ("SETLK %lx", ino);
+
+  xdp_reply_err (op, req, ENOSYS);
+}
+
+static void
+xdp_fuse_flock (fuse_req_t req,
+                fuse_ino_t ino,
+                struct fuse_file_info *fi,
+                int lock_op)
+{
+  const char *op = "FLOCK";
+
+  g_debug ("FLOCK %lx", ino);
+
+  xdp_reply_err (op, req, ENOSYS);
+}
+
+static void
+xdp_fuse_init_cb (void                  *userdata,
+                  struct fuse_conn_info *conn)
+{
+  g_debug ("INIT");
 }
 
 extern void on_fuse_unmount (void);
@@ -2300,9 +2771,9 @@ extern void on_fuse_unmount (void);
 static int destroyed;
 
 static void
-xdp_fuse_destroy (void *userdata)
+xdp_fuse_destroy_cb (void *userdata)
 {
-  g_debug ("xdp_fuse_destroy");
+  g_debug ("DESTROY");
 
   destroyed = 1;
 
@@ -2310,153 +2781,43 @@ xdp_fuse_destroy (void *userdata)
 }
 
 static struct fuse_lowlevel_ops xdp_fuse_oper = {
-  .destroy      = xdp_fuse_destroy,
-  .lookup       = xdp_fuse_lookup,
-  .forget       = xdp_fuse_forget,
-  .getattr      = xdp_fuse_getattr,
-  .opendir      = xdp_fuse_opendir,
-  .readdir      = xdp_fuse_readdir,
-  .releasedir   = xdp_fuse_releasedir,
-  .fsyncdir     = xdp_fuse_fsyncdir,
-  .open         = xdp_fuse_open,
-  .read         = xdp_fuse_read,
-  .release      = xdp_fuse_release,
-  .setattr      = xdp_fuse_setattr,
-  .write        = xdp_fuse_write,
-  .write_buf    = xdp_fuse_write_buf,
-  .fsync        = xdp_fuse_fsync,
-  .create       = xdp_fuse_create,
-  .unlink       = xdp_fuse_unlink,
-  .rename       = xdp_fuse_rename,
-  .access       = xdp_fuse_access,
+ .init         = xdp_fuse_init_cb,
+ .destroy      = xdp_fuse_destroy_cb,
+ .lookup       = xdp_fuse_lookup,
+ .getattr      = xdp_fuse_getattr,
+ .setattr      = xdp_fuse_setattr,
+ .readdir      = xdp_fuse_readdir,
+ .open         = xdp_fuse_open,
+ .read         = xdp_fuse_read,
+ .write        = xdp_fuse_write,
+ .write_buf    = xdp_fuse_write_buf,
+ .fsync        = xdp_fuse_fsync,
+ .forget       = xdp_fuse_forget,
+ .forget_multi = xdp_fuse_forget_multi,
+ .releasedir   = xdp_fuse_releasedir,
+ .release      = xdp_fuse_release,
+ .opendir      = xdp_fuse_opendir,
+ .fsyncdir     = xdp_fuse_fsyncdir,
+ .create       = xdp_fuse_create,
+ .unlink       = xdp_fuse_unlink,
+ .rename       = xdp_fuse_rename,
+ .access       = xdp_fuse_access,
+ .readlink     = xdp_fuse_readlink,
+ .rmdir        = xdp_fuse_rmdir,
+ .mkdir        = xdp_fuse_mkdir,
+ .symlink      = xdp_fuse_symlink,
+ .link         = xdp_fuse_link,
+ .flush        = xdp_fuse_flush,
+ .statfs       = xdp_fuse_statfs,
+ .setxattr     = xdp_fuse_setxattr,
+ .getxattr     = xdp_fuse_getxattr,
+ .listxattr    = xdp_fuse_listxattr,
+ .removexattr  = xdp_fuse_removexattr,
+ .getlk        = xdp_fuse_getlk,
+ .setlk        = xdp_fuse_setlk,
+ .flock        = xdp_fuse_flock,
+ .fallocate    = xdp_fuse_fallocate,
 };
-
-/* Called when a apps permissions to see a document is changed,
-   and with null opt_app_id when the doc is created/removed */
-void
-xdp_fuse_invalidate_doc_app (const char *doc_id,
-                             const char *opt_app_id)
-{
-  g_autoptr(XdpInode) inode = NULL;
-  fuse_ino_t ino;
-  GList *l;
-
-  /* This can happen if fuse is not initialized yet for the very
-     first dbus message that activated the service */
-  if (main_ch == NULL)
-    return;
-
-  g_debug ("invalidate %s/%s", doc_id, opt_app_id ? opt_app_id : "*");
-
-  XDP_AUTOLOCK (inodes);
-  ino = get_dir_inode_nr_unlocked (opt_app_id, doc_id);
-  inode = xdp_inode_lookup_unlocked (ino);
-  if (inode != NULL)
-    {
-      fuse_lowlevel_notify_inval_inode (main_ch, inode->ino, 0, 0);
-      fuse_lowlevel_notify_inval_entry (main_ch, inode->parent->ino,
-                                        inode->filename, strlen (inode->filename));
-
-      for (l = inode->children; l != NULL; l = l->next)
-        {
-          XdpInode *child = l->data;
-
-          fuse_lowlevel_notify_inval_inode (main_ch, child->ino, 0, 0);
-          if (child->filename != NULL)
-            fuse_lowlevel_notify_inval_entry (main_ch, inode->ino,
-                                              child->filename, strlen (child->filename));
-        }
-    }
-}
-
-char *
-xdp_fuse_lookup_id_for_inode (ino_t ino)
-{
-  g_autoptr(XdpInode) inode = NULL;
-
-  inode = xdp_inode_lookup (ino);
-  if (inode == NULL)
-    return NULL;
-
-  if (inode->type != XDP_INODE_DOC_FILE ||
-      !inode->is_doc)
-    return NULL;
-
-  return g_strdup (inode->doc_id);
-}
-
-const char *
-xdp_fuse_get_mountpoint (void)
-{
-  if (mount_path == NULL)
-    mount_path = g_build_filename (g_get_user_runtime_dir (), "doc", NULL);
-  return mount_path;
-}
-
-void
-xdp_fuse_exit (void)
-{
-  if (!destroyed && session)
-    fuse_session_exit (session);
-
-  if (fuse_pthread)
-    pthread_kill (fuse_pthread, SIGHUP);
-
-  if (fuse_thread)
-    g_thread_join (fuse_thread);
-}
-
-static void
-free_global_inodes (void)
-{
-  GHashTableIter iter;
-  gpointer key, value;
-  GList *l;
-  g_autoptr(GList) kernel_refs = NULL;
-  g_autoptr(GList) tmpfile_refs = NULL;
-
-  /* First iterate over all outstanding inodes to see if any
-   * needs unref:ing. We do this before unrefing them so that
-   * its safe to iterate over the table (i.e. no deletes to it)
-   */
-  g_hash_table_iter_init (&iter, inodes);
-  while (g_hash_table_iter_next (&iter, &key, &value))
-    {
-      XdpInode *inode = (XdpInode *)value;
-
-      /* The kernel didn't tell us what to forget before unmounting */
-      if (inode->kernel_ref_count > 0)
-        kernel_refs = g_list_prepend (kernel_refs, xdp_inode_ref (inode));
-
-      /* This tmpfile was never unlinked */
-      if (inode->type == XDP_INODE_DOC_FILE && !inode->is_doc)
-        tmpfile_refs = g_list_prepend (tmpfile_refs, xdp_inode_ref (inode));
-    }
-
-  for (l = kernel_refs; l != NULL; l = l->next)
-    {
-      g_autoptr(XdpInode) inode = l->data;
-      g_autofree char *path = xdp_inode_get_path (inode);
-
-      g_debug ("unreffing kernel inode %s", path);
-      while (inode->kernel_ref_count > 0)
-        xdp_inode_kernel_unref (inode);
-    }
-
-  for (l = tmpfile_refs; l != NULL; l = l->next)
-    {
-      g_autoptr(XdpInode) inode = l->data;
-      g_autofree char *path = xdp_inode_get_path (inode);
-      g_autoptr(XdpInode) unlinked = NULL;
-
-      g_debug ("unlinking remaining tmpfile %s", path);
-      unlinked = xdp_inode_unlink_child (inode->parent, inode->filename);
-    }
-
-  /* Free toplevel inodes */
-  xdp_inode_unref (root_inode);
-  xdp_inode_unref (by_app_inode);
-}
 
 static gpointer
 xdp_fuse_mainloop (gpointer data)
@@ -2472,30 +2833,8 @@ xdp_fuse_mainloop (gpointer data)
     {
       GError *error = NULL;
       g_autoptr(GString) s = g_string_new ("");
-      GHashTableIter iter;
-      gpointer key, value;
-      gboolean ok = TRUE;
 
-      free_global_inodes ();
-
-      g_hash_table_iter_init (&iter, inodes);
-      while (g_hash_table_iter_next (&iter, &key, &value))
-        {
-          XdpInode *inode = (XdpInode *)value;
-          g_autofree char *path = xdp_inode_get_path (inode);
-
-          if (ok)
-            {
-              ok = FALSE;
-              g_string_append (s, "Leaked inodes: ");
-            }
-          else
-            g_string_append (s, ", ");
-          g_string_append (s, path);
-        }
-
-      if (ok)
-        g_string_append (s, "ok");
+      g_string_append (s, "ok");
 
       g_file_set_contents (status, s->str, -1, &error);
       g_assert_no_error (error);
@@ -2511,21 +2850,47 @@ xdp_fuse_mainloop (gpointer data)
 gboolean
 xdp_fuse_init (GError **error)
 {
-  char *argv[] = { "xdp-fuse", "-osplice_write,splice_move" };
-  struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (argv), argv);
+  /* Options:
+   *  auto_unmount: Tell fusermount to auto unmount if we die.
+   *  splice_read: use splice() to read from fuse pipe
+   *  splice_write: use splice() to write to fuse pipe
+   *  splice_move: move buffers from writing app to kernel during splice write
+   *  atomic_o_trunc: We handle O_TRUNC in create()
+   *  big_writes: Allow > 4k writes
+   */
+  char *fusermount_argv[] = { "xdp-fuse", "-osubtype=portal,fsname=portal,auto_unmount,splice_read,splice_write,splice_move,atomic_o_trunc,big_writes" };
+  struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (fusermount_argv), fusermount_argv);
   struct stat st;
   struct statfs stfs;
   const char *path;
+  struct rlimit rl;
   int statfs_res;
+  g_autoptr(XdpDomain) root_domain = NULL;
+  g_autoptr(XdpDomain) by_app_domain = NULL;
 
-  inodes =
-    g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, NULL);
-  root_inode = xdp_inode_new (ROOT_INODE, XDP_INODE_ROOT, NULL, "/", NULL, NULL);
-  by_app_inode = xdp_inode_new (BY_APP_INODE, XDP_INODE_BY_APP, root_inode, BY_APP_NAME, NULL, NULL);
-  dir_to_inode_nr =
-    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  my_uid = getuid ();
+  my_gid = getgid ();
+
+  all_inodes = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, NULL);
+
+  root_domain = xdp_domain_new_root ();
+  root_inode = xdp_inode_new (root_domain, NULL);
+  by_app_domain = xdp_domain_new_by_app (root_domain);
+  by_app_inode = xdp_inode_new (by_app_domain, NULL);
+
+  physical_inodes =
+    g_hash_table_new_full (devino_hash, devino_equal, NULL, NULL);
+
+    /* Bump nr of filedescriptor limit to max */
+  if (getrlimit (RLIMIT_NOFILE , &rl) == 0 &&
+      rl.rlim_cur != rl.rlim_max)
+    {
+      rl.rlim_cur = rl.rlim_max;
+      setrlimit (RLIMIT_NOFILE, &rl);
+    }
 
   path = xdp_fuse_get_mountpoint ();
+
   if ((stat (path, &st) == -1 && errno == ENOTCONN) ||
       (((statfs_res = statfs (path, &stfs)) == -1 && errno == ENOTCONN) ||
        (statfs_res == 0 && stfs.f_type == 0x65735546 /* fuse */)))
@@ -2552,6 +2917,7 @@ xdp_fuse_init (GError **error)
   main_ch = fuse_mount (path, &args);
   if (main_ch == NULL)
     {
+      fuse_opt_free_args (&args);
       g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_FAILED,
                    "Can't mount fuse fs on %s: %s", path, g_strerror (errno));
       return FALSE;
@@ -2561,6 +2927,7 @@ xdp_fuse_init (GError **error)
                                sizeof (xdp_fuse_oper), NULL);
   if (session == NULL)
     {
+      fuse_opt_free_args (&args);
       g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_FAILED,
                    "Can't create fuse session");
       return FALSE;
@@ -2569,5 +2936,128 @@ xdp_fuse_init (GError **error)
 
   fuse_thread = g_thread_new ("fuse mainloop", xdp_fuse_mainloop, session);
 
+  fuse_opt_free_args (&args);
+
   return TRUE;
+}
+
+void
+xdp_fuse_exit (void)
+{
+  if (!destroyed && session)
+    fuse_session_exit (session);
+
+  if (fuse_pthread)
+    pthread_kill (fuse_pthread, SIGHUP);
+
+  if (fuse_thread)
+    g_thread_join (fuse_thread);
+}
+
+const char *
+xdp_fuse_get_mountpoint (void)
+{
+  if (mount_path == NULL)
+    mount_path = g_build_filename (g_get_user_runtime_dir (), "doc", NULL);
+  return mount_path;
+}
+
+typedef struct {
+  fuse_ino_t ino;
+  char *filename;
+} Invalidate;
+
+/* Called with domain_inodes lock held, don't block */
+static void
+invalidate_doc_inode (XdpInode *parent_inode,
+                      const char *doc_id,
+                      GArray *invalidates)
+{
+  XdpInode *doc_inode = g_hash_table_lookup (parent_inode->domain->inodes, doc_id);
+  Invalidate inval;
+
+  if (doc_inode == NULL)
+    return;
+
+  inval.ino = xdp_inode_to_ino (doc_inode);
+  inval.filename = NULL;
+  g_array_append_val (invalidates, inval);
+
+  inval.ino = xdp_inode_to_ino (parent_inode);
+  inval.filename = g_strdup (doc_id);
+  g_array_append_val (invalidates, inval);
+
+  /* No need to invalidate doc children, we don't cache them */
+}
+
+
+/* Called when a apps permissions to see a document is changed,
+   and with null opt_app_id when the doc is created/removed */
+void
+xdp_fuse_invalidate_doc_app (const char *doc_id,
+                             const char *opt_app_id)
+{
+  g_autoptr(GArray) invalidates = NULL;
+  int i;
+
+  /* This can happen if fuse is not initialized yet for the very
+     first dbus message that activated the service */
+  if (main_ch == NULL)
+    return;
+
+  g_debug ("invalidate %s/%s", doc_id, opt_app_id ? opt_app_id : "*");
+
+  invalidates = g_array_new (FALSE, FALSE, sizeof (Invalidate));
+
+  G_LOCK (domain_inodes);
+  if (opt_app_id != NULL)
+    {
+      XdpInode *app_inode = g_hash_table_lookup (by_app_inode->domain->inodes, opt_app_id);
+      if (app_inode)
+        invalidate_doc_inode (app_inode, doc_id, invalidates);
+    }
+  else
+    {
+      GHashTableIter iter;
+      gpointer key, value;
+
+      invalidate_doc_inode (root_inode, doc_id, invalidates);
+      g_hash_table_iter_init (&iter, by_app_inode->domain->inodes);
+      while (g_hash_table_iter_next (&iter, &key, &value))
+        invalidate_doc_inode ((XdpInode *)value, doc_id, invalidates);
+    }
+
+  G_UNLOCK (domain_inodes);
+
+  for (i = 0; i < invalidates->len; i++)
+    {
+      Invalidate *invalidate = &g_array_index (invalidates, Invalidate, i);
+
+      if (invalidate->filename)
+        {
+          fuse_lowlevel_notify_inval_entry (main_ch, invalidate->ino,
+                                            invalidate->filename, strlen (invalidate->filename));
+          g_free (invalidate->filename);
+        }
+      else
+        fuse_lowlevel_notify_inval_inode (main_ch, invalidate->ino, 0, 0);
+    }
+}
+
+char *
+xdp_fuse_lookup_id_for_inode (ino_t ino)
+{
+  XdpInode *inode = _xdp_inode_from_maybe_ino (ino);
+  char *doc_id = NULL;
+
+  G_LOCK (all_inodes);
+  inode = g_hash_table_lookup (all_inodes, inode);
+  if (inode)
+    {
+      /* We're not allowed to ressurect the inode here, but we can get the data while in the lock */
+      doc_id = g_strdup (inode->domain->doc_id);
+    }
+  G_UNLOCK (all_inodes);
+
+  return doc_id;
 }

--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -3049,7 +3049,6 @@ xdp_fuse_lookup_id_for_inode (ino_t ino, gboolean directory,
                               char **real_path_out)
 {
   XdpInode *inode = _xdp_inode_from_maybe_ino (ino);
-  g_autofree char *doc_id = NULL;
   g_autoptr(XdpDomain) domain = NULL;
   g_autoptr(XdpPhysicalInode) physical = NULL;
 

--- a/document-portal/document-portal-fuse.h
+++ b/document-portal/document-portal-fuse.h
@@ -15,7 +15,9 @@ void        xdp_fuse_exit (void);
 const char *xdp_fuse_get_mountpoint (void);
 void        xdp_fuse_invalidate_doc_app (const char *doc_id,
                                          const char *opt_app_id);
-char      *xdp_fuse_lookup_id_for_inode (ino_t inode, gboolean directory);
+char      *xdp_fuse_lookup_id_for_inode (ino_t    inode,
+                                         gboolean directory,
+                                         char   **real_path_out);
 
 
 G_END_DECLS

--- a/document-portal/document-portal-fuse.h
+++ b/document-portal/document-portal-fuse.h
@@ -15,7 +15,7 @@ void        xdp_fuse_exit (void);
 const char *xdp_fuse_get_mountpoint (void);
 void        xdp_fuse_invalidate_doc_app (const char *doc_id,
                                          const char *opt_app_id);
-char      *xdp_fuse_lookup_id_for_inode (ino_t inode);
+char      *xdp_fuse_lookup_id_for_inode (ino_t inode, gboolean directory);
 
 
 G_END_DECLS

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -286,7 +286,7 @@ portal_delete (GDBusMethodInvocation *invocation,
 }
 
 static char *
-do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_existing, gboolean persistent)
+do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_existing, gboolean persistent, gboolean directory)
 {
   g_autoptr(GVariant) data = NULL;
   g_autoptr(PermissionDbEntry) entry = NULL;
@@ -294,12 +294,14 @@ do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_exis
   char *id = NULL;
   guint32 flags = 0;
 
-  g_debug ("Creating document at path '%s', resuse_existing: %d, persistent: %d", path, reuse_existing, persistent);
+  g_debug ("Creating document at path '%s', resuse_existing: %d, persistent: %d, directory: %d", path, reuse_existing, persistent, directory);
 
   if (!reuse_existing)
     flags |= DOCUMENT_ENTRY_FLAG_UNIQUE;
   if (!persistent)
     flags |= DOCUMENT_ENTRY_FLAG_TRANSIENT;
+  if (directory)
+    flags |= DOCUMENT_ENTRY_FLAG_DIRECTORY;
   data =
     g_variant_ref_sink (g_variant_new ("(^ayttu)",
                                        path,
@@ -348,8 +350,9 @@ do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_exis
 gboolean
 validate_fd (int fd,
              XdpAppInfo *app_info,
+             gboolean is_directory,
              struct stat *st_buf,
-             struct stat *real_parent_st_buf,
+             struct stat *real_dir_st_buf,
              char **path_out,
              gboolean *writable_out,
              GError **error)
@@ -360,41 +363,54 @@ validate_fd (int fd,
   xdp_autofd int dir_fd = -1;
   struct stat real_st_buf;
 
-  path = xdp_app_info_get_path_for_fd (app_info, fd, S_IFREG, st_buf, writable_out);
+  path = xdp_app_info_get_path_for_fd (app_info, fd, 0, st_buf, writable_out);
   if (path == NULL)
-    {
-      /* Don't leak any info about real file path existence, etc */
-      g_set_error (error,
-                   XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Invalid fd passed");
-      return FALSE;
-    }
+    goto errout;
 
-  /* We open the parent directory and do the stat in that, so that we have
-   * trustworthy parent dev/ino + filename for later verification. Otherwise the caller
-   * could later replace a parent with a symlink and make us read some other file.
-   */
-  dirname = g_path_get_dirname (path);
-  name = g_path_get_basename (path);
+  if (!is_directory && S_ISREG (st_buf->st_mode))
+    {
+      /* We open the parent directory and do the stat in that, so that we have
+       * trustworthy parent dev/ino + filename for later verification. Otherwise the caller
+       * could later replace a parent with a symlink and make us read some other file.
+       */
+      dirname = g_path_get_dirname (path);
+      name = g_path_get_basename (path);
+    }
+  else if (is_directory && S_ISDIR (st_buf->st_mode))
+    {
+      /* For dirs, we keep the dev/ino of the directory itself */
+      dirname = g_strdup (path);
+    }
+  else
+    goto errout;
+
   dir_fd = open (dirname, O_CLOEXEC | O_PATH);
+  if (dir_fd < 0 || fstat (dir_fd, real_dir_st_buf) != 0)
+    goto errout;
 
-  if (dir_fd < 0 ||
-      fstat (dir_fd, real_parent_st_buf) < 0 ||
-      fstatat (dir_fd, name, &real_st_buf, AT_SYMLINK_NOFOLLOW) < 0 ||
-      st_buf->st_dev != real_st_buf.st_dev ||
-      st_buf->st_ino != real_st_buf.st_ino)
+  if (name != NULL)
     {
-      /* Don't leak any info about real file path existence, etc */
-      g_set_error (error,
-                   XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Invalid fd passed");
-      return FALSE;
+      if (fstatat (dir_fd, name, &real_st_buf, AT_SYMLINK_NOFOLLOW) < 0 ||
+          st_buf->st_dev != real_st_buf.st_dev ||
+          st_buf->st_ino != real_st_buf.st_ino)
+        goto errout;
     }
+  else if (st_buf->st_dev != real_dir_st_buf->st_dev ||
+           st_buf->st_ino != real_dir_st_buf->st_ino)
+    goto errout;
+
 
   if (path_out)
     *path_out = g_steal_pointer (&path);
 
   return TRUE;
+
+ errout:
+  /* Don't leak any info about real file path existence, etc */
+  g_set_error (error,
+               XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+               "Invalid fd passed");
+  return FALSE;
 }
 
 static char *
@@ -727,8 +743,8 @@ document_add_full (int                      *fd,
   const char *app_id = xdp_app_info_get_id (app_info);
   g_autoptr(GPtrArray) ids = g_ptr_array_new_with_free_func (g_free);
   g_autoptr(GPtrArray) paths = g_ptr_array_new_with_free_func (g_free);
-  gboolean reuse_existing, persistent, as_needed_by_app, allow_write;
-  g_autofree struct stat *real_parent_st_bufs = NULL;
+  gboolean reuse_existing, persistent, as_needed_by_app, allow_write, is_dir;
+  g_autofree struct stat *real_dir_st_bufs = NULL;
   struct stat st_buf;
   g_autofree gboolean *writable = NULL;
   int i;
@@ -737,24 +753,25 @@ document_add_full (int                      *fd,
   reuse_existing = (flags & DOCUMENT_ADD_FLAGS_REUSE_EXISTING) != 0;
   persistent = (flags & DOCUMENT_ADD_FLAGS_PERSISTENT) != 0;
   as_needed_by_app = (flags & DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP) != 0;
+  is_dir = (flags & DOCUMENT_ADD_FLAGS_DIRECTORY) != 0;
   allow_write = (target_perms & DOCUMENT_PERMISSION_FLAGS_WRITE) != 0;
 
   g_ptr_array_set_size (paths, n_args + 1);
   g_ptr_array_set_size (ids, n_args + 1);
-  real_parent_st_bufs = g_new0 (struct stat, n_args);
+  real_dir_st_bufs = g_new0 (struct stat, n_args);
   writable = g_new0 (gboolean, n_args);
 
   for (i = 0; i < n_args; i++)
     {
       g_autofree char *path = NULL;
 
-      if (!validate_fd (fd[i], app_info, &st_buf, &real_parent_st_bufs[i], &path, &writable[i], error))
+      if (!validate_fd (fd[i], app_info, is_dir, &st_buf, &real_dir_st_bufs[i], &path, &writable[i], error))
         return NULL;
 
       if (parent_dev != NULL && parent_ino != NULL)
         {
-          if (real_parent_st_bufs[i].st_dev != parent_dev[i] ||
-              real_parent_st_bufs[i].st_ino != parent_ino[i])
+          if (real_dir_st_bufs[i].st_dev != parent_dev[i] ||
+              real_dir_st_bufs[i].st_ino != parent_ino[i])
             {
               g_set_error (error,
                            XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
@@ -776,6 +793,7 @@ document_add_full (int                      *fd,
       if (st_buf.st_dev == fuse_dev)
         {
           /* The passed in fd is on the fuse filesystem itself */
+          /* TODO: This reuse code is not right for directory exposes (i.e. which file in there?) */
           id = verify_existing_document (&st_buf, reuse_existing);
           if (id == NULL)
             {
@@ -814,7 +832,7 @@ document_add_full (int                      *fd,
 
         if (g_ptr_array_index(ids,i) == NULL)
           {
-            id = do_create_doc (&real_parent_st_bufs[i], path, reuse_existing, persistent);
+            id = do_create_doc (&real_dir_st_bufs[i], path, reuse_existing, persistent, is_dir);
             g_ptr_array_index(ids,i) = id;
 
             if (app_id[0] != '\0' && strcmp (app_id, target_app_id) != 0)
@@ -894,7 +912,9 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
       return;
     }
 
-  if ((flags & ~DOCUMENT_ADD_FLAGS_FLAGS_ALL) != 0)
+  if ((flags & ~DOCUMENT_ADD_FLAGS_FLAGS_ALL) != 0 ||
+      /* Don't support directory named documents */
+      (flags & DOCUMENT_ADD_FLAGS_DIRECTORY) != 0)
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
@@ -965,7 +985,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
       }
     else
       {
-        id = do_create_doc (&parent_st_buf, path, reuse_existing, persistent);
+        id = do_create_doc (&parent_st_buf, path, reuse_existing, persistent, FALSE);
 
         if (app_id[0] != '\0' && strcmp (app_id, target_app_id) != 0)
           {
@@ -1066,7 +1086,7 @@ portal_add_named (GDBusMethodInvocation *invocation,
 
   XDP_AUTOLOCK (db);
 
-  id = do_create_doc (&parent_st_buf, path, reuse_existing, persistent);
+  id = do_create_doc (&parent_st_buf, path, reuse_existing, persistent, FALSE);
 
   g_dbus_method_invocation_return_value (invocation,
                                          g_variant_new ("(s)", id));
@@ -1116,7 +1136,7 @@ portal_lookup (GDBusMethodInvocation *invocation,
   const char *filename;
   g_autofree char *path = NULL;
   xdp_autofd int fd = -1;
-  struct stat st_buf, real_parent_st_buf;
+  struct stat st_buf, real_dir_st_buf;
   g_auto(GStrv) ids = NULL;
   g_autofree char *id = NULL;
   GError *error = NULL;
@@ -1141,7 +1161,7 @@ portal_lookup (GDBusMethodInvocation *invocation,
       return TRUE;
     }
 
-  if (!validate_fd (fd, app_info, &st_buf, &real_parent_st_buf, &path, NULL, &error))
+  if (!validate_fd (fd, app_info, FALSE, &st_buf, &real_dir_st_buf, &path, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       return TRUE;
@@ -1151,6 +1171,7 @@ portal_lookup (GDBusMethodInvocation *invocation,
     {
       /* The passed in fd is on the fuse filesystem itself */
       id = xdp_fuse_lookup_id_for_inode (st_buf.st_ino);
+      /* TODO: Handle directory documents here */
       g_debug ("path on fuse, id %s", id);
     }
   else
@@ -1159,8 +1180,8 @@ portal_lookup (GDBusMethodInvocation *invocation,
 
       data = g_variant_ref_sink (g_variant_new ("(^ayttu)",
                                                 path,
-                                                (guint64)real_parent_st_buf.st_dev,
-                                                (guint64)real_parent_st_buf.st_ino,
+                                                (guint64)real_dir_st_buf.st_dev,
+                                                (guint64)real_dir_st_buf.st_ino,
                                                 0));
       ids = permission_db_list_ids_by_value (db, data);
       if (ids[0] != NULL)

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -924,7 +924,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
         parent_fd = fds[parent_fd_id];
     }
 
-  if (strchr (filename, '/') != NULL)
+  if (strchr (filename, '/') != NULL || *filename == 0)
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
@@ -1045,7 +1045,7 @@ portal_add_named (GDBusMethodInvocation *invocation,
         parent_fd = fds[parent_fd_id];
     }
 
-  if (strchr (filename, '/') != NULL)
+  if (strchr (filename, '/') != NULL || *filename == 0)
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
@@ -1063,8 +1063,6 @@ portal_add_named (GDBusMethodInvocation *invocation,
     }
 
   path = g_build_filename (parent_path, filename, NULL);
-
-  g_debug ("portal_add_named %s", path);
 
   XDP_AUTOLOCK (db);
 

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -634,7 +634,7 @@ portal_add_full (GDBusMethodInvocation *invocation,
   g_autoptr(GVariant) array = NULL;
   guint32 flags;
   const char *target_app_id;
-  const char **permissions = NULL;
+  g_autofree const char **permissions = NULL;
   DocumentPermissionFlags target_perms;
   gsize n_args;
   GDBusMessage *message;
@@ -1201,7 +1201,7 @@ get_path (PermissionDbEntry *entry)
   g_autoptr (GVariant) data = permission_db_entry_get_data (entry);
   const char *path;
 
-  g_variant_get (data, "(^ayttu)", &path, NULL, NULL, NULL);
+  g_variant_get (data, "(^&ayttu)", &path, NULL, NULL, NULL);
   return g_variant_new_bytestring (path);
 }
 
@@ -1503,7 +1503,7 @@ main (int    argc,
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
   GDBusConnection *session_bus;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   GDBusMethodInvocation *invocation;
 
   setlocale (LC_ALL, "");
@@ -1595,7 +1595,5 @@ main (int    argc,
 
   g_bus_unown_name (owner_id);
 
-  exit (final_exit_status);
-
-  return 0;
+  return final_exit_status;
 }

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1301,7 +1301,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   dbus_api = xdp_dbus_documents_skeleton_new ();
 
-  xdp_dbus_documents_set_version (XDP_DBUS_DOCUMENTS (dbus_api), 3);
+  xdp_dbus_documents_set_version (XDP_DBUS_DOCUMENTS (dbus_api), 4);
 
   g_signal_connect_swapped (dbus_api, "handle-get-mount-point", G_CALLBACK (handle_get_mount_point), NULL);
   g_signal_connect_swapped (dbus_api, "handle-add", G_CALLBACK (handle_method), portal_add);

--- a/document-portal/document-portal.h
+++ b/document-portal/document-portal.h
@@ -25,6 +25,7 @@
 
 gboolean validate_fd (int           fd,
                       XdpAppInfo   *app_info,
+                      gboolean      is_directory,
                       struct stat  *st_buf,
                       struct stat  *real_parent_st_buf,
                       char        **path_out,

--- a/document-portal/document-portal.h
+++ b/document-portal/document-portal.h
@@ -23,9 +23,15 @@
 #include <gio/gio.h>
 #include "document-enums.h"
 
+typedef enum {
+      VALIDATE_FD_FILE_TYPE_REGULAR,
+      VALIDATE_FD_FILE_TYPE_DIR,
+      VALIDATE_FD_FILE_TYPE_ANY,
+} ValidateFdType;
+
 gboolean validate_fd (int           fd,
                       XdpAppInfo   *app_info,
-                      gboolean      is_directory,
+                      ValidateFdType ensure_type,
                       struct stat  *st_buf,
                       struct stat  *real_parent_st_buf,
                       char        **path_out,

--- a/document-portal/document-store.h
+++ b/document-portal/document-store.h
@@ -9,6 +9,7 @@ G_BEGIN_DECLS
 
 #define DOCUMENT_ENTRY_FLAG_UNIQUE (1 << 0)
 #define DOCUMENT_ENTRY_FLAG_TRANSIENT (1 << 1)
+#define DOCUMENT_ENTRY_FLAG_DIRECTORY (1 << 2)
 
 const char **      xdg_unparse_permissions (DocumentPermissionFlags permissions);
 DocumentPermissionFlags xdp_parse_permissions (const char **permissions,

--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -417,7 +417,7 @@ add_files (GDBusMethodInvocation *invocation,
           return;
         }
 
-      if (!validate_fd (fd, app_info, &st_buf, &parent_st_buf, &path, &fd_is_writable, NULL) ||
+      if (!validate_fd (fd, app_info, FALSE, &st_buf, &parent_st_buf, &path, &fd_is_writable, NULL) ||
           (transfer->writable && !fd_is_writable))
         {
           g_dbus_method_invocation_return_error (invocation,

--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -417,7 +417,7 @@ add_files (GDBusMethodInvocation *invocation,
           return;
         }
 
-      if (!validate_fd (fd, app_info, FALSE, &st_buf, &parent_st_buf, &path, &fd_is_writable, NULL) ||
+      if (!validate_fd (fd, app_info, VALIDATE_FD_FILE_TYPE_REGULAR, &st_buf, &parent_st_buf, &path, &fd_is_writable, NULL) ||
           (transfer->writable && !fd_is_writable))
         {
           g_dbus_method_invocation_return_error (invocation,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -173,3 +173,20 @@ gboolean xdp_spawnv     (GFile                *dir,
 char * xdp_canonicalize_filename (const char *path);
 gboolean  xdp_has_path_prefix (const char *str,
                                const char *prefix);
+
+#if !GLIB_CHECK_VERSION (2, 58, 0)
+static inline gboolean
+g_hash_table_steal_extended (GHashTable    *hash_table,
+                             gconstpointer  lookup_key,
+                             gpointer      *stolen_key,
+                             gpointer      *stolen_value)
+{
+  if (g_hash_table_lookup_extended (hash_table, lookup_key, stolen_key, stolen_value))
+    {
+      g_hash_table_steal (hash_table, lookup_key);
+      return TRUE;
+    }
+  else
+      return FALSE;
+}
+#endif

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -102,7 +102,16 @@ if ENABLE_INSTALLED_TESTS
 dist_installed_test_dbs_DATA = tests/dbs/no_tables
 endif
 
+dist_installed_test_data = \
+	tests/session.conf.in \
+	$(NULL)
+
+dist_installed_test_extra_scripts = \
+	tests/test-document-fuse.py \
+	$(NULL)
+
 dist_test_scripts = \
+	tests/test-document-fuse.sh \
 	$(NULL)
 
 test_programs += \

--- a/tests/session.conf.in
+++ b/tests/session.conf.in
@@ -1,0 +1,56 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Our well-known bus type, don't change this -->
+  <type>session</type>
+
+  <!-- If we fork, keep the user's original umask to avoid affecting
+       the behavior of child processes. -->
+  <keep_umask/>
+
+  <listen>unix:tmpdir=/tmp</listen>
+
+  <servicedir>@testdir@/services</servicedir>
+
+  <!-- disabled for now; this causes gnome-keyring to be spawned, which can
+       interfere with user's real keyrings, as well as causing long delays
+       during D-BUS activation -->
+  <!-- <standard_session_servicedirs /> -->
+
+  <policy context="default">
+    <!-- Allow everything to be sent -->
+    <allow send_destination="*" eavesdrop="true"/>
+    <!-- Allow everything to be received -->
+    <allow eavesdrop="true"/>
+    <!-- Allow anyone to own anything -->
+    <allow own="*"/>
+  </policy>
+
+  <include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include>
+
+  <!-- For the session bus, override the default relatively-low limits 
+       with essentially infinite limits, since the bus is just running 
+       as the user anyway, using up bus resources is not something we need 
+       to worry about. In some cases, we do set the limits lower than 
+       "all available memory" if exceeding the limit is almost certainly a bug, 
+       having the bus enforce a limit is nicer than a huge memory leak. But the 
+       intent is that these limits should never be hit. -->
+
+  <!-- the memory limits are 1G instead of say 4G because they can't exceed 32-bit signed int max -->
+  <limit name="max_incoming_bytes">1000000000</limit>
+  <limit name="max_incoming_unix_fds">250000000</limit>
+  <limit name="max_outgoing_bytes">1000000000</limit>
+  <limit name="max_outgoing_unix_fds">250000000</limit>
+  <limit name="max_message_size">1000000000</limit>
+  <limit name="max_message_unix_fds">4096</limit>
+  <limit name="service_start_timeout">120000</limit>  
+  <limit name="auth_timeout">240000</limit>
+  <limit name="max_completed_connections">100000</limit>  
+  <limit name="max_incomplete_connections">10000</limit>
+  <limit name="max_connections_per_user">100000</limit>
+  <limit name="max_pending_service_starts">10000</limit>
+  <limit name="max_names_per_connection">50000</limit>
+  <limit name="max_match_rules_per_connection">50000</limit>
+  <limit name="max_replies_per_connection">50000</limit>
+
+</busconfig>

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -925,7 +925,7 @@ test_version (void)
       return;
     }
 
-  g_assert_cmpint (xdp_dbus_documents_get_version (documents), ==, 3);  
+  g_assert_cmpint (xdp_dbus_documents_get_version (documents), ==, 4);
 }
 
 int

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -507,7 +507,7 @@ test_create_docs (void)
   guint32 fd_ids[2];
   GUnixFDList *fd_list = NULL;
   gboolean res;
-  char **out_doc_ids;
+  g_auto(GStrv) out_doc_ids = NULL;
   g_autoptr(GVariant) out_extra = NULL;
   const char *permissions[] = { "read", NULL };
   const char *basenames[] = { "doc1", "doc2" };
@@ -743,6 +743,7 @@ check_fuse (void)
 
   if (chan == NULL)
     {
+      fuse_opt_free_args (&args);
       cannot_use_fuse = g_strdup_printf ("fuse_mount: %s",
                                          g_strerror (errno));
       return FALSE;
@@ -754,6 +755,8 @@ check_fuse (void)
 
   if (g_rmdir (path) != 0)
     g_error ("rmdir %s: %s", path, g_strerror (errno));
+
+  fuse_opt_free_args (&args);
 
   return TRUE;
 }

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -1,0 +1,821 @@
+#!/usr/bin/env python3
+
+import os, sys, stat, random, errno, argparse
+from gi.repository import Gio, GLib
+
+def filename_to_ay(filename):
+    return list(filename.encode("utf-8")) + [0]
+
+running_count = {}
+
+app_prefix = "org.test."
+dir_prefix = "dir"
+ensure_no_remaining = True
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--verbose', '-v', action='count')
+parser.add_argument("--iterations", type=int, default=3)
+parser.add_argument("--prefix")
+args = parser.parse_args(sys.argv[1:])
+
+if args.prefix:
+    app_prefix = app_prefix + args.prefix + "."
+    dir_prefix = dir_prefix + "-" + args.prefix + "-"
+    ensure_no_remaining = False
+
+def log(str):
+    if args.prefix:
+        print("%s: %s" % (args.prefix, str))
+    else:
+        print(str)
+
+def logv(str):
+    if args.verbose:
+        log(str)
+
+def get_a_count(counter):
+    global running_count
+    if counter in running_count:
+        count = running_count[counter]
+        count = count + 1
+        running_count[counter] = count
+        return count
+    running_count[counter] = 1
+    return 1
+
+def setFileContent(path, content):
+    with open(path, "w") as f:
+        f.write(content)
+
+def appendFileContent(path, content):
+    with open(path, "a") as f:
+        f.write(content)
+
+def readFdContent(fd):
+    os.lseek(fd, 0, os.SEEK_SET)
+    return str(os.read(fd, 64*1024), "utf-8")
+
+def replaceFdContent(fd, content):
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.ftruncate(fd, 0)
+    os.write(fd, bytes(content, "utf-8"))
+
+def appendFdContent(fd, content):
+    os.lseek(fd, 0, os.SEEK_END)
+    os.write(fd, bytes(content, "utf-8"))
+
+TEST_DATA_DIR=os.environ['TEST_DATA_DIR']
+DOCUMENT_ADD_FLAGS_REUSE_EXISTING             = (1 << 0)
+DOCUMENT_ADD_FLAGS_PERSISTENT                 = (1 << 1)
+DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP           = (1 << 2)
+DOCUMENT_ADD_FLAGS_DIRECTORY                  = (1 << 3)
+
+def assertRaises(exc_type, func, *args, **kwargs):
+    raised_exc = None
+    try:
+        func(*args, **kwargs)
+    except:
+        raised_exc = sys.exc_info()[0]
+
+    if not raised_exc:
+        raise AssertionError("{0} was not raised".format(exc_type.__name__))
+    if raised_exc != exc_type:
+        raise AssertionError("Wrong assertion type {0} was raised instead of {1}".format(raised_exc.__name__, exc_type.__name__))
+
+def assertRaisesErrno(error_nr, func, *args, **kwargs):
+    raised_exc = None
+    raised_exc_value = None
+    try:
+        func(*args, **kwargs)
+    except:
+        raised_exc = sys.exc_info()[0]
+        raised_exc_value = sys.exc_info()[1]
+
+    if not raised_exc:
+        raise AssertionError("No assertion was raised")
+    if raised_exc != OSError:
+        raise AssertionError("OSError was not raised")
+    if raised_exc_value.errno != error_nr:
+        raise AssertionError("Wrong errno {0} was raised instead of {1}".format(raised_exc_value.errno, error_nr))
+
+def assertEmpty(a_set):
+    if len(a_set) != 0:
+        raise AssertionError("Set was not empty as expected (was: {0})".format(a_set))
+
+def assertEqual(a, b):
+    if a != b:
+        raise AssertionError("{} was not the expected {}".format(a, b))
+
+def assertIn(element, container):
+    if not element in container:
+        raise AssertionError("{} was not in the container {}".format(element, container))
+
+def assertFileHasContent(path, expected_content):
+    with open(path) as f:
+        file_content = f.read()
+        assertEqual(file_content, expected_content)
+
+def assertFdHasContent(fd, expected_content):
+    content = readFdContent(fd)
+    assertEqual(content, expected_content)
+
+def assertSameStat(a, b, b_mode_mask):
+    if not (a.st_mode == (b.st_mode & b_mode_mask) and
+            a.st_nlink == b.st_nlink and
+            a.st_size == b.st_size and
+            a.st_uid == b.st_uid and
+            a.st_gid == b.st_gid and
+            a.st_atime == b.st_atime and
+            a.st_mtime == b.st_mtime and
+            a.st_ctime == b.st_ctime):
+        raise AssertionError("Stat value {} was not the expected {})".format(a, b))
+
+def assertFileExist(path):
+    try:
+        info = os.lstat(path)
+        if info.st_mode & stat.S_IFREG != stat.S_IFREG:
+            raise AssertionError("File {} is not a regular file".format(path))
+    except:
+        raise AssertionError("File {} doesn't exist".format(path))
+
+def assertDirExist(path):
+    try:
+        info = os.lstat(path)
+        if info.st_mode & stat.S_IFDIR != stat.S_IFDIR:
+            raise AssertionError("File {} is not a directory file".format(path))
+    except:
+        raise AssertionError("File {} doesn't exist".format(path))
+
+def assertSymlink(path, expected_target):
+    try:
+        info = os.lstat(path)
+        if info.st_mode & stat.S_IFLNK != stat.S_IFLNK:
+            raise AssertionError("File {} is not a symlink".format(path))
+        target = os.readlink(path)
+        if target != expected_target:
+            raise AssertionError("File {} has wrong target {}, expected {}".format(path, target, expected_target))
+    except:
+        raise AssertionError("Symlink {} doesn't exist".format(path))
+
+def assertFileNotExist(path):
+    try:
+        os.lstat(path)
+    except FileNotFoundError:
+        return
+    except:
+        raise AssertionError("Got wrong execption {} for {}, expected FileNotFoundError".format(sys.exc_info()[0], path))
+    raise AssertionError("Path {} unexpectedly exists".format(path))
+
+def assertDirFiles(path, expected_files, exhaustive = True):
+    found_files = os.listdir (path)
+    remaining = set(found_files)
+    for file in expected_files:
+        if not file in remaining:
+            raise AssertionError("Expected file {} not found in dir {} (all: {})".format(file, path, found_files))
+        remaining.remove(file)
+    if exhaustive:
+        if len(remaining) != 0:
+            raise AssertionError("Unexpected files {} in dir {} (all: {})".format(remaining, path, found_files))
+
+class Doc:
+    def __init__(self, portal, id, path, content, is_dir = False):
+        self.portal = portal
+        self.id = id
+        self.content = content
+        self.real_path = path
+        self.is_dir = is_dir
+        self.apps = []
+        self.files = []
+
+        if is_dir:
+            self.real_dirname = path
+            self.filename = None
+        else:
+            (self.real_dirname, self.filename) = os.path.split(path)
+            if content:
+                self.files.append(self.filename)
+
+    def is_readable_by(self, app_id):
+        if app_id:
+            return app_id in self.apps
+        return True
+
+    def is_writable_by(self, app_id):
+        if app_id:
+            return app_id in self.apps and ".write." in app_id
+        else:
+            return True
+
+    def get_doc_path(self, app_id):
+        if app_id:
+            return portal.app_path(app_id) + "/" + self.id
+        else:
+            return portal.mountpoint + "/" + self.id
+
+    def __str__(self):
+        name = self.id
+        if self.is_dir:
+            return "%s(dir)" % (name)
+        elif self.content == None:
+            return "%s(missing)" % (name)
+        else:
+            return "%s" % (name)
+
+class DocPortal:
+    def __init__(self):
+        self.apps = []
+        self.docs = {}
+        self.bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        self.proxy = Gio.DBusProxy.new_sync( self.bus, Gio.DBusProxyFlags.NONE, None,
+                                             "org.freedesktop.portal.Documents", "/org/freedesktop/portal/documents", "org.freedesktop.portal.Documents", None)
+        self.mountpoint = self.get_mount_path()
+
+    def get_mount_path(self):
+        res = self.proxy.call_sync ("GetMountPoint",
+                                    GLib.Variant('()', ()),
+                                    0, -1, None)
+        return bytearray(res[0][:-1]).decode("utf-8")
+
+    def grant_permissions(self, doc_id, app_id, permissions):
+        self.proxy.call_sync ("GrantPermissions",
+                              GLib.Variant('(ssas)', (doc_id, app_id, permissions)),
+                              0, -1, None)
+
+    def add(self, path):
+        fdlist = Gio.UnixFDList.new()
+        fd = os.open (path, os.O_PATH)
+        handle = fdlist.append(fd);
+        os.close(fd)
+        res = self.proxy.call_with_unix_fd_list_sync ("Add",
+                                                      GLib.Variant('(hbb)',
+                                                                   (handle, False, False)),
+                                                      0, -1, fdlist, None)
+        doc_id = res[0][0]
+        with open(path) as f:
+            content = f.read()
+        doc = Doc(self, doc_id, path, content)
+        self.docs[doc.id] = doc
+        return doc
+
+    def add_named(self, path):
+        (dirname, filename) = os.path.split(path)
+        fdlist = Gio.UnixFDList.new()
+        fd = os.open (dirname, os.O_PATH)
+        handle = fdlist.append(fd);
+        os.close(fd)
+        res = self.proxy.call_with_unix_fd_list_sync ("AddNamed",
+                                                      GLib.Variant('(haybb)',
+                                                                   (handle, filename_to_ay(filename), False, False)),
+                                                      0, -1, fdlist, None)
+        doc_id = res[0][0]
+        try:
+            with open(path) as f:
+                content = f.read()
+        except:
+            content = None
+        doc = Doc(self, doc_id, path, content)
+        self.docs[doc.id] = doc
+        return doc
+
+    def add_full(self, path, flags):
+        fdlist = Gio.UnixFDList.new()
+        fd = os.open (path, os.O_PATH)
+        handle = fdlist.append(fd);
+        os.close(fd)
+        res = self.proxy.call_with_unix_fd_list_sync ("AddFull",
+                                                      GLib.Variant('(ahusas)',
+                                                                   ([handle], flags, '', [])),
+                                                      0, -1, fdlist, None)
+        doc_id = res[0][0][0]
+        doc = Doc(self, doc_id, path, True, (flags & DOCUMENT_ADD_FLAGS_DIRECTORY) != 0)
+        self.docs[doc.id] = doc
+        return doc
+
+    def add_dir(self, path):
+        return self.add_full (path, DOCUMENT_ADD_FLAGS_DIRECTORY)
+
+    def get_docs_for_app(self, app_id):
+        docs = []
+        for doc in self.docs.values():
+            if doc.is_readable_by(app_id):
+                docs.append(doc.id)
+        return docs
+
+    def ensure_app_id(self, app_id):
+        if not app_id in self.apps:
+            self.apps.append(app_id)
+
+    def get_docs(self):
+        return list(portal.docs.values())
+
+    def get_docs_randomized(self):
+        docs = list(portal.docs.values())
+        random.shuffle(docs)
+        return docs
+
+    def get_doc(self, doc_id):
+        return self.docs[doc_id]
+
+    def get_app_ids(self):
+        return self.apps
+
+    def get_app_ids_randomized(self):
+        apps = self.apps.copy()
+        random.shuffle(apps)
+        return apps
+
+    def by_app_path(self):
+        return portal.mountpoint + "/by-app"
+
+    def app_path(self, app_id):
+        return portal.mountpoint + "/by-app/" + app_id
+
+def check_virtual_stat (info, writable = False):
+    assertEqual(info.st_uid, os.getuid())
+    assertEqual(info.st_gid, os.getgid())
+    if writable:
+        assertEqual(info.st_mode, stat.S_IFDIR | 0o700)
+    else:
+        assertEqual(info.st_mode, stat.S_IFDIR | 0o500)
+
+def verify_virtual_dir (path, files):
+    info = os.lstat(path)
+    check_virtual_stat (info)
+    assert os.access(path, os.R_OK)
+    assert not os.access(path, os.W_OK)
+
+    assertRaises(FileNotFoundError, os.lstat, path + "/not-existing-file")
+
+    if files != None:
+        assertDirFiles(path, files, ensure_no_remaining)
+
+def verify_doc(doc, app_id=None):
+    dir = doc.get_doc_path(app_id)
+    info = os.lstat(dir)
+    check_virtual_stat (info, doc.is_writable_by(app_id))
+    assert os.access(dir, os.R_OK)
+    if doc.is_writable_by(app_id):
+        assert os.access(dir, os.W_OK)
+    else:
+        assert not os.access(dir, os.W_OK)
+
+    assertRaises(FileNotFoundError, os.lstat, dir + "/not-existing-file")
+
+    assertDirFiles(dir, doc.files)
+
+    for file in doc.files:
+        filepath = dir + "/" + file
+        info = os.lstat(filepath)
+        assertEqual(info.st_uid, os.getuid())
+        assertEqual(info.st_gid, os.getgid())
+
+        assert os.access(filepath, os.R_OK)
+        if doc.is_writable_by(app_id):
+            assert os.access(filepath, os.W_OK)
+        else:
+            assert not os.access(filepath, os.W_OK)
+
+    if doc.filename:
+        main_path = dir + "/" + doc.filename
+        real_path = doc.real_path
+        if doc.content:
+            assertFileExist(main_path)
+            content = None
+            assertFileHasContent(main_path, doc.content)
+            assertFileHasContent(real_path, doc.content)
+
+            info = os.lstat(main_path)
+            real_info = os.lstat(real_path)
+            mode_mask = ~(stat.S_ISUID|stat.S_ISGID|stat.S_ISVTX);
+            if not doc.is_writable_by(app_id):
+                mode_mask = mode_mask & ~(stat.S_IWUSR|stat.S_IWGRP|stat.S_IWOTH);
+            assertSameStat(info, real_info, mode_mask)
+
+        else:
+            assertRaises(FileNotFoundError, os.lstat, main_path)
+            assertRaises(FileNotFoundError, os.open, main_path, os.O_RDONLY)
+            assertRaises(FileNotFoundError, os.lstat, doc.real_path)
+            assertRaises(FileNotFoundError, os.open, doc.real_path, os.O_RDONLY)
+
+    # Ensure no leftover temp files
+    for real_file in os.listdir (os.path.dirname(doc.real_path)):
+        assert not real_file.startswith(".xdp")
+
+def verify_fs_layout():
+    verify_virtual_dir (portal.mountpoint, ["by-app"] + list(portal.docs.keys()))
+    verify_virtual_dir (portal.by_app_path(), portal.get_app_ids())
+
+    for doc in portal.get_docs():
+        verify_doc(doc)
+
+    # Verify the by-app subdirs (just the directory for now)
+    for app_id in portal.get_app_ids():
+        docs_for_app = portal.get_docs_for_app(app_id)
+        verify_virtual_dir (portal.app_path(app_id), docs_for_app)
+        for doc_id in docs_for_app:
+            doc = portal.get_doc(doc_id)
+            verify_doc(doc, app_id)
+
+def check_virtdir_perms(path):
+    assertRaises(PermissionError, os.mkdir, path + "/a_dir")
+    assertRaises(PermissionError, os.open, path + "/a-file", os.O_RDWR|os.O_CREAT)
+
+def check_root_perms(path):
+    check_virtdir_perms(path)
+    assertRaises(PermissionError, os.rename, path + "/by-app", path + "/by-app2")
+    assertRaises(PermissionError, os.rmdir, path + "/by-app")
+
+def check_byapp_perms(path):
+    check_virtdir_perms(path)
+    assertRaises(PermissionError, os.mkdir, path + "/a_dir")
+
+def check_regular_doc_perms(doc, app_id):
+    path = doc.get_doc_path(app_id)
+    writable = doc.is_writable_by(app_id)
+    # regular documents, can't do most stuff
+    assertRaises(PermissionError, os.mkdir, path + "/dir")
+    assertRaises(PermissionError, os.symlink, "symlink-value", path + "/symlink")
+
+    docpath = path + "/" + doc.filename
+    tmppath = path + "/a-tmpfile"
+    tmppath2 = path + "/another-tmpfile"
+    if doc.content: # Main file exists
+        assertFileExist(docpath)
+        assertFileExist(doc.real_path)
+        assertRaises(PermissionError, os.link, docpath, path + "/a-hardlink")
+        assertRaises(NotADirectoryError, os.rmdir, docpath)
+        assertRaises(PermissionError, os.setxattr, docpath, "user.attr", b"foo")
+        assertRaises(PermissionError, os.removexattr, docpath, "user.attr")
+
+        fd = os.open(docpath, os.O_RDONLY, 0o600)
+        os.close(fd)
+
+        if not writable:
+            assertRaises(PermissionError, os.open, docpath, os.O_RDONLY|os.O_TRUNC, 0o600)
+            assertRaises(PermissionError, os.open, docpath, os.O_WRONLY, 0o600)
+            assertRaises(PermissionError, os.open, docpath, os.O_RDWR, 0o600)
+            assertRaises(PermissionError, os.rename, docpath, docpath + "renamed")
+            assertRaises(PermissionError, os.truncate, docpath, 1)
+            assertRaises(PermissionError, os.unlink, docpath)
+            assertRaises(PermissionError, os.utime, docpath)
+        else:
+            # Can't move file out of docdir or into other version of same docdir
+            assertRaisesErrno(errno.EXDEV, os.rename, docpath, path + "/../" + doc.filename)
+            if app_id:
+                assertRaisesErrno(errno.EXDEV, os.rename, docpath, doc.get_doc_path(None) + doc.filename)
+            if doc.apps and app_id != doc.apps[0]:
+                assertRaisesErrno(errno.EXDEV, os.rename, docpath, doc.get_doc_path(doc.apps[0]) + doc.filename)
+
+            # Ensure we can read it (multiple times)
+            fd = os.open(docpath, os.O_RDONLY, 0o600)
+            assertFdHasContent(fd, doc.content)
+            assertFdHasContent(fd, doc.content)
+
+            # Ensure we can rename it
+            os.rename(docpath, docpath + "_renamed")
+            assertRaises(FileNotFoundError, os.open, docpath, os.O_RDONLY, 0o600)
+            # ... and still read it
+            assertFdHasContent(fd, doc.content)
+
+            # Ensure we can delete it
+            os.unlink(docpath + "_renamed")
+            # ... and still read it
+            assertFdHasContent(fd, doc.content)
+            os.close(fd)
+
+            # Replace main file with rename of tmpfile
+            setFileContent(docpath, "orig-data")
+            fd1 = os.open(docpath, os.O_RDONLY, 0o600)
+
+            setFileContent(tmppath, "new-data")
+            fd2 = os.open(tmppath, os.O_RDONLY, 0o600)
+
+            os.rename(tmppath, tmppath2)
+            assertRaises(FileNotFoundError, os.lstat, tmppath)
+            assertFdHasContent(fd2, "new-data")
+            assertFileHasContent(tmppath2, "new-data")
+
+            os.rename(tmppath2, docpath)
+            assertRaises(FileNotFoundError, os.lstat, tmppath2)
+            assertFdHasContent(fd1, "orig-data")
+            assertFdHasContent(fd2, "new-data")
+            assertFileHasContent(docpath, "new-data")
+            appendFileContent(docpath, "-more")
+            assertFdHasContent(fd2, "new-data-more")
+
+            setFileContent(tmppath, "replace-this-data")
+            fd3 = os.open(tmppath, os.O_RDONLY, 0o600)
+            os.rename(docpath, tmppath)
+            assertFdHasContent(fd2, "new-data-more")
+            assertFdHasContent(fd3, "replace-this-data")
+            fd4 = os.open(tmppath, os.O_RDWR, 0o600)
+            assertFdHasContent(fd4, "new-data-more")
+
+            # Restore original version
+            os.rename(tmppath, docpath)
+            replaceFdContent(fd4, doc.content)
+            assertFdHasContent(fd2, doc.content)
+            assertFdHasContent(fd4, doc.content)
+            assertFileHasContent(docpath, doc.content)
+            assertFdHasContent(fd1, "orig-data")
+            assertFdHasContent(fd3, "replace-this-data")
+
+            os.close(fd1)
+            os.close(fd2)
+            os.close(fd3)
+            os.close(fd4)
+
+            assertRaises(NotADirectoryError, os.rmdir, docpath)
+            assertRaises(PermissionError, os.link, docpath, path + "/a-hardlink")
+            assertRaises(PermissionError, os.setxattr, docpath, "user.attr", b"foo")
+            assertRaises(PermissionError, os.removexattr, docpath, "user.attr")
+
+    else: # Main file doesn't exist
+        assertFileNotExist(docpath)
+        assertFileNotExist(doc.real_path)
+        if writable: # But we can create it
+            setFileContent(docpath, "some-data")
+            assertFileHasContent(docpath, "some-data")
+            os.unlink(docpath)
+        else: # And we can't create it
+            assertRaises(PermissionError, os.open, docpath, os.O_CREAT|os.O_RDONLY|os.O_TRUNC, 0o600)
+            assertRaises(PermissionError, os.open, docpath, os.O_CREAT|os.O_WRONLY, 0o600)
+            assertRaises(PermissionError, os.open, docpath, os.O_CREAT|os.O_RDWR, 0o600)
+
+        # Ensure it show up if created outside
+        setFileContent(doc.real_path, "from-outside")
+        assertFileExist(docpath)
+        assertFileHasContent(docpath, "from-outside")
+        if writable:
+            os.unlink(docpath)
+        else:
+            assertRaises(PermissionError, os.unlink, docpath)
+            os.unlink(doc.real_path)
+        assertFileNotExist(docpath)
+
+    if writable: # We can create tempfiles, do some simple checks
+        setFileContent(tmppath, "tempdata")
+        assertFileHasContent(tmppath, "tempdata")
+        assertRaises(NotADirectoryError, os.rmdir, tmppath)
+        assertRaises(PermissionError, os.link, tmppath, path + "/a-hardlink")
+        assertRaises(PermissionError, os.setxattr, tmppath, "user.attr", b"foo")
+        assertRaises(PermissionError, os.removexattr, tmppath, "user.attr")
+
+        os.rename(tmppath, tmppath2)
+        assertFileHasContent(tmppath2, "tempdata")
+        os.unlink(tmppath2)
+    else:
+        # We should be unable to create tempfiles
+        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT|os.O_RDONLY|os.O_TRUNC, 0o600)
+        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT|os.O_WRONLY, 0o600)
+        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT|os.O_RDWR, 0o600)
+
+def check_directory_doc_perms(doc, app_id):
+    writable = doc.is_writable_by(app_id)
+
+    docpath = doc.get_doc_path(app_id)
+    realpath = doc.real_path
+
+    # Create some pre-existing files:
+
+    real_dir = realpath + "/dir"
+    os.mkdir(real_dir)
+    setFileContent(real_dir + "/realfile", "real1")
+    setFileContent(real_dir + "/readonly", "readonly")
+    os.chmod(real_dir + "/readonly", 0o500)
+    os.mkdir(real_dir + "/subdir")
+    os.link(real_dir + "/realfile", real_dir + "/subdir/hardlink")
+    os.symlink("realfile", real_dir + "/symlink")
+    os.symlink("the-void", real_dir + "/broken-symlink")
+
+    # Ensure they are visible via portal
+
+    dir = docpath + "/dir"
+    assertDirFiles(docpath, ["dir"])
+    assertDirExist(dir)
+    assertDirFiles(dir, ["realfile", "readonly", "subdir", "symlink", "broken-symlink"])
+    assertDirExist(dir + "/subdir")
+    assertDirFiles(dir + "/subdir", ["hardlink"])
+    assertFileHasContent(dir + "/realfile", "real1")
+    assertFileHasContent(dir + "/readonly", "readonly")
+    assertFileHasContent(dir + "/subdir/hardlink", "real1")
+    assertEqual(os.lstat(dir + "/realfile").st_ino,
+                os.lstat(dir + "/subdir/hardlink").st_ino)
+    assertSymlink(dir + "/symlink", "realfile")
+    assertSymlink(dir + "/broken-symlink", "the-void")
+
+    filepath = docpath + "/a-file"
+    real_filepath = doc.real_path + "/a-file"
+    filepath2 = docpath + "/dir/a-file2"
+    real_filepath2 = doc.real_path + "/dir/a-file2"
+
+    if writable: # We can create files
+        assertRaises(PermissionError, os.open, dir + "/readonly", os.O_RDWR)
+        os.chmod(dir + "/readonly", 0o700)
+        fd = os.open (dir + "/readonly", os.O_RDWR) # Works now
+        os.close(fd)
+
+        setFileContent(filepath, "filedata")
+        assertFileHasContent(filepath, "filedata")
+        assertFileHasContent(real_filepath, "filedata")
+
+        fd = os.open (filepath, os.O_RDONLY)
+        fd2 = os.open (filepath, os.O_RDWR)
+        assertFdHasContent(fd, "filedata")
+        assertFdHasContent(fd2, "filedata")
+        appendFdContent(fd2, "-more")
+        assertFdHasContent(fd, "filedata-more")
+        assertFdHasContent(fd2, "filedata-more")
+
+        os.link(filepath, filepath2)
+        assertEqual(os.lstat(filepath).st_ino,
+                    os.lstat(filepath2).st_ino)
+        assertEqual(os.lstat(filepath).st_ino,
+                    os.fstat(fd).st_ino)
+        assertFileHasContent(filepath2, "filedata-more")
+        assertFileHasContent(real_filepath2, "filedata-more")
+
+        os.unlink(filepath)
+        assertFileNotExist(filepath)
+        assertFileNotExist(real_filepath)
+        assertFdHasContent(fd, "filedata-more")
+        assertFdHasContent(fd2, "filedata-more")
+
+        replaceFdContent(fd2, "replaced")
+        assertFileHasContent(filepath2, "replaced")
+        assertFileHasContent(real_filepath2, "replaced")
+        assertFileNotExist(filepath)
+        assertFileNotExist(real_filepath)
+        assertFdHasContent(fd, "replaced")
+        assertFdHasContent(fd2, "replaced")
+
+        # Move between dirs
+        os.rename (filepath2, docpath + "/moved")
+        assertFileHasContent(docpath + "/moved", "replaced")
+
+        assertRaisesErrno(errno.EXDEV, os.rename, docpath, portal.mountpoint)
+
+        os.unlink(docpath + "/moved")
+
+        os.close(fd)
+        os.close(fd2)
+
+        os.symlink("realfile", dir + "/symlink2")
+        os.symlink("the-void", dir + "/broken-symlink2")
+        assertSymlink(dir + "/symlink2", "realfile")
+        assertSymlink(dir + "/broken-symlink2", "the-void")
+        os.unlink(dir + "/symlink2")
+        os.unlink(dir + "/broken-symlink2")
+
+    else:
+        # We should be unable to create files
+        assertRaises(PermissionError, os.open, filepath, os.O_CREAT|os.O_RDONLY|os.O_TRUNC, 0o600)
+        assertRaises(PermissionError, os.open, filepath, os.O_CREAT|os.O_WRONLY, 0o600)
+        assertRaises(PermissionError, os.open, filepath, os.O_CREAT|os.O_RDWR, 0o600)
+
+        assertRaises(PermissionError, os.open, dir + "/realfile", os.O_RDWR)
+        assertRaises(PermissionError, os.open, dir + "/readonly", os.O_RDWR)
+        assertRaises(PermissionError, os.truncate, dir + "/realfile", 0)
+        assertRaises(PermissionError, os.link, dir + "/realfile", dir + "/foo")
+        assertRaises(PermissionError, os.symlink, "foo", dir + "/new-symlink")
+        assertRaises(PermissionError, os.rename, dir + "/realfile", dir + "/foo")
+        assertRaises(PermissionError, os.unlink, dir + "/realfile")
+        assertRaises(PermissionError, os.chmod, dir + "/realfile", 0o700)
+        assertRaises(PermissionError, os.rmdir, dir + "/subdir")
+
+    os.unlink(real_dir + "/realfile")
+    os.unlink(real_dir + "/readonly")
+    os.unlink(real_dir + "/subdir/hardlink")
+    os.unlink(real_dir + "/symlink")
+    os.unlink(real_dir + "/broken-symlink")
+    os.rmdir(real_dir + "/subdir")
+    os.rmdir(real_dir)
+
+def check_doc_perms(doc, app_id):
+    path = doc.get_doc_path(app_id)
+    readable = doc.is_readable_by(app_id)
+    if not readable:
+        assertRaises(FileNotFoundError, os.lstat, path)
+        assertRaises(PermissionError, os.mkdir, path)
+        return
+
+    assertRaises(PermissionError, os.rmdir, path)
+    assertRaises(PermissionError, os.rename, path, path + "_renamed")
+    assertRaises(IsADirectoryError, os.unlink, path)
+    if doc.is_dir:
+        check_directory_doc_perms(doc, app_id)
+    else:
+        check_regular_doc_perms(doc, app_id)
+
+def check_perms():
+    check_root_perms(portal.mountpoint)
+    check_byapp_perms(portal.by_app_path())
+
+    for doc in portal.get_docs_randomized():
+        check_doc_perms(doc, None)
+        for app_id in portal.get_app_ids_randomized():
+            check_doc_perms(doc, app_id)
+
+# Ensure that a single lookup by app-id creates that app id (we need this for when mounting the subdir for an app)
+def create_app_by_lookup ():
+    # Should only work for valid app ids
+    assertRaises(FileNotFoundError, os.lstat, portal.app_path("not-an-app-id"))
+
+    app_id = app_prefix + "Lookup"
+    info = os.lstat(portal.app_path(app_id))
+    check_virtual_stat (info)
+    portal.ensure_app_id(app_id)
+
+def ensure_real_dir(create_hidden_file=True):
+    count = get_a_count("doc")
+    dir = TEST_DATA_DIR + "/" + dir_prefix + str(count)
+    os.makedirs(dir)
+    if create_hidden_file:
+        setFileContent(dir + "/cant-see-this-file", "s3krit")
+    return (dir, count)
+
+def ensure_real_dir_file(create_file):
+    (dir, count) = ensure_real_dir()
+    path = dir + "/the-file"
+    if create_file:
+        setFileContent(path, "data" + str(count))
+    return path
+
+def export_a_doc ():
+    path = ensure_real_dir_file(True)
+    doc = portal.add(path)
+    logv("exported %s as %s" % (path, doc))
+
+def export_a_named_doc (create_file):
+    path = ensure_real_dir_file(False)
+    doc = portal.add_named(path)
+    logv("exported (named) %s as %s" % (path, doc))
+
+def export_a_dir_doc ():
+    (dir, count) = ensure_real_dir(False)
+    doc = portal.add_dir(dir)
+    logv("exported (dir) %s as %s" % (dir, doc))
+
+def add_an_app (num_docs):
+    if num_docs == 0:
+        return
+    count = get_a_count("app")
+    read_app = app_prefix + "read.App"+ str(count)
+    write_app = app_prefix + "write.App"+ str(count)
+    portal.ensure_app_id(read_app)
+    portal.ensure_app_id(write_app)
+
+    docs = portal.get_docs()
+    ids = []
+    for i in range(num_docs):
+        if len(docs) == 0:
+            continue
+        indx = random.randint(0,len(docs)-1)
+        doc = docs[indx]
+        del docs[indx]
+        ids.append(doc.id)
+        portal.grant_permissions(doc.id, read_app, ["read"])
+        doc.apps.append(read_app)
+        portal.grant_permissions(doc.id, write_app, ["read", "write"])
+        doc.apps.append(write_app)
+    logv("granted acces to %s and %s for %s" % (read_app, write_app, ids))
+
+log("Connecting to portal")
+portal = DocPortal()
+
+log("Running fuse tests...")
+create_app_by_lookup ()
+verify_fs_layout()
+
+log("Creating some docs")
+for i in range(10):
+    export_a_doc ()
+verify_fs_layout()
+
+log("Creating some named docs (existing)")
+for i in range(10):
+    export_a_named_doc (True)
+verify_fs_layout()
+
+log("Creating some named docs (non-existing)")
+for i in range(10):
+    export_a_named_doc (False)
+verify_fs_layout()
+
+log("Creating some dir docs")
+for i in range(10):
+    export_a_dir_doc ()
+verify_fs_layout()
+
+log("Creating some apps")
+for i in range(10):
+    add_an_app (6)
+verify_fs_layout()
+
+for i in range(args.iterations):
+    log("Checking permissions, pass %d" % (i+1))
+    check_perms()
+    verify_fs_layout()
+
+log("fuse tests ok")
+sys.exit(0)

--- a/tests/test-document-fuse.sh
+++ b/tests/test-document-fuse.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+echo "1..2"
+
+set -e
+
+if [ -n "${G_TEST_SRCDIR:-}" ]; then
+    test_srcdir="${G_TEST_SRCDIR}"
+else
+    test_srcdir=$(realpath $(dirname $0))
+fi
+
+if [ -n "${G_TEST_BUILDDIR:-}" ]; then
+    test_builddir="${G_TEST_BUILDDIR}"
+else
+    test_builddir=$(realpath $(dirname $0))
+fi
+
+export TEST_DATA_DIR=`mktemp -d /tmp/xdp-XXXXXX`
+mkdir -p ${TEST_DATA_DIR}/home
+mkdir -p ${TEST_DATA_DIR}/runtime
+mkdir -p ${TEST_DATA_DIR}/system
+mkdir -p ${TEST_DATA_DIR}/config
+
+export HOME=${TEST_DATA_DIR}/home
+export XDG_CACHE_HOME=${TEST_DATA_DIR}/home/cache
+export XDG_CONFIG_HOME=${TEST_DATA_DIR}/home/config
+export XDG_DATA_HOME=${TEST_DATA_DIR}/home/share
+export XDG_RUNTIME_DIR=${TEST_DATA_DIR}/runtime
+
+cleanup () {
+    fusermount -u $XDG_RUNTIME_DIR/doc || :
+    sleep 0.1
+    /bin/kill -9 $DBUS_SESSION_BUS_PID
+    kill $(jobs -p) &> /dev/null || true
+    rm -rf $TEST_DATA_DIR
+}
+trap cleanup EXIT
+
+sed s#@testdir@#${test_builddir}# ${test_srcdir}/session.conf.in > session.conf
+
+dbus-daemon --fork --config-file=session.conf --print-address=3 --print-pid=4 \
+            3> dbus-session-bus-address 4> dbus-session-bus-pid
+export DBUS_SESSION_BUS_ADDRESS="$(cat dbus-session-bus-address)"
+DBUS_SESSION_BUS_PID="$(cat dbus-session-bus-pid)"
+
+if ! /bin/kill -0 "$DBUS_SESSION_BUS_PID"; then
+    assert_not_reached "Failed to start dbus-daemon"
+fi
+
+# Run portal manually so that we get any segfault our assert output
+# Add -v here to get debug output from fuse
+./xdg-document-portal -r &
+
+# First run a basic single-thread test
+echo Testing single-threaded
+python3 ${test_srcdir}/test-document-fuse.py --iterations 3 -v
+echo "ok single-threaded"
+
+# Then a bunch of copies in parallel to stress-test
+echo Testing in parallel
+PIDS=()
+for i in $(seq 20); do
+    python3 ${test_srcdir}/test-document-fuse.py --iterations 10 --prefix $i &
+    PID="$!"
+    PIDS+=( "$PID" )
+done
+
+for PID in ${PIDS[@]}; do
+    echo waiting for pid ${PID}
+    wait ${PID}
+done
+echo "ok load-test"

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -38,7 +38,7 @@ changed_cb (XdgPermissionStore *store,
             GVariant *perms,
             gpointer user_data)
 {
-  char **strv;
+  g_autofree char **strv = NULL;
   gboolean res;
 
   change_count++;
@@ -142,7 +142,7 @@ test_lookup (void)
   const char * perms[] = { "one", "two", NULL };
   g_autoptr(GVariant) p = NULL;
   g_autoptr(GVariant) d = NULL;
-  char **strv;
+  g_autofree char **strv = NULL;
   GVariantBuilder pb;
 
   res = xdg_permission_store_call_lookup_sync (permissions,


### PR DESCRIPTION
This reimplements the fuse backend in a much nicer way. It also adds a new flag to export and entire directory, bumping the portal version to 4. I also added a new testsuite for the fuse implementation.

This is not quite finished, outstanding issues are:
 * The code to re-use existing document ids is busted for directories.
 * I need to actually test this live with existing apps to make sure we don't regress.
 * There is a possibility the the new implementation run out of fd:s easier, I need to do some testing on this, especially on older distro versions with lower max-fd settings.
 * We're currently not doing *anything* about symlinks in the directory support, which means that they relative symlinks in the exported directories might break. This needs more consideration to see if we can solve it better.
