### PR TITLE
utils: Remap /run/flatpak/app, for Flatpak 1.11.x

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -331,6 +331,9 @@ xdp_app_info_remap_path (XdpAppInfo *app_info,
         return g_build_filename ("/usr", path + strlen ("/run/host/usr/"), NULL);
       else if (g_str_has_prefix (path, "/run/host/etc/"))
         return g_build_filename ("/etc", path + strlen ("/run/host/etc/"), NULL);
+      else if (g_str_has_prefix (path, "/run/flatpak/app/"))
+        return g_build_filename (g_get_user_runtime_dir (), "app",
+                                 path + strlen ("/run/flatpak/app/"), NULL);
     }
 
   return g_strdup (path);


### PR DESCRIPTION
Flatpak 1.11.x avoids mounting anything into the app-controlled
XDG_RUNTIME_DIR, so $XDG_RUNTIME_DIR/app in the container shows up as
a symlink to /run/flatpak/app. This particularly affects apps that
set TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID and use the URI portal
to request that a file in /tmp gets opened on the host.

Manual test:

    (run any Flatpak app with --command=bash)
    echo "hello" > $XDG_RUNTIME_DIR/app/$FLATPAK_ID/readme.txt
    xdg-open $XDG_RUNTIME_DIR/app/$FLATPAK_ID/readme.txt

Resolves: #589
Signed-off-by: Simon McVittie <smcv@collabora.com>