### PR TITLE
file-chooser: Add "directory" option

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -60,6 +60,12 @@
             </para></listitem>
           </varlistentry>
           <varlistentry>
+            <term>directory b</term>
+            <listitem><para>
+              Whether to select for folders instead of files. Default is to select files.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
             <term>filters a(sa(us))</term>
             <listitem><para>
               A list of serialized file filters.

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -70,6 +70,12 @@
           <listitem><para>
             Whether multiple files can be selected or not. Default is single-selection.
           </para></listitem>
+       </varlistentry>
+       <varlistentry>
+          <term>directory b</term>
+          <listitem><para>
+            Whether to select for folders instead of files. Default is to select files.
+          </para></listitem>
         </varlistentry>
         <varlistentry>
           <term>filters a(sa(us))</term>

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -439,6 +439,7 @@ static XdpOptionKey open_file_options[] = {
   { "accept_label", G_VARIANT_TYPE_STRING, NULL },
   { "modal", G_VARIANT_TYPE_BOOLEAN, NULL },
   { "multiple", G_VARIANT_TYPE_BOOLEAN, NULL },
+  { "directory", G_VARIANT_TYPE_BOOLEAN, NULL },
   { "filters", (const GVariantType *)"a(sa(us))", validate_filters },
   { "current_filter", (const GVariantType *)"(sa(us))", validate_current_filter },
   { "choices", (const GVariantType *)"a(ssa(ss)s)", validate_choices }


### PR DESCRIPTION
Add a new directory option to "OpenFile" to allow selecting directories
instead of files.