### PR TITLE
Try to use less file descriptors in document portal

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -1633,6 +1633,8 @@ xdp_fuse_lookup (fuse_req_t req,
         return xdp_reply_err (op, req, -res);
     }
 
+  g_debug ("LOOKUP %lx:%s => %lx", parent_ino, name, e.ino);
+
   if (fuse_reply_entry (req, &e) == -ENOENT)
     abort_reply_entry (&e);
 }
@@ -1883,6 +1885,7 @@ forget_one (fuse_ino_t ino,
 {
   g_autoptr(XdpInode) inode = xdp_inode_from_ino (ino);
 
+  g_debug ("FORGET %lx %ld", ino, nlookup);
   xdp_inode_kernel_unref (inode, nlookup);
 }
 
@@ -1891,7 +1894,6 @@ xdp_fuse_forget (fuse_req_t req,
                  fuse_ino_t ino,
                  unsigned long nlookup)
 {
-  g_debug ("FORGET %lx %ld", ino, nlookup);
   forget_one (ino, nlookup);
   fuse_reply_none (req);
 }

--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -1664,7 +1664,7 @@ invalidate_doc_domain (gpointer user_data)
 
   parent_ino = xdp_inode_to_ino (doc_domain->parent_inode);
 
-  if (g_atomic_int_get (&doc_domain->parent_inode->kernel_ref_count) > 0)
+  if (g_atomic_int_get (&doc_domain->parent_inode->kernel_ref_count) > 0 && main_ch != NULL)
     fuse_lowlevel_notify_inval_entry (main_ch, parent_ino, doc_domain->doc_id, strlen (doc_domain->doc_id));
 
   return FALSE;
@@ -3079,6 +3079,7 @@ xdp_fuse_mainloop (gpointer data)
   fuse_session_remove_chan (main_ch);
   fuse_session_destroy (session);
   fuse_unmount (mount_path, main_ch);
+  main_ch = NULL;
 
   return NULL;
 }

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -170,9 +170,10 @@ def assertDirFiles(path, expected_files, exhaustive = True, volatile_files = Non
     found_files = os.listdir (path)
     remaining = set(found_files)
     for file in expected_files:
-        if not file in remaining and not file in volatile_files:
+        if file in remaining:
+            remaining.remove(file)
+        elif not file in volatile_files:
             raise AssertionError("Expected file {} not found in dir {} (all: {})".format(file, path, found_files))
-        remaining.remove(file)
     if exhaustive:
         if len(remaining) != 0:
             raise AssertionError("Unexpected files {} in dir {} (all: {})".format(remaining, path, found_files))


### PR DESCRIPTION
This has some work that tries to keep down the nr of fds used in the document portal.
This was causing some issues when building on ubuntu, as it needed > 4096 fds in the fuse stress test.