### PR TITLE
location: Update accuracy translation

### DIFF
--- a/src/location.c
+++ b/src/location.c
@@ -440,13 +440,13 @@ handle_create_session (XdpLocation *object,
         session->accuracy = GCLUE_ACCURACY_LEVEL_NONE;
       else if (accuracy == 1)
         session->accuracy = GCLUE_ACCURACY_LEVEL_COUNTRY;
-      else if (accuracy == 4)
+      else if (accuracy == 2)
         session->accuracy = GCLUE_ACCURACY_LEVEL_CITY;
-      else if (accuracy == 5)
+      else if (accuracy == 3)
         session->accuracy = GCLUE_ACCURACY_LEVEL_NEIGHBORHOOD;
-      else if (accuracy == 6)
+      else if (accuracy == 4)
         session->accuracy = GCLUE_ACCURACY_LEVEL_STREET;
-      else if (accuracy == 8)
+      else if (accuracy == 5)
         session->accuracy = GCLUE_ACCURACY_LEVEL_EXACT;
       else
         {


### PR DESCRIPTION
Currently the translation uses the geoclue enum values rather than
the documented values, which breaks consumers like geoclue's client
library that translates accuracy values according to the documentation.
