### PR TITLE
Use system default browser when opening links

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -448,10 +448,20 @@ static gboolean
 can_skip_app_chooser (const char *scheme,
                       const char *content_type)
 {
-  /* We skip the app chooser for Internet URIs, to be open in the browser */
-  /*  Skipping the chooser for directories is useful too (e.g. opening in Nautilus) */
-  if (g_strcmp0 (scheme, "http") == 0 ||
-      g_strcmp0 (scheme, "https") == 0 ||
+  const char *skipped_schemes[] = {
+    "http",
+    "https",
+    "ftp",
+    "mailto",
+    "webcal",
+    "calendar",
+    NULL
+  };
+
+  /* We skip the app chooser for Internet URIs, to be open in the browser,
+   * mail client, or calendar, as well as for directories to be opened in
+   * the file manager */
+  if (g_strv_contains (skipped_schemes, scheme) ||
       g_strcmp0 (content_type, "inode/directory") == 0)
     {
       g_debug ("Can skip app chooser for %s", content_type);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -235,6 +235,13 @@ launch_application_with_uri (const char *choice_id,
   g_autofree char *ruri = NULL;
   GList uris;
 
+  if (info == NULL)
+    {
+      g_debug ("Cannot launch %s because desktop file does not exist", desktop_id);
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND, "Desktop file %s does not exist", desktop_id);
+      return FALSE;
+    }
+
   g_debug ("Launching %s %s", choice_id, uri);
 
   if (is_sandboxed (info) && is_file_uri (uri))


### PR DESCRIPTION
Unless the user has "always ask" set in the permissions, or the application requested for the application chooser to be shown, always open browser (or other internet) links and directories in the default application.