### PR TITLE
permission-store: Add GetPermission

### DIFF
--- a/data/org.freedesktop.impl.portal.PermissionStore.xml
+++ b/data/org.freedesktop.impl.portal.PermissionStore.xml
@@ -146,6 +146,23 @@
     </method>
 
     <!--
+        GetPermission:
+        @table: the name of the table to use
+        @id: the resource ID to modify
+        @app: the application ID to modify
+        @permissions: permissions to get
+
+        Gets the entry for an application and a resource
+        in the given table.
+    -->
+    <method name="GetPermission">
+      <arg name='table' type='s' direction='in'/>
+      <arg name='id' type='s' direction='in'/>
+      <arg name='app' type='s' direction='in'/>
+      <arg name='permissions' type='as' direction='out'/>
+    </method>
+
+    <!--
         List:
         @table: the name of the table to use
         @ids: IDs of all resources that are present in the table

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -483,6 +483,75 @@ test_delete5 (void)
 }
 
 static void
+test_get_permission1 (void)
+{
+  gboolean res;
+  g_autoptr(GError) error = NULL;
+  g_autofree char **out_perms = NULL;
+
+  res = xdg_permission_store_call_get_permission_sync (permissions,
+                                                       "no-such-table",
+                                                       "no-such-entry",
+                                                       "no-such-app",
+                                                       &out_perms,
+                                                       NULL,
+                                                       &error);
+  g_assert_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND);
+  g_assert_false (res);
+}
+
+static void
+test_get_permission2 (void)
+{
+  gboolean res;
+  const char * in_perms[] = { "yes", NULL };
+  g_autofree char **out_perms = NULL;
+  g_autoptr(GError) error = NULL;
+
+  res = xdg_permission_store_call_set_permission_sync (permissions,
+                                                       "notifications",
+                                                       TRUE,
+                                                       "notification",
+                                                       "a",
+                                                       in_perms,
+                                                       NULL,
+                                                       &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  res = xdg_permission_store_call_get_permission_sync (permissions,
+                                                       "notifications",
+                                                       "notification",
+                                                       "a",
+                                                       &out_perms,
+                                                       NULL,
+                                                       &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  g_assert (g_strv_length (out_perms) == 1);
+  g_assert (g_strv_contains ((const char *const *)out_perms, "yes"));
+}
+
+static void
+test_get_permission3 (void)
+{
+  gboolean res;
+  g_autofree char **out_perms = NULL;
+  g_autoptr(GError) error = NULL;
+
+  res = xdg_permission_store_call_get_permission_sync (permissions,
+                                                       "notifications",
+                                                       "notification",
+                                                       "no-such-app",
+                                                       &out_perms,
+                                                       NULL,
+                                                       &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  g_assert (g_strv_length (out_perms) == 0);
+}
+
+static void
 global_setup (void)
 {
   GError *error = NULL;
@@ -603,6 +672,9 @@ main (int argc, char **argv)
   g_test_add_func ("/permissions/create1", test_create1);
   g_test_add_func ("/permissions/create2", test_create2);
   g_test_add_func ("/permissions/set-value", test_set_value);
+  g_test_add_func ("/permissions/get-pemission1", test_get_permission1);
+  g_test_add_func ("/permissions/get-pemission2", test_get_permission2);
+  g_test_add_func ("/permissions/get-pemission3", test_get_permission3);
 
   global_setup ();
 


### PR DESCRIPTION
We currently have SetPermission and DeletePermission which operate
with specific apps, but we didn't have a GetPermission method that
does the same. Instead, we rely on LookUp which brings all (table,
id, app) tuples.
   
From what I have seen,in GNOME Control Center and what I needed
to do for Flatseal, we call LookUp, check if the app is present
among the retrieved tuples,  to then access the permission data
we are looking for (e.g, ["yes"], etc).

As more UI tools ala-flatseal appear, a GetPermission would make
more sense for such tools as these operate per-app basis.

Another reason is that the permission store data tends to grow,
which means that  LookUp  will keep bringing more and more data
unnecessarily for the case described.

Closes #583