### PR TITLE
wallpaper: reflect on open-uri.c behavior, avoiding a crash

### DIFF
--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -145,9 +145,10 @@ handle_set_wallpaper_in_thread_func (GTask *task,
       g_warning ("Rejecting invalid open-uri request (both URI and fd are set)");
       if (request->exported)
         {
+          g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
           xdp_request_emit_response (XDP_REQUEST (request),
                                      XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
-                                     NULL);
+                                     g_variant_builder_end (&opt_builder));
           request_unexport (request);
         }
       return;
@@ -238,9 +239,10 @@ handle_set_wallpaper_in_thread_func (GTask *task,
           /* Reject the request */
           if (request->exported)
             {
+              g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
               xdp_request_emit_response (XDP_REQUEST (request),
                                          XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
-                                         NULL);
+                                         g_variant_builder_end (&opt_builder));
               request_unexport (request);
             }
           return;


### PR DESCRIPTION
(/usr/libexec/xdg-desktop-portal:13660): GLib-CRITICAL **: 18:57:58.512: g_variant_get_type: assertion 'value != NULL' failed

(/usr/libexec/xdg-desktop-portal:13660): GLib-CRITICAL **: 18:57:58.512: g_variant_type_is_subtype_of: assertion 'g_variant_type_check (type)' failed

(/usr/libexec/xdg-desktop-portal:13660): GLib-CRITICAL **: 18:57:58.512: g_variant_get_type_string: assertion 'value != NULL' failed

(/usr/libexec/xdg-desktop-portal:13660): GLib-ERROR **: 18:57:58.512: g_variant_new: expected GVariant of type 'a{sv}' but received value has type '(null)'

CC @mcatanzaro