### PR TITLE
ScreenCast: Add 'VIRTUAL' source type

### DIFF
--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -175,6 +175,7 @@
         <simplelist>
           <member>1: MONITOR</member>
           <member>2: WINDOW</member>
+          <member>3: VIRTUAL</member>
         </simplelist>
     -->
     <property name="AvailableSourceTypes" type="u" access="read"/>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -235,6 +235,7 @@
         <simplelist>
           <member>1: MONITOR</member>
           <member>2: WINDOW</member>
+          <member>4: VIRTUAL</member>
         </simplelist>
     -->
     <property name="AvailableSourceTypes" type="u" access="read"/>

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -338,10 +338,10 @@ validate_device_types (const char *key,
 {
   guint32 types = g_variant_get_uint32 (value);
 
-  if ((types & ~(1 | 2)) != 0)
+  if ((types & ~(1 | 2 | 4)) != 0)
     {
       g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Unsupported device type: %x", types & ~(1 | 2));
+                   "Unsupported device type: %x", types & ~(1 | 2 | 4));
       return FALSE;
     } 
 


### PR DESCRIPTION
This is a source type that by the portal implementation backend should
be implemented as a per screen cast stream created virtual monitor. The
dimension of the stream for these types of screen cast streams are
typically determined during the pipewire stream negotiation.


---

Use case for this is e.g. gnome-network-displays like applications; anything that wants to provide a virtual monitor like functionality.