### PR TITLE
Settings: do not put failed implementations into the list

### DIFF
--- a/tests/backend/Makefile.am.inc
+++ b/tests/backend/Makefile.am.inc
@@ -31,6 +31,8 @@ tests_test_backends_SOURCES = \
 	tests/backend/print.h \
 	tests/backend/screenshot.c \
 	tests/backend/screenshot.h \
+	tests/backend/settings.c \
+	tests/backend/settings.h \
         tests/backend/wallpaper.c \
         tests/backend/wallpaper.h \
         tests/glib-backports.c \

--- a/tests/backend/settings.c
+++ b/tests/backend/settings.c
@@ -1,0 +1,31 @@
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <gio/gio.h>
+
+#include "src/xdp-impl-dbus.h"
+
+#include "request.h"
+#include "settings.h"
+
+void
+settings_init (GDBusConnection *connection,
+               const char *object_path)
+{
+  g_autoptr(GError) error = NULL;
+  GDBusInterfaceSkeleton *helper;
+
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_settings_skeleton_new ());
+
+  if (!g_dbus_interface_skeleton_export (helper, connection, object_path, &error))
+    {
+      g_error ("Failed to export %s skeleton: %s\n",
+               g_dbus_interface_skeleton_get_info (helper)->name,
+               error->message);
+      exit (1);
+    }
+
+  g_debug ("providing %s at %s", g_dbus_interface_skeleton_get_info (helper)->name, object_path);
+}

--- a/tests/backend/settings.h
+++ b/tests/backend/settings.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void settings_init (GDBusConnection *connection, const char *object_path);

--- a/tests/backend/test-backends.c
+++ b/tests/backend/test-backends.c
@@ -16,6 +16,7 @@
 #include "notification.h"
 #include "print.h"
 #include "screenshot.h"
+#include "settings.h"
 #include "wallpaper.h"
 
 #define BACKEND_BUS_NAME "org.freedesktop.impl.portal.Test"
@@ -39,6 +40,7 @@ on_bus_acquired (GDBusConnection *connection,
   notification_init (connection, BACKEND_OBJECT_PATH);
   print_init (connection, BACKEND_OBJECT_PATH);
   screenshot_init (connection, BACKEND_OBJECT_PATH);
+  settings_init (connection, BACKEND_OBJECT_PATH);
   wallpaper_init (connection, BACKEND_OBJECT_PATH);
 }
 

--- a/tests/portals/test.portal
+++ b/tests/portals/test.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.Test
-Interfaces=org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Notification;
+Interfaces=org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Settings;
 UseIn=test


### PR DESCRIPTION
With settings portal ability to load multiple backend implementations, there is a possibility that one of them will not load correctly and be placed into the list anyway. This results into failed implementation being used, we will call Read/ReadAll on it and it will fail and crash. To avoid that, we will create a temporary list, check real number of working implementations and put them into the final list we will use later. 