### PR TITLE
use correct type for the session object path

### DIFF
--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -366,7 +366,7 @@ create_monitor_done (GObject *source_object,
     }
 
   g_variant_builder_add (&results_builder, "{sv}",
-                         "session_handle", g_variant_new ("s", session->id));
+                         "session_handle", g_variant_new ("o", session->id));
 
 out:
   if (request->exported)

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -221,7 +221,7 @@ create_session_done (GObject *source_object,
     }
 
   g_variant_builder_add (&results_builder, "{sv}",
-                         "session_handle", g_variant_new ("s", session->id));
+                         "session_handle", g_variant_new ("o", session->id));
 
 out:
   if (request->exported)

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -187,7 +187,7 @@ create_session_done (GObject *source_object,
     }
 
   g_variant_builder_add (&results_builder, "{sv}",
-                         "session_handle", g_variant_new ("s", session->id));
+                         "session_handle", g_variant_new ("o", session->id));
 
 out:
   if (request->exported)


### PR DESCRIPTION
The session id is defined as the object path of the session.
We should use a type of 'o' instead of 's'.

Note that the docs mentions the correct type https://flatpak.github.io/xdg-desktop-portal/portal-docs.html#gdbus-method-org-freedesktop-portal-ScreenCast.CreateSession.