### PR TITLE
xdp-utils: check if alternate doc portal path matches in path_for_fd()

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1448,6 +1448,8 @@ on_name_acquired (GDBusConnection *connection,
 
   fuse_dev = stbuf.st_dev;
 
+  xdp_set_documents_mountpoint (xdp_fuse_get_mountpoint ());
+
   while ((invocation = g_queue_pop_head (&get_mount_point_invocations)) != NULL)
     {
       xdp_dbus_documents_complete_get_mount_point (dbus_api, invocation, xdp_fuse_get_mountpoint ());

--- a/src/documents.c
+++ b/src/documents.c
@@ -31,6 +31,7 @@
 #include <gio/gunixfdlist.h>
 
 #include "xdp-dbus.h"
+#include "xdp-utils.h"
 #include "document-enums.h"
 
 static XdpDocuments *documents = NULL;
@@ -46,6 +47,7 @@ init_document_proxy (GDBusConnection *connection)
   xdp_documents_call_get_mount_point_sync (documents,
                                            &documents_mountpoint,
                                            NULL, NULL);
+  xdp_set_documents_mountpoint (documents_mountpoint);
 }
 
 char *

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -88,6 +88,9 @@ char **     xdp_app_info_rewrite_commandline (XdpAppInfo *app_info,
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdpAppInfo, xdp_app_info_unref)
 
+void  xdp_set_documents_mountpoint    (const char *path);
+char *xdp_get_alternate_document_path (const char *path, const char *app_id);
+
 XdpAppInfo *xdp_invocation_lookup_app_info_sync (GDBusMethodInvocation *invocation,
                                                  GCancellable          *cancellable,
                                                  GError               **error);


### PR DESCRIPTION
The document portal uses different inode number when exposing a particular document in different parts of the file system.  As sandboxed apps only have a subtree of the document portal file system mounted, the "same file" checks in xdp_app_info_get_path_for_fd() would fail for document portal paths.

To fix this, we check to see whether the corresponding "by-app/$app_id" path matches the stat information of the file descriptor.

Fixes #545