### PR TITLE
permission-store: Don't crash when deleting permissions

### DIFF
--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -1259,12 +1259,17 @@ permission_db_entry_remove_app_permissions (PermissionDbEntry *entry,
 {
   GVariant *v = (GVariant *) entry;
   GVariant *res;
+  GVariant *app_permissions;
 
   g_autoptr(GVariant) old_data_v = g_variant_get_child_value (v, 0);
   g_autoptr(GVariant) old_data = g_variant_get_child_value (old_data_v, 0);
   g_autoptr(GVariant) old_permissions = g_variant_get_child_value (v, 1);
 
-  res = make_entry (old_data, remove_permissions (old_permissions, app));
+  app_permissions = remove_permissions (old_permissions, app);
+  if (app_permissions == NULL)
+    app_permissions = make_empty_app_permissions ();
+
+  res = make_entry (old_data, app_permissions);
   return (PermissionDbEntry  *) g_variant_ref_sink (res);
 }
 


### PR DESCRIPTION
The permission store crashes when it attempts to remove
the last entry of an specific  table and id pair,  e.g.
"notifications", "notification", "a".

The crash occurs due to the assumption that there should
still be one entry left after the operation,  but is not
the case here.

Prevent this by writing an empty entry for this specific
table and id  pair, instead. So  that the specific  pair
is kept in the database.

I assume this is the right thing to do, due to:

1. There's a separate API for deleting table and ids pairs.
2. The removal-related code already assumes that there should
   be at least one entry left after this operation.
3. It's what "flatpak permissions-reset --all" does.

Closes #573