### PR TITLE
Screencast: document source_type property in the response

### DIFF
--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -146,6 +146,14 @@
               stream.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>source_type u</term>
+            <listitem><para>
+              The type of the content which is being screen casted.
+              For available source types, see the AvailableSourceTypes property.
+              This property was added in version 3 of this interface.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
     -->
     <method name="Start">

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -192,6 +192,14 @@
               stream.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>source_type u</term>
+            <listitem><para>
+              The type of the content which is being screen casted.
+              For available source types, see the AvailableSourceTypes property.
+              This property was added in version 3 of this interface.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
     -->
     <method name="Start">

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -947,7 +947,7 @@ on_supported_cursor_modes_changed (GObject *gobject,
 static void
 screen_cast_init (ScreenCast *screen_cast)
 {
-  xdp_screen_cast_set_version (XDP_SCREEN_CAST (screen_cast), 2);
+  xdp_screen_cast_set_version (XDP_SCREEN_CAST (screen_cast), 3);
 
   g_signal_connect (impl, "notify::supported-source-types",
                     G_CALLBACK (on_supported_source_types_changed),


### PR DESCRIPTION
This is supposed to be a new addition for the clients to help them identify whether the user picked a screen or a window and what will be the content of the stream.