### PR TITLE
Fix openuri test regression (#524)

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -554,10 +554,12 @@ static gboolean
 app_exists (const char *app_id)
 {
   g_autoptr(GDesktopAppInfo) info = NULL;
+  g_autofree gchar *with_desktop = NULL;
 
   g_return_val_if_fail (app_id != NULL, FALSE);
 
-  info = g_desktop_app_info_new (app_id);
+  with_desktop = g_strconcat (app_id, ".desktop", NULL);
+  info = g_desktop_app_info_new (with_desktop);
   return (info != NULL);
 }
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -669,6 +669,8 @@ handle_open_in_thread_func (GTask *task,
 
   /* collect all the information */
   find_recommended_choices (scheme, content_type, &default_app, &choices, &n_choices);
+  /* it's never NULL, but might be empty (only contain the NULL terminator) */
+  g_assert (choices != NULL);
   if (default_app != NULL && !app_exists (default_app))
     g_clear_pointer (&default_app, g_free);
   use_default_app = should_use_default_app (scheme, content_type);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -555,6 +555,8 @@ app_exists (const char *app_id)
 {
   g_autoptr(GDesktopAppInfo) info = NULL;
 
+  g_return_val_if_fail (app_id != NULL, FALSE);
+
   info = g_desktop_app_info_new (app_id);
   return (info != NULL);
 }
@@ -667,13 +669,13 @@ handle_open_in_thread_func (GTask *task,
 
   /* collect all the information */
   find_recommended_choices (scheme, content_type, &default_app, &choices, &n_choices);
-  if (!app_exists (default_app))
+  if (default_app != NULL && !app_exists (default_app))
     g_clear_pointer (&default_app, g_free);
   use_default_app = should_use_default_app (scheme, content_type);
   get_latest_choice_info (app_id, content_type,
                           &latest_id, &latest_count, &latest_threshold,
                           &ask_for_content_type);
-  if (!app_exists (latest_id))
+  if (latest_id != NULL && !app_exists (latest_id))
     g_clear_pointer (&latest_id, g_free);
 
   skip_app_chooser = FALSE;
@@ -729,7 +731,7 @@ handle_open_in_thread_func (GTask *task,
         app = latest_id;
       else if (default_app != NULL)
         app = default_app;
-      else if (choices && app_exists (choices[0]))
+      else if (n_choices > 0 && app_exists (choices[0]))
         app = choices[0];
 
       if (app)

--- a/tests/backend/appchooser.c
+++ b/tests/backend/appchooser.c
@@ -122,7 +122,13 @@ handle_choose_application (XdpImplAppChooser *object,
   g_assert_no_error (error);
 
   if (g_key_file_has_key (keyfile, "backend", "expect-no-call", NULL))
-    g_assert_not_reached ();
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_IO_ERROR,
+                                             G_IO_ERROR_FAILED,
+                                             "Did not expect ChooseApplication to be called here");
+      return TRUE;  /* handled */
+    }
 
   request = request_new (sender, arg_app_id, arg_handle);
 


### PR DESCRIPTION
* open-uri: Don't crash if there is no default or latest app
    
    g_desktop_app_info_new() requires a non-NULL argument.
    
    Partially addresses #524.
    
    Fixes: 69205f12 "open-uri: Show app chooser when default app does not exist"

* open-uri: Assert that find_recommended_choices yields non-NULL
    
    choices is never NULL, but might be an array containing only NULL.

* tests: Make app chooser backend more debuggable
    
    Instead of crashing out when our expectations are not met, return an
    error that other components can log.

* open-uri: Use correct app ID to determine whether it exists
    
    x-d-p represents apps by their app ID *without* the .desktop suffix,
    but GDesktopAppInfo represents them by the app ID *with* the .desktop
    suffix.
    
    Fixes: 69205f12 "open-uri: Show app chooser when default app does not exist"  
    Resolves: #524

cc @hadess @mcatanzaro 