### PR TITLE
utils: Remap Flatpak /var/config, /var/data

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -334,6 +334,14 @@ xdp_app_info_remap_path (XdpAppInfo *app_info,
       else if (g_str_has_prefix (path, "/run/flatpak/app/"))
         return g_build_filename (g_get_user_runtime_dir (), "app",
                                  path + strlen ("/run/flatpak/app/"), NULL);
+      else if (g_str_has_prefix (path, "/var/config/"))
+        return g_build_filename (g_get_home_dir (), ".var", "app",
+                                 app_info->id, "config",
+                                 path + strlen ("/var/config/"), NULL);
+      else if (g_str_has_prefix (path, "/var/data/"))
+        return g_build_filename (g_get_home_dir (), ".var", "app",
+                                 app_info->id, "data",
+                                 path + strlen ("/var/data/"), NULL);
     }
 
   return g_strdup (path);


### PR DESCRIPTION
In a Flatpak app, /var/config and /var/data are parallel mount points for
    the same directories as $XDG_CONFIG_HOME and $XDG_DATA_HOME, which are
    canonically under ~/.var/app/$FLATPAK_ID. /var/config and /var/data
    don't exist as conventional FHS paths, so it seems safe to assume that
    if they appear inside a Flatpak app, it's these aliases that are meant.

/var/cache and /var/tmp are not handled here, because those are
    ambiguous and will need a different code structure to handle: they're
    usually aliases for $XDG_CACHE_HOME and $XDG_CACHE_HOME/tmp respectively,
    but it would be reasonable for a Flatpak app to have
    --filesystem=/var/tmp, and not impossible for it to have
    --filesystem=/var/cache/something.
    
Resolves: #592