### PR TITLE
Close fd in OpenURI portal

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -622,6 +622,7 @@ handle_open_in_thread_func (GTask *task,
       gboolean fd_is_writable;
 
       path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, &fd_is_writable);
+      close (fd);
       if (path == NULL ||
           (writable && !fd_is_writable) ||
           (!xdp_app_info_is_host (request->app_info) && !writable && fd_is_writable))


### PR DESCRIPTION
Didn't managed to get portals to work with my own build, so this is untested.

Not sure if `xdp_impl_app_chooser_call_choose_application()` uses the fd since I have no idea where is function is defined.

Closes #509