### PR TITLE
FileChooser: Add a 'current_filter' return value

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -110,6 +110,15 @@
             </para></listitem>
           </varlistentry>
           <varlistentry>
+            <term>current_filter (sa(us))</term>
+            <listitem>
+              <para>
+                The filter that was selected.
+                See org.freedesktop.portal.FileChooser.OpenFile() for details.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
             <term>writable b</term>
             <listitem><para>
               Whether the file is opened with write access. Default is no.
@@ -215,6 +224,15 @@
               An array of pairs of strings, corresponding to the passed-in choices.
               See org.freedesktop.portal.FileChooser.OpenFile() for details.
             </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>current_filter (sa(us))</term>
+            <listitem>
+              <para>
+                The filter that was selected.
+                See org.freedesktop.portal.FileChooser.OpenFile() for details.
+              </para>
+            </listitem>
           </varlistentry>
         </variablelist>
     -->

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -151,6 +151,15 @@
             </para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term>current_filter (sa(us))</term>
+          <listitem>
+            <para>
+              The filter that was selected. This may match a filter in the
+              filter list or another filter that was applied unconditionally.
+            </para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     -->
     <method name="OpenFile">
@@ -247,6 +256,15 @@
             An array of pairs of strings, corresponding to the passed-in choices.
             See org.freedesktop.portal.FileChooser.OpenFile() for details.
           </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>current_filter (sa(us))</term>
+          <listitem>
+            <para>
+              The filter that was selected.
+              See org.freedesktop.portal.FileChooser.OpenFile() for details.
+            </para>
+          </listitem>
         </varlistentry>
       </variablelist>
     -->

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -79,6 +79,7 @@ send_response_in_thread_func (GTask        *task,
   const char **uris;
   GVariant *choices;
   gboolean for_save;
+  GVariant *current_filter;
 
   g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_init (&ruris, G_VARIANT_TYPE_STRING_ARRAY);
@@ -99,6 +100,10 @@ send_response_in_thread_func (GTask        *task,
   choices = g_variant_lookup_value (options, "choices", G_VARIANT_TYPE ("a(ss)"));
   if (choices)
     g_variant_builder_add (&results, "{sv}", "choices", choices);
+
+  current_filter = g_variant_lookup_value (options, "current_filter", G_VARIANT_TYPE ("(sa(us))"));
+  if (current_filter)
+    g_variant_builder_add (&results, "{sv}", "current_filter", current_filter);
 
   if (g_variant_lookup (options, "uris", "^a&s", &uris))
     {


### PR DESCRIPTION
Add a 'current_filter' element for the FileChooser response which is used to specify which filter
was selected in the file chooser.

This will allow making Gtk's 'gtk_file_chooser_get_filter' work for the portal native file chooser.

See https://gitlab.gnome.org/GNOME/gtk/-/issues/1820 for more details. I'll add a link to the corresponding gtk and xdg-desktop-portal-gtk merge/pull requests here once I have created them.