### PR TITLE
documents: Use symbolic names for flags

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -204,6 +204,7 @@ xdg_desktop_portal_CFLAGS = \
 	$(GEOCLUE_CFLAGS) \
 	-I$(srcdir)/src \
 	-I$(builddir)/src \
+	-I$(srcdir)/document-portal \
 	$(NULL)
 xdg_desktop_portal_CPPFLAGS = \
 	-DGETTEXT_PACKAGE=\"$(GETTEXT_PACKAGE)\"        \

--- a/src/documents.c
+++ b/src/documents.c
@@ -31,6 +31,7 @@
 #include <gio/gunixfdlist.h>
 
 #include "xdp-dbus.h"
+#include "document-enums.h"
 
 static XdpDocuments *documents = NULL;
 static char *documents_mountpoint = NULL;
@@ -111,7 +112,7 @@ register_document (const char *uri,
           ret = xdp_documents_call_add_named_full_sync (documents,
                                                         g_variant_new_handle (fd_in),
                                                         basename,
-                                                        7, /* reuse+persistent+as-needed */
+                                                        DOCUMENT_ADD_FLAGS_REUSE_EXISTING | DOCUMENT_ADD_FLAGS_PERSISTENT | DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP,
                                                         app_id,
                                                         permissions,
                                                         fd_list,
@@ -140,7 +141,7 @@ register_document (const char *uri,
         {
           ret = xdp_documents_call_add_full_sync (documents,
                                                   g_variant_new_fixed_array (G_VARIANT_TYPE_HANDLE, &fd_in, 1, sizeof (gint32)),
-                                                  7, /* reuse+persistent+as-needed */
+                                                  DOCUMENT_ADD_FLAGS_REUSE_EXISTING | DOCUMENT_ADD_FLAGS_PERSISTENT | DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP,
                                                   app_id,
                                                   permissions,
                                                   fd_list,


### PR DESCRIPTION
Rather than documenting a magic number, use the symbolic names as
defined in an enum.