### PR TITLE
Place portals in session.slice

### DIFF
--- a/document-portal/xdg-document-portal.service.in
+++ b/document-portal/xdg-document-portal.service.in
@@ -5,3 +5,4 @@ Description=flatpak document portal service
 BusName=org.freedesktop.portal.Documents
 ExecStart=@libexecdir@/xdg-document-portal
 Type=dbus
+Slice=session.slice

--- a/src/xdg-desktop-portal.service.in
+++ b/src/xdg-desktop-portal.service.in
@@ -5,3 +5,4 @@ Description=Portal service
 Type=dbus
 BusName=org.freedesktop.portal.Desktop
 ExecStart=@libexecdir@/xdg-desktop-portal
+Slice=session.slice


### PR DESCRIPTION
Services and applications like these portals should be placed in the
session slice.

From DESKTOP_ENVIRONEMTNS[1]

> The purpose of this grouping is to assign different priorities to the
> applications. This could e.g. mean reserving memory to session
> processes, preferentially killing background tasks in out-of-memory
> situations or assigning different memory/CPU/IO priorities to ensure
> that the session runs smoothly under load.

And from man:systemd.special(7):

> session.slice
>  All essential services and applications required for the session
>  should use this slice. These are services that either cannot be
>  restarted easily or where latency issues may affect the interactivity
>  of the system and applications. This includes the display server,
>  screen readers and other services such as DBus or XDG portals. Such
>  services should be configured to be part of this slice by adding
>  Slice=session.slice to their unit files.  # Please enter the commit
>  message for your changes. Lines starting

Note that XDG portals are explicitly mentioned here. This should
reduce the priority of the portals when it comes to freeing up
resources. Having the portals get killed can further affect the
stability of other desktop applications.

[1]: https://systemd.io/DESKTOP_ENVIRONMENTS/