### PR TITLE
Improve error handling when passing files by fd

### DIFF
--- a/src/email.c
+++ b/src/email.c
@@ -245,10 +245,13 @@ handle_compose_email (XdpEmail *object,
               return TRUE;
             }
 
-          path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, NULL);
+          path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, NULL, &error);
 
           if (path == NULL)
             {
+              g_debug ("Invalid attachment fd passed: %s", error->message);
+
+              /* Don't leak any info about real file path existence, etc */
               g_dbus_method_invocation_return_error (invocation,
                                                      XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
                                                      "Invalid attachment fd passed");

--- a/src/email.c
+++ b/src/email.c
@@ -246,6 +246,15 @@ handle_compose_email (XdpEmail *object,
             }
 
           path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, NULL);
+
+          if (path == NULL)
+            {
+              g_dbus_method_invocation_return_error (invocation,
+                                                     XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                                                     "Invalid attachment fd passed");
+              return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+
           g_variant_builder_add (&attachments, "s", path);
         }
 

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -646,17 +646,18 @@ handle_open_in_thread_func (GTask *task,
           (!xdp_app_info_is_host (request->app_info) && !writable && fd_is_writable))
         {
           /* Reject the request */
+          if (path == NULL)
+            {
+              g_debug ("Rejecting open request as fd has no path associated to it");
+            }
+          else
+            {
+              g_debug ("Rejecting open request for %s as opening %swritable but fd is %swritable",
+                       path, writable ? "" : "not ", fd_is_writable ? "" : "not ");
+            }
+
           if (request->exported)
             {
-              if (path == NULL)
-                {
-                  g_debug ("Rejecting open request as fd has no path associated to it");
-                }
-              else
-                {
-                  g_debug ("Rejecting open request for %s as opening %swritable but fd is %swritable",
-                           path, writable ? "" : "not ", fd_is_writable ? "" : "not ");
-                }
               g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
               xdp_request_emit_response (XDP_REQUEST (request),
                                          XDG_DESKTOP_PORTAL_RESPONSE_OTHER,

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -639,8 +639,9 @@ handle_open_in_thread_func (GTask *task,
     {
       g_autofree char *path = NULL;
       gboolean fd_is_writable;
+      g_autoptr(GError) local_error = NULL;
 
-      path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, &fd_is_writable);
+      path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, &fd_is_writable, &local_error);
       if (path == NULL ||
           (writable && !fd_is_writable) ||
           (!xdp_app_info_is_host (request->app_info) && !writable && fd_is_writable))
@@ -648,7 +649,7 @@ handle_open_in_thread_func (GTask *task,
           /* Reject the request */
           if (path == NULL)
             {
-              g_debug ("Rejecting open request as fd has no path associated to it");
+              g_debug ("Rejecting open request: %s", local_error->message);
             }
           else
             {

--- a/src/trash.c
+++ b/src/trash.c
@@ -70,11 +70,11 @@ trash_file (XdpAppInfo *app_info,
   g_autoptr(GFile) file = NULL;
   g_autoptr(GError) local_error = NULL;
 
-  path = xdp_app_info_get_path_for_fd (app_info, fd, 0, NULL, &writable);
+  path = xdp_app_info_get_path_for_fd (app_info, fd, 0, NULL, &writable, &local_error);
 
   if (path == NULL)
     {
-      g_debug ("Cannot trash file with invalid fd");
+      g_debug ("Cannot trash file with invalid fd: %s", local_error->message);
       return 0;
     }
 

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -233,9 +233,11 @@ handle_set_wallpaper_in_thread_func (GTask *task,
     {
       g_autofree char *path = NULL;
 
-      path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, NULL);
+      path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, NULL, &error);
       if (path == NULL)
         {
+          g_debug ("Cannot get path for fd: %s", error->message);
+
           /* Reject the request */
           if (request->exported)
             {

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -29,6 +29,11 @@
 #include <gio/gio.h>
 #include <errno.h>
 
+#ifndef G_DBUS_METHOD_INVOCATION_HANDLED
+#define G_DBUS_METHOD_INVOCATION_HANDLED TRUE
+#define G_DBUS_METHOD_INVOCATION_UNHANDLED FALSE
+#endif
+
 #define DESKTOP_PORTAL_OBJECT_PATH "/org/freedesktop/portal/desktop"
 
 #define FLATPAK_METADATA_GROUP_APPLICATION "Application"

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -83,7 +83,8 @@ char *      xdp_app_info_get_path_for_fd (XdpAppInfo  *app_info,
                                           int          fd,
                                           int          require_st_mode,
                                           struct stat *st_buf,
-                                          gboolean    *writable_out);
+                                          gboolean    *writable_out,
+                                          GError     **error);
 gboolean    xdp_app_info_has_network     (XdpAppInfo  *app_info);
 XdpAppInfo *xdp_get_app_info_from_pid    (pid_t        pid,
                                           GError     **error);


### PR DESCRIPTION
* verify_proc_self_fd: Raise a GError
    
    This lets us log the failure reason as a debug message on failure.

* xdp_app_info_get_path_for_fd: Factor out check_same_file
    
    As with the previous commit, this lets us log a more detailed debug
    message when we don't get a match.

* utils: Add fallback definition for G_DBUS_METHOD_INVOCATION_HANDLED
    
    When implementing GDBus methods, it's not always obvious that
    "return TRUE" on error is correct - but in fact it is, because the
    boolean result is handled/unhandled rather than the usual success/error.
    GLib 2.68 introduced macros to make this more obvious. Backport them
    here for older GLib versions.
    
    I'm not systematically converting existing code right now, but the new
    macros can be used in new code.

* email: Handle error from xdp_app_info_get_path_for_fd
    
    Otherwise we would append NULL to the GVariantBuilder, which is
    considered to be a programming error, resulting in a runtime warning
    and not actually attaching the intended attachment.

* open-uri: Emit debug messages even if request was not exported yet

* trash: Log debug messages on failure

* xdp_app_info_get_path_for_fd: Raise a GError
    
    This allows better context-sensitive logging.

---

This is mostly just adding more detailed `g_debug()` when a file cannot be passed to the portal. We log this via `g_debug()` rather than sending information back to the calling app in order to avoid leaking information about the host filesystem into the sandbox of a Flatpak (or Snap) app.

I'm in two minds about "email: Handle error from xdp_app_info_get_path_for_fd": do we want trying to attach a file that cannot be shared with the host to cause an error, or do we want to log a message and gracefully degrade to sending the email without the attachment? Marked as draft until this is resolved.

I originally thought the right answer was an error (as implemented here), but while testing this I found that the `xdg-email --attach` in flatpak-xdg-utils has, effectively, silently ignored `--attach` since 2017 (flatpak/flatpak-xdg-utils#50, fix proposed in flatpak/flatpak-xdg-utils#51), and it still doesn't implement multiple `--attach`; so clearly nobody has found that feature to be particularly important?