### PR TITLE
Show app chooser when app to open doesn't exist

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -713,21 +713,26 @@ handle_open_in_thread_func (GTask *task,
           /* Launch the app directly */
           g_autoptr(GError) error = NULL;
 
-          g_debug ("Skipping app chooser");
-
           gboolean result = launch_application_with_uri (app, uri, parent_window, writable, &error);
-          if (request->exported)
+          if (result)
             {
-              if (!result)
-                g_debug ("Open request for '%s' failed: %s", uri, error->message);
-              g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
-              xdp_request_emit_response (XDP_REQUEST (request),
-                                         result ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
-                                         g_variant_builder_end (&opts_builder));
-              request_unexport (request);
-            }
+              g_debug ("Skipped app chooser");
 
-          return;
+              if (request->exported)
+                {
+                  g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
+                  xdp_request_emit_response (XDP_REQUEST (request),
+                                             result ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
+                                             g_variant_builder_end (&opts_builder));
+                  request_unexport (request);
+                }
+
+              return;
+            }
+          else
+            {
+              g_debug ("Failed to skip app chooser: %s", error->message);
+            }
         }
     }
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -235,6 +235,13 @@ launch_application_with_uri (const char *choice_id,
   g_autofree char *ruri = NULL;
   GList uris;
 
+  if (info == NULL)
+    {
+      g_debug ("Cannot launch %s because desktop file does not exist", desktop_id);
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND, "Desktop file %s does not exist", desktop_id);
+      return FALSE;
+    }
+
   g_debug ("Launching %s %s", choice_id, uri);
 
   if (is_sandboxed (info) && is_file_uri (uri))


### PR DESCRIPTION
If the app to open doesn't exist, we should go ahead and show the app chooser instead of spewing criticals and failing to open any app.

~~**Note that this will cause xdg-desktop-portal-gtk to crash.** I'll try to fix that next.~~