### PR TITLE
build: drop unneeded fontconfig dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ AC_PATH_PROG([BWRAP], [bwrap])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 
-PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0 fontconfig json-glib-1.0])
+PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0 json-glib-1.0])
 AC_SUBST(BASE_CFLAGS)
 AC_SUBST(BASE_LIBS)
 


### PR DESCRIPTION
It seems to have been removed in https://github.com/flatpak/xdg-desktop-portal/commit/80043fc333847a3a200662d18d8f5a29fe10c5b5.