### PR TITLE
Update ScreenCast and Camera documentation to Pipewire 0.3 api

### DIFF
--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -57,8 +57,8 @@
 
         Open a file descriptor to the PipeWire remote where the camera nodes
         are available. The file descriptor should be used to create a
-        <classname>pw_remote</classname> object, by using
-        <function>pw_remote_connect_fd</function>.
+        <classname>pw_core</classname> object, by using
+        <function>pw_context_connect_fd</function>.
 
         This method will only succeed if the application already has permission
         to access camera devices.

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -216,8 +216,8 @@
 
         Open a file descriptor to the PipeWire remote where the screen cast
         streams are available. The file descriptor should be used to create a
-        <classname>pw_remote</classname> object, by using
-        <function>pw_remote_connect_fd</function>. Only the screen cast stream
+        <classname>pw_core</classname> object, by using
+        <function>pw_context_connect_fd</function>. Only the screen cast stream
         nodes will be available from this PipeWire node.
     -->
     <method name="OpenPipeWireRemote">


### PR DESCRIPTION
`pw_remote_connect_fd` does not exist any more.

Closes https://github.com/flatpak/xdg-desktop-portal/issues/617