### PR TITLE
Use real filesystem path for OpenDirectory

### DIFF
--- a/src/documents.c
+++ b/src/documents.c
@@ -200,3 +200,28 @@ register_document (const char *uri,
   doc_path = g_build_filename (documents_mountpoint, doc_id, basename, NULL);
   return g_filename_to_uri (doc_path, NULL, NULL);
 }
+
+char *
+get_real_path_for_doc_path (const char *path,
+                            const char *app_id)
+{
+  g_autofree char *doc_id = NULL;
+  gboolean ret = FALSE;
+  char *real_path = NULL;
+
+  if (app_id == NULL || *app_id == '\0')
+    return g_strdup (path);
+
+  ret = xdp_documents_call_lookup_sync (documents, path, &doc_id, NULL, NULL);
+  if (!ret)
+    return g_strdup (path);
+
+  if (!g_strcmp0 (doc_id, ""))
+    return g_strdup (path);
+
+  ret = xdp_documents_call_info_sync (documents, doc_id, &real_path, NULL, NULL, NULL);
+  if (!ret)
+    return g_strdup (path);
+
+  return real_path;
+}

--- a/src/documents.h
+++ b/src/documents.h
@@ -30,3 +30,6 @@ char *register_document (const char *uri,
                          gboolean writable,
                          gboolean directory,
                          GError **error);
+
+char *get_real_path_for_doc_path (const char *path,
+                                  const char *app_id);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -668,8 +668,10 @@ handle_open_in_thread_func (GTask *task,
 
       if (open_dir)
         {
-          char *dir = g_path_get_dirname (path);
+          char *real_path = get_real_path_for_doc_path (path, app_id);
           g_free (path);
+          char *dir = g_path_get_dirname (real_path);
+          g_free (real_path);
           path = dir;
         }
 


### PR DESCRIPTION
Before this change the file manager would open inside the document portal directory like `/run/user/1000/doc/10288756` which is not very user-friendly. With this change it opens in the real filesystem path. Now actions like "Show in Files" can be properly implemented.

cc https://github.com/flatpak/xdg-desktop-portal/issues/363