### PR TITLE
open-uri: Close fd after opening dir or file

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -30,7 +30,6 @@
 #include <fcntl.h>
 
 #include <gio/gio.h>
-#include <gio/gunixfdlist.h>
 
 #include "account.h"
 #include "request.h"

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -31,7 +31,6 @@
 #include <fcntl.h>
 
 #include <gio/gio.h>
-#include <gio/gunixfdlist.h>
 
 #include "file-chooser.h"
 #include "request.h"

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -844,6 +844,7 @@ handle_open_uri (XdpOpenURI *object,
   if (!g_variant_lookup (arg_options, "ask", "b", &ask))
     ask = FALSE;
 
+  g_object_set_data (G_OBJECT (request), "fd", GINT_TO_POINTER (-1));
   g_object_set_data_full (G_OBJECT (request), "uri", g_strdup (arg_uri), g_free);
   g_object_set_data_full (G_OBJECT (request), "parent-window", g_strdup (arg_parent_window), g_free);
   g_object_set_data (G_OBJECT (request), "writable", GINT_TO_POINTER (writable));

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -586,7 +586,7 @@ handle_open_in_thread_func (GTask *task,
   gboolean ask_for_content_type;
   GVariantBuilder opts_builder;
   gboolean skip_app_chooser = FALSE;
-  int fd;
+  g_auto(XdpFd) fd = -1;
   gboolean writable = FALSE;
   gboolean ask = FALSE;
   gboolean open_dir = FALSE;

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -29,7 +29,6 @@
 #include <fcntl.h>
 
 #include <gio/gio.h>
-#include <gio/gunixfdlist.h>
 
 #include "screenshot.h"
 #include "request.h"

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -48,6 +48,9 @@ typedef void (*XdpPeerDiedCallback) (const char *name);
 
 typedef struct _XdpAppInfo XdpAppInfo;
 
+typedef int XdpFd;
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(XdpFd, close, -1)
+
 XdpAppInfo *xdp_app_info_ref             (XdpAppInfo  *app_info);
 void        xdp_app_info_unref           (XdpAppInfo  *app_info);
 const char *xdp_app_info_get_id          (XdpAppInfo  *app_info);


### PR DESCRIPTION
Use new XdpFd type with g_auto to make sure the file descriptor gets
closed when the function finishes.