### PR TITLE
utils: Fix use-after-free in xdp_get_app_info_from_pid()

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -618,7 +618,7 @@ xdp_get_app_info_from_pid (pid_t pid,
   if (app_info == NULL)
     app_info = xdp_app_info_new_host ();
 
-  return app_info;
+  return g_steal_pointer (&app_info);
 }
 
 static XdpAppInfo *


### PR DESCRIPTION
This was freeing the value before returning it.

This was noticed by jhenstridge in https://github.com/flatpak/xdg-desktop-portal/pull/443