### PR TITLE
Revert "Add the directory option to the file chooser impl interface"

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -66,12 +66,6 @@
             </para></listitem>
           </varlistentry>
           <varlistentry>
-            <term>directory b</term>
-            <listitem><para>
-              Whether to select for folders instead of files. Default is to select files.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
             <term>filters a(sa(us))</term>
             <listitem><para>
               A list of serialized file filters.


### PR DESCRIPTION
This reverts commit ee041ae8c8c8b0534bdd300953f131f1c93434cd.
Documentation for this parameter was already added in c616b491 so this
just duplicates it.