### PR TITLE
Add a portal for Emulated Input

### DIFF
--- a/Makefile.am.inc
+++ b/Makefile.am.inc
@@ -5,6 +5,7 @@ PORTAL_IFACE_FILES =\
 	$(top_srcdir)/data/org.freedesktop.portal.Device.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.Documents.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.Email.xml \
+	$(top_srcdir)/data/org.freedesktop.portal.EmulatedInput.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.FileChooser.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.FileTransfer.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.GameMode.xml \
@@ -35,6 +36,7 @@ PORTAL_IMPL_IFACE_FILES =\
 	$(top_srcdir)/data/org.freedesktop.impl.portal.AppChooser.xml \
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Background.xml \
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Email.xml \
+	$(top_srcdir)/data/org.freedesktop.impl.portal.EmulatedInput.xml \
 	$(top_srcdir)/data/org.freedesktop.impl.portal.FileChooser.xml \
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Inhibit.xml \
 	$(top_srcdir)/data/org.freedesktop.impl.portal.Lockdown.xml \

--- a/data/org.freedesktop.impl.portal.EmulatedInput.xml
+++ b/data/org.freedesktop.impl.portal.EmulatedInput.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2021 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.impl.portal.EmulatedInput:
+      @short_description: Emulated input backend interface
+
+      The emulated input portal enables applications to emulate input devices.
+  -->
+  <interface name="org.freedesktop.impl.portal.EmulatedInput">
+    <!--
+        CreateSession:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session being created
+        @app_id: App id of the application
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Create an emulated input session
+
+        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>session_id s</term>
+            <listitem><para>
+              The session id. A string representing the created screen cast session.
+            </para></listitem>
+          </varlistentry>
+      </variablelist>
+    -->
+    <method name="CreateSession">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+    <!--
+        ConnectToEIS:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @fd: File descriptor to be passed into libei. Only valid for a zero result.
+        @app_id: App id of the application
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Request a connection to the Emulated Input Server (EIS).
+
+        The following results get returned via the @results dictionary:
+        <variablelist>
+          <varlistentry>
+            <term>fd h</term>
+            <listitem><para>
+              A socket to the EIS implementation. This socket can be passed to ei_setup_backend_socket().
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="ConnectToEIS">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.impl.portal.Lockdown.xml
+++ b/data/org.freedesktop.impl.portal.Lockdown.xml
@@ -38,5 +38,6 @@
     <property name="disable-camera" type="b" access="readwrite"/>
     <property name="disable-microphone" type="b" access="readwrite"/>
     <property name="disable-sound-output" type="b" access="readwrite"/>
+    <property name="disable-emulated-input" type="b" access="readwrite"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -32,11 +32,9 @@
   <interface name="org.freedesktop.portal.Background">
     <!--
         RequestBackground:
-        @parent_window: Identifier for the application window, see
-            <link linkend="parent_window">Common Conventions</link>
+        @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
         @options: Vardict with optional further information
-        @handle: Object path for the #org.freedesktop.portal.Request
-            object representing this call
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
         Requests that the application is allowed to run in the
         background.

--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -43,7 +43,7 @@
         </variablelist>
 
         Following the #org.freedesktop.portal.Request::Response signal, if
-        granted, #org.freedesktop.org.Camera.OpenPipeWireRemote can be used to
+        granted, org.freedesktop.portal.Camera.OpenPipeWireRemote() can be used to
         open a PipeWire remote.
     -->
     <method name="AccessCamera">

--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -49,7 +49,7 @@
       The D-Bus interface for the document portal is available under the
       bus name org.freedesktop.portal.Documents and the object path
       /org/freedesktop/portal/documents.
- 
+
       This documentation describes version 4 of this interface.
   -->
   <interface name='org.freedesktop.portal.Documents'>
@@ -123,15 +123,15 @@
         contain an empty string.
 
         Additionally, if app_id is specified, it will be given the permissions
-        listed in GrantPermission.
+        listed in org.freedesktop.portal.Documents.GrantPermissions().
 
         The method also returns some extra info that can be used to avoid
         multiple roundtrips. For now it only contains as "mountpoint", the
         fuse mountpoint of the document portal.
 
-        This method was added in version 2 of the org.freedesktop.portal.Documents interface.
+        This method was added in version 2 of the #org.freedesktop.portal.Documents interface.
 
-        Support for exporting directories were added in version 4 of the org.freedesktop.portal.Documents interface.
+        Support for exporting directories were added in version 4 of the #org.freedesktop.portal.Documents interface.
     -->
     <method name="AddFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -161,13 +161,13 @@
         contain an empty string.
 
         Additionally, if app_id is specified, it will be given the permissions
-        listed in GrantPermission.
+        listed in org.freedesktop.portal.Documents.GrantPermissions().
 
         The method also returns some extra info that can be used to avoid
         multiple roundtrips. For now it only contains as "mountpoint", the
         fuse mountpoint of the document portal.
 
-        This method was added in version 3 of the org.freedesktop.portal.Documents interface.
+        This method was added in version 3 of the #org.freedesktop.portal.Documents interface.
     -->
     <method name="AddNamedFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>

--- a/data/org.freedesktop.portal.EmulatedInput.xml
+++ b/data/org.freedesktop.portal.EmulatedInput.xml
@@ -22,6 +22,11 @@
       @short_description: Portal for emulating input events
 
       The emulated input portal enables applications to emulate input events.
+      The portal's functionality is limited to session management and
+      establishing a side-channel used as the transport layer for the actual
+      input events. Once that side-channel is established, the emulating
+      application communicates directly with the compositor without involvement
+      of the portal.
   -->
   <interface name="org.freedesktop.portal.EmulatedInput">
     <!--
@@ -29,10 +34,11 @@
         @options: Vardict with optional further information
         @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
-        Create a session to emulate input. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session::Close, or may
+        Create a session to emulate input events. A successfully created
+        session can at any time be closed using
+        org.freedesktop.portal.Session.Close(), or may
         at any time be closed by the portal implementation, which will be
-        signalled via org.freedesktop.portal.Session::Closed.
+        signalled via #org.freedesktop.portal.Session::Closed.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -77,8 +83,17 @@
         @response: Zero on success or 1 on error
         @results: Vardict with the results of the call
 
-        Request a connection to the Emulated Input Server (EIS). This method
-        is expected to complete immediately, it does not use a Request object.
+        Request a connection to an
+        <ulink url="https://libinput.pages.freedesktop.org/libei/"> Emulated Input Server (EIS)</ulink>
+        implementation. This method is expected to complete immediately, it does not use a Request object.
+        The returned file descriptor serves as the transport layer for input events in this session.
+
+        When the Session is #org.freedesktop.portal.Session::Closed, the EIS
+        implementation closes the file descriptor. For technical reasons it
+        cannot be guaranteed that the #org.freedesktop.portal.Session::Closed
+        signal arrives before the first error on the file descriptor occurs.
+        An application must handle read or write errors on the file descriptor
+        correctly.
 
         This method will only succeed if the application has permission
         to emulate input.

--- a/data/org.freedesktop.portal.EmulatedInput.xml
+++ b/data/org.freedesktop.portal.EmulatedInput.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2021 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.EmulatedInput:
+      @short_description: Portal for emulating input events
+
+      The emulated input portal enables applications to emulate input events.
+  -->
+  <interface name="org.freedesktop.portal.EmulatedInput">
+    <!--
+        CreateSession:
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Create a session to emulate input. A successfully created session can at
+        any time be closed using org.freedesktop.portal.Session::Close, or may
+        at any time be closed by the portal implementation, which will be
+        signalled via org.freedesktop.portal.Session::Closed.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the @handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Request documentation for
+              more information about the @handle.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>session_handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the session handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Session documentation for
+              more information about the session handle.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>session_handle o</term>
+            <listitem><para>
+              The session handle. An object path for the
+              #org.freedesktop.portal.Session object representing the created
+              session.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="CreateSession">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+    <!--
+        ConnectToEIS:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @options: Vardict with optional further information
+        @response: Zero on success or 1 on error
+        @results: Vardict with the results of the call
+
+        Request a connection to the Emulated Input Server (EIS). This method
+        is expected to complete immediately, it does not use a Request object.
+
+        This method will only succeed if the application has permission
+        to emulate input.
+
+        The following results get returned via the @results dictionary:
+        <variablelist>
+          <varlistentry>
+            <term>fd h</term>
+            <listitem><para>
+              A socket to the EIS implementation. This socket can be passed to ei_setup_backend_socket().
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <method name="ConnectToEIS">
+      <annotation name="org.gtk.GDBus.C.Name" value="connect_to_eis"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.FileTransfer.xml
+++ b/data/org.freedesktop.portal.FileTransfer.xml
@@ -23,19 +23,20 @@
        org.freedesktop.portal.FileTransfer:
        @short_description: Portal for transferring files between apps
 
-       The FileTransfer portal operates as a middle-man between apps
-       when transferring files via drag-and-drop or copy-paste, taking
-       care of the necessary exporting of files in the document portal.
+       The #org.freedesktop.portal.FileTransfer portal operates as a middle-man
+       between apps when transferring files via drag-and-drop or copy-paste,
+       taking care of the necessary exporting of files in the document portal.
 
        Toolkits are expected to use the application/vnd.portal.filetransfer
        mimetype when using this mechanism for file exchange via copy-paste
        or drag-and-drop.
 
        The data that is transmitted with this mimetype should be the key
-       returned by the StartTransfer method. Upon receiving this mimetype,
-       the target should call RetrieveFiles with the key, to obtain the
-       list of files. The portal will take care of exporting files in
-       the document store as necessary to make them accessible to the
+       returned by the org.freedesktop.portal.FileTransfer.StartTransfer()
+       method. Upon receiving this mimetype, the target should call
+       org.freedesktop.portal.FileTransfer.RetrieveFiles() with the key,
+       to obtain the list of files. The portal will take care of exporting
+       files in the document store as necessary to make them accessible to the
        target.
 
        The D-Bus interface for the this portal is available under the
@@ -48,13 +49,15 @@
     <!--
         StartTransfer:
         @options: Vardict with optional further onformation
-        @key: a key that needs to be passed to RetrieveFiles to obtain the files
+        @key: a key that needs to be passed to org.freedesktop.portal.FileTransfer.RetrieveFiles() to obtain the files
 
         Starts a session for a file transfer.
-        The caller should call AddFiles at least once, to add files to this session.
+        The caller should call org.freedesktop.portal.FileTransfer.AddFiles()
+        at least once, to add files to this session.
 
-        Another application can then call RetrieveFiles to obtain them, if it has
-        the @session and @secret.
+        Another application can then call
+        org.freedesktop.portal.FileTransfer.RetrieveFiles() to obtain them, if
+        it has the @session and @secret.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -73,7 +76,7 @@
             <term>autostop b</term>
             <listitem><para>
               Whether to stop the transfer automatically after the first
-              RetrieveFiles call. Default: True
+              org.freedesktop.portal.FileTransfer.RetrieveFiles() call. Default: True
             </para></listitem>
           </varlistentry>
         </variablelist>
@@ -85,7 +88,7 @@
 
     <!--
         AddFiles:
-        @key: A key returned by StartTransfer
+        @key: A key returned by org.freedesktop.portal.FileTransfer.StartTransfer()
         @fds: File descriptors for the files to register
 
         Adds files to a session. This method can be called multiple times on
@@ -94,7 +97,7 @@
 
         Note that the session bus often has a low limit of file descriptors per
         message (typically, 16), so you may have to send large file lists with
-        multiple AddFiles calls.
+        multiple org.freedesktop.portal.FileTransfer.AddFiles() calls.
     -->
     <method name="AddFiles">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -105,17 +108,17 @@
 
     <!--
         RetrieveFiles:
-        @key: A key returned by StartTransfer
+        @key: A key returned by org.freedesktop.portal.FileTransfer.StartTransfer()
         @options: Vardict with optional further onformation
         @files: list of paths
 
         Retrieves files that were previously added to the session with
-        AddFiles. The files will be exported in the document portal
-        as-needed for the caller, and they will be writable if the
-        owner of the session allowed it.
+        org.freedesktop.portal.FileTransfer.AddFiles(). The files will be
+        exported in the document portal as-needed for the caller, and they
+        will be writable if the owner of the session allowed it.
 
-        After the first RetrieveFiles call, the session will be closed
-        by the portal, unless autostop has been set to False.
+        After the first org.freedesktop.portal.FileTransfer.RetrieveFiles() call,
+        the session will be closed by the portal, unless @autostop has been set to False.
     -->
     <method name="RetrieveFiles">
       <arg type="s" name="key" direction="in"/>
@@ -125,10 +128,10 @@
 
     <!--
         StopTransfer:
-        @key: A key returned by StartTransfer
+        @key: A key returned by org.freedesktop.portal.FileTransfer.StartTransfer()
 
-        Ends the transfer. Further calls to AddFiles or RetrieveFiles
-        for this key will return an error.
+        Ends the transfer. Further calls to org.freedesktop.portal.FileTransfer.AddFiles()
+        or org.freedesktop.portal.FileTransfer.RetrieveFiles() for this key will return an error.
     -->
     <method name="StopTransfer">
       <arg type="s" name="key" direction="in"/>

--- a/data/org.freedesktop.portal.GameMode.xml
+++ b/data/org.freedesktop.portal.GameMode.xml
@@ -30,17 +30,18 @@
       separate process  ids (pids) within two different namespaces
       that both identify same process. One id from the pid namespace
       inside the sandbox and one id from the host pid namespace.
-      Since GameMode expects pids from the host pid namespace but
-      programs inside the sandbox can only know pids from the sandbox
-      namespace, process ids need to be translated from the portal to
-      the host namespace. The portal will do that transparently for
-      all calls where this is necessary.
+      Since org.freedesktop.portal.GameMode expects pids from the host
+      pid namespace but programs inside the sandbox can only know pids
+      from the sandbox namespace, process ids need to be translated from
+      the portal to the host namespace. The portal will do that transparently
+      for all calls where this is necessary.
 
-      Note: GameMode will monitor active clients, i.e. games and
-      other programs that have successfully called 'RegisterGame'.
+      Note: #org.freedesktop.portal.GameMode will monitor active clients,
+      i.e. games and other programs that have successfully called
+      org.freedesktop.portal.GameMode.RegisterGame().
       In the event that a client terminates without a call to the
-      'UnregisterGame' method, GameMode will automatically un-register
-      the client. This might happen with a (small) delay.
+      org.freedesktop.portal.GameMode.UnregisterGame() method, GameMode will
+      automatically un-register the client. This might happen with a (small) delay.
 
       This documentation describes version 3 of this interface.
     -->

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -84,7 +84,7 @@
         A successfully created session can at any time be closed using
         org.freedesktop.portal.Session::Close, or may at any time be closed
         by the portal implementation, which will be signalled via
-        org.freedesktop.portal.Session::Closed.
+        #org.freedesktop.portal.Session::Closed.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -135,7 +135,7 @@
         the session state changes.
 
         When the session state changes to 'Query End', clients with active monitoring
-        sessions are expected to respond by calling 
+        sessions are expected to respond by calling
         org.freedesktop.portal.Inhibit.QueryEndResponse() within a second
         of receiving the StateChanged signal. They may call org.freedesktop.portal.Inhibit.Inhibit()
         first to inhibit logout, to prevent the session from proceeding to the Ending state.

--- a/data/org.freedesktop.portal.Location.xml
+++ b/data/org.freedesktop.portal.Location.xml
@@ -35,10 +35,10 @@
         @handle: Object path for the created #org.freedesktop.portal.Session object
 
         Create a location session. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session::Close, or may
+        any time be closed using org.freedesktop.portal.Session.Close(), or may
         at any time be closed by the portal implementation, which will be
-        signalled via org.freedesktop.portal.Session::Closed.
-`
+        signalled via #org.freedesktop.portal.Session::Closed.
+
         Supported keys in the @options vardict include:
         <variablelist>
           <varlistentry>

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -38,7 +38,7 @@
       exported and will be activated via the ActivateAction()
       method in the org.freedesktop.Application interface. Other
       actions are activated by sending the
-      #org.freedeskop.portal.Notification::ActionInvoked signal
+      #org.freedesktop.portal.Notification::ActionInvoked signal
       to the application.
 
       This documentation describes version 1 of this interface.

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -35,12 +35,12 @@
 
         A remote desktop session is used to allow remote controlling a desktop
         session. It can also be used together with a screen cast session (see
-        org.freedesktop.portal.ScreenCast), but may only be started and stopped
+        #org.freedesktop.portal.ScreenCast), but may only be started and stopped
         with this interface.
 
         To also get a screen content, call the
-        #org.freedesktop.ScreenCast.SelectSources with the
-        #org.freedesktop.Session object created with this method.
+        org.freedesktop.portal.ScreenCast.SelectSources() with the
+        #org.freedesktop.portal.Session object created with this method.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -61,7 +61,7 @@
             </para></listitem>
           </varlistentry>
         </variablelist>
-        
+
         The following results get returned via the #org.freedesktop.portal.Request::Response signal:
         <variablelist>
           <varlistentry>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -32,9 +32,9 @@
         @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
         Create a screen cast session. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session::Close, or may
+        any time be closed using org.freedesktop.portal.Session.Close(), or may
         at any time be closed by the portal implementation, which will be
-        signalled via org.freedesktop.portal.Session::Closed.
+        signalled via #org.freedesktop.portal.Session::Closed.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -111,7 +111,7 @@
             <term>cursor_mode u</term>
             <listitem><para>
               Determines how the cursor will be drawn in the screen cast stream. It must be
-              one of the curosr modes advertised in
+              one of the cursor modes advertised in
               #org.freedesktop.portal.ScreenCast.AvailableCursorModes. Setting a cursor mode
               not advertised will cause the screen cast session to be closed. The default
               cursor mode is 'Hidden'.
@@ -175,10 +175,11 @@
 
         Start the screen cast session. This will typically result the portal
         presenting a dialog letting the user do the selection set up by
-        SelectSources. An application can only attempt start a session once.
+        org.freedesktop.portal.ScreenCast.SelectSources(). An application can
+        only attempt start a session once.
 
         A screen cast session may only be started after having selected sources
-        using org.freedesktop.portal.ScreenCast::SelectSources.
+        using org.freedesktop.portal.ScreenCast.SelectSources().
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -203,8 +204,10 @@
               properties.
 
               The array will contain a single stream if 'multiple' (see
-              SelectSources) was set to 'false', or at least one stream if
-              'multiple' was set to 'true' as part of the SelectSources method.
+              org.freedesktop.portal.ScreenCast.SelectSources())
+              was set to 'false', or at least one stream if
+              'multiple' was set to 'true' as part of the
+              org.freedesktop.portal.ScreenCast.SelectSources() method.
             </para></listitem>
           </varlistentry>
           <varlistentry>
@@ -212,7 +215,7 @@
             <listitem><para>
               The restore token. This token is a single use token that can later
               be used to restore a session. See
-              #org.freedesktop.portal.ScreenCast.SelectSources for details.
+              org.freedesktop.portal.ScreenCast.SelectSources() for details.
 
               This response option was added in version 4 of this interface.
             </para></listitem>

--- a/data/org.freedesktop.portal.Secret.xml
+++ b/data/org.freedesktop.portal.Secret.xml
@@ -54,7 +54,7 @@
 
         The portal may return an additional identifier associated with
         the secret in the results vardict of
-        org.freedesktop.portal.Request.Response() call. In the next
+        #org.freedesktop.portal.Request::Response signal. In the next
         call of this method, the application shall indicate it through
         a token element in @options.
 

--- a/data/org.freedesktop.portal.Session.xml
+++ b/data/org.freedesktop.portal.Session.xml
@@ -31,8 +31,8 @@
       The duration of the session is defined by the interface that creates it.
       For convenience, the interface contains a method
       org.freedesktop.portal.Session.Close(), and a signal
-      org.freedesktop.portal.Session::Closed. Whether it is allowed to directly
-      call Close() depends on the interface.
+      #org.freedesktop.portal.Session::Closed. Whether it is allowed to directly
+      call org.freedesktop.portal.Session.Close() depends on the interface.
 
       The handle of a session will be of the form
       /org/freedesktop/portal/desktop/session/SENDER/TOKEN, where SENDER is the

--- a/data/org.freedesktop.portal.Wallpaper.xml
+++ b/data/org.freedesktop.portal.Wallpaper.xml
@@ -31,8 +31,7 @@
   <interface name="org.freedesktop.portal.Wallpaper">
     <!--
         SetWallpaperURI:
-        @parent_window: Identifier for the application window, see
-            <link linkend="parent_window">Common Conventions</link>
+        @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
         @uri: The picture file uri
         @options: Options that influence the behavior of the portal
         @handle: Object path for the #org.freedesktop.portal.Request object representing this call
@@ -40,12 +39,24 @@
         Asks to set a given picture as the desktop background picture.
 
         Note that file: uris are explicitly not supported here. To use a local image file as
-        background, use the SetWallpaperFile method.
+        background, use the org.freedesktop.portal.Wallpaper.SetWallpaperFile() method.
 
-        The following options are supported:
-        show-preview: (b) whether to show a preview of the picture. Note that the portal may
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>show-preview b</term>
+            <listitem><para>
+             whether to show a preview of the picture. Note that the portal may
              decide to show a preview even if this option is not set
-        set-on: (s) where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>set-on s</term>
+            <listitem><para>
+              where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="SetWallpaperURI">
       <arg type="s" name="parent_window" direction="in"/>
@@ -56,18 +67,29 @@
 
     <!--
         SetWallpaperFile:
-        @parent_window: Identifier for the application window, see
-            <link linkend="parent_window">Common Conventions</link>
+        @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
         @fd: File descriptor for the file to open
         @options: Options that influence the behavior of the portal
         @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
         Asks to set a given local file as the desktop background picture.
 
-        The following options are supported:
-        show-preview: (b) whether to show a preview of the picture. Note that the portal may
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>show-preview b</term>
+            <listitem><para>
+             whether to show a preview of the picture. Note that the portal may
              decide to show a preview even if this option is not set
-        set-on: (s) where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>set-on s</term>
+            <listitem><para>
+              where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="SetWallpaperFile">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -54,7 +54,7 @@
         ::Closed signal is emitted to inform the application.
       </para>
     </section>
-    <section id="parent_window"> 
+    <section id="parent_window">
       <title>Parent window identifiers</title>
       <para>
         Most portals interact with the user by showing dialogs. These dialogs
@@ -96,6 +96,7 @@
     <xi:include href="portal-org.freedesktop.portal.Device.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Documents.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Email.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.EmulatedInput.xml"/>
     <xi:include href="portal-org.freedesktop.portal.FileChooser.xml"/>
     <xi:include href="portal-org.freedesktop.portal.FileTransfer.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Flatpak.UpdateMonitor.xml"/>
@@ -147,6 +148,7 @@
     <xi:include href="portal-org.freedesktop.impl.portal.AppChooser.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Background.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Email.xml"/>
+    <xi:include href="portal-org.freedesktop.impl.portal.EmulatedInput.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.FileChooser.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Inhibit.xml"/>
     <xi:include href="portal-org.freedesktop.impl.portal.Lockdown.xml"/>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -103,6 +103,8 @@ xdg_desktop_portal_SOURCES = \
 	src/permissions.h               \
 	src/email.c                     \
 	src/email.h                     \
+	src/emulated-input.c	\
+	src/emulated-input.h	\
 	src/settings.c			\
 	src/settings.h			\
 	src/session.c			\

--- a/src/emulated-input.c
+++ b/src/emulated-input.c
@@ -20,9 +20,6 @@
 
 #include <glib/gi18n.h>
 #include <gio/gunixfdlist.h>
-#include <gio/gdesktopappinfo.h>
-#include <gio/gunixsocketaddress.h>
-#include <stdio.h>
 
 #include "session.h"
 #include "request.h"

--- a/src/emulated-input.c
+++ b/src/emulated-input.c
@@ -1,0 +1,613 @@
+/*
+ * Copyright © 2018-2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+#include <gio/gunixfdlist.h>
+#include <gio/gdesktopappinfo.h>
+#include <gio/gunixsocketaddress.h>
+#include <stdio.h>
+
+#include "session.h"
+#include "request.h"
+#include "permissions.h"
+#include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
+#include "xdp-utils.h"
+
+/* The permission table is "emulated-input" : $appid */
+#define PERMISSION_TABLE "emulated-input"
+
+static XdpImplAccess *impl_access;
+static XdpImplLockdown *lockdown;
+static XdpImplEmulatedInput *impl;
+static int impl_version;
+
+typedef struct _EmulatedInput EmulatedInput;
+typedef struct _EmulatedInputClass EmulatedInputClass;
+
+static GQuark quark_request_session;
+
+struct _EmulatedInput
+{
+  XdpEmulatedInputSkeleton parent_instance;
+};
+
+struct _EmulatedInputClass
+{
+  XdpEmulatedInputSkeletonClass parent_class;
+};
+
+static EmulatedInput *emulated_input;
+
+GType emulated_input_get_type (void);
+static void emulated_input_iface_init (XdpEmulatedInputIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (EmulatedInput, emulated_input, XDP_TYPE_EMULATED_INPUT_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_TYPE_EMULATED_INPUT,
+                                                emulated_input_iface_init))
+
+typedef enum _EmulatedInputSessionState
+{
+  EMULATED_INPUT_SESSION_STATE_INIT,
+  EMULATED_INPUT_SESSION_STATE_STARTING,
+  EMULATED_INPUT_SESSION_STATE_STARTED,
+  EMULATED_INPUT_SESSION_STATE_CLOSED
+} EmulatedInputSessionState;
+
+typedef struct _EmulatedInputSession
+{
+  Session parent;
+
+  EmulatedInputSessionState state;
+} EmulatedInputSession;
+
+typedef struct _EmulatedInputSessionClass
+{
+  SessionClass parent_class;
+} EmulatedInputSessionClass;
+
+GType emulated_input_session_get_type (void);
+
+G_DEFINE_TYPE (EmulatedInputSession, emulated_input_session, session_get_type ())
+
+static gboolean
+is_emulated_input_session (Session *session)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (session, emulated_input_session_get_type ());
+}
+
+static EmulatedInputSession *
+emulated_input_session_new (const char *session_token,
+                            Request *request,
+                            GError **error)
+{
+  Session *session;
+  GDBusInterfaceSkeleton *interface_skeleton = G_DBUS_INTERFACE_SKELETON (request);
+  GDBusConnection *connection =
+    g_dbus_interface_skeleton_get_connection (interface_skeleton);
+  GDBusConnection *impl_connection =
+    g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
+  const char *impl_dbus_name = g_dbus_proxy_get_name (G_DBUS_PROXY (impl));
+
+  session = g_initable_new (emulated_input_session_get_type (), NULL, error,
+                            "sender", request->sender,
+                            "app-id", xdp_app_info_get_id (request->app_info),
+                            "token", session_token,
+                            "connection", connection,
+                            "impl-connection", impl_connection,
+                            "impl-dbus-name", impl_dbus_name,
+                            NULL);
+
+  if (session)
+    g_debug ("emulated input session owned by '%s' created", session->sender);
+
+  return (EmulatedInputSession*)session;
+}
+
+static void
+create_session_done (GObject *source_object,
+                     GAsyncResult *res,
+                     gpointer data)
+{
+  g_autoptr(Request) request = data;
+  Session *session;
+  guint response = 2;
+  gboolean should_close_session = FALSE;
+  GVariantBuilder results_builder;
+  g_autoptr(GError) error = NULL;
+
+  REQUEST_AUTOLOCK (request);
+
+  session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
+  SESSION_AUTOLOCK_UNREF (g_object_ref (session));
+  g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+
+  if (!xdp_impl_emulated_input_call_create_session_finish (impl,
+                                                           &response,
+                                                           NULL,
+                                                           res,
+                                                           &error))
+    {
+      g_warning ("A backend call failed: %s", error->message);
+      should_close_session = TRUE;
+      goto out;
+    }
+
+  if (request->exported && response == 0)
+    {
+      if (!session_export (session, &error))
+        {
+          g_warning ("Failed to export session: %s", error->message);
+          response = 2;
+          should_close_session = TRUE;
+          goto out;
+        }
+
+      should_close_session = FALSE;
+      session_register (session);
+    }
+  else
+    {
+      should_close_session = TRUE;
+    }
+
+  ((EmulatedInputSession*) session)->state = EMULATED_INPUT_SESSION_STATE_STARTED;
+
+  g_variant_builder_add (&results_builder, "{sv}",
+                         "session_handle", g_variant_new ("s", session->id));
+
+out:
+  if (request->exported)
+    {
+      xdp_request_emit_response (XDP_REQUEST (request),
+                                 response,
+                                 g_variant_builder_end (&results_builder));
+      request_unexport (request);
+    }
+  else
+    {
+      g_variant_builder_clear (&results_builder);
+    }
+
+  if (should_close_session)
+    session_close (session, FALSE);
+}
+
+static gboolean
+emulated_input_query_permission_sync (const char *app_id,
+                                      Request    *request)
+{
+  Permission permission = PERMISSION_UNSET;
+  gboolean allowed;
+
+  /* If we don't have an app-id we can't check for anything */
+  if (app_id == NULL || app_id[0] == '\0')
+      return TRUE;
+
+  if (permission == PERMISSION_ASK || permission == PERMISSION_UNSET)
+    {
+      GVariantBuilder opt_builder;
+      g_autofree char *title = NULL;
+      g_autofree char *subtitle = NULL;
+      g_autofree char *body = NULL;
+      guint32 response = 2;
+      g_autoptr(GVariant) results = NULL;
+      g_autoptr(GError) error = NULL;
+      g_autoptr(GAppInfo) info = NULL;
+      g_autoptr(XdpImplRequest) impl_request = NULL;
+
+      if (app_id[0] != 0)
+        {
+          g_autofree char *desktop_id;
+          desktop_id = g_strconcat (app_id, ".desktop", NULL);
+          info = (GAppInfo*)g_desktop_app_info_new (desktop_id);
+        }
+
+      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+      g_variant_builder_add (&opt_builder, "{sv}", "icon", g_variant_new_string ("input-mouse-symbolic"));
+
+      title = g_strdup (_("Allow Emulated Input?"));
+      body = g_strdup (_("Permissions to allow emulated input can be changed "
+                         "at any time from the privacy settings."));
+
+      if (info == NULL)
+          subtitle = g_strdup (_("An application wants to emulate input."));
+      else
+          subtitle = g_strdup_printf (_("%s wants to emulate input."), g_app_info_get_display_name (info));
+
+      impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl_access)),
+                                                      G_DBUS_PROXY_FLAGS_NONE,
+                                                      g_dbus_proxy_get_name (G_DBUS_PROXY (impl_access)),
+                                                      request->id,
+                                                      NULL, &error);
+      if (!impl_request)
+        return FALSE;
+
+      request_set_impl_request (request, impl_request);
+
+      g_debug ("Calling backend for emulated input permission for: %s", app_id);
+
+      if (!xdp_impl_access_call_access_dialog_sync (impl_access,
+                                                    request->id,
+                                                    app_id,
+                                                    "",
+                                                    title,
+                                                    subtitle,
+                                                    body,
+                                                    g_variant_builder_end (&opt_builder),
+                                                    &response,
+                                                    &results,
+                                                    NULL,
+                                                    &error))
+        {
+          g_warning ("A backend call failed: %s", error ? error->message : "internal dbus error");
+        }
+
+      allowed = response == 0;
+
+      if (permission == PERMISSION_UNSET)
+        set_permission_sync (app_id, PERMISSION_TABLE, app_id, allowed ? PERMISSION_YES : PERMISSION_NO);
+    }
+  else
+    allowed = permission == PERMISSION_YES ? TRUE : FALSE;
+
+  g_debug ("Allowed? %d", allowed);
+  return allowed;
+}
+
+static void
+handle_create_session_in_thread_func (GTask *task,
+                                      gpointer source_object,
+                                      gpointer task_data,
+                                      GCancellable *cancellable)
+{
+  Request *request = (Request *)task_data;
+  Session *session = NULL;
+  GVariantBuilder results;
+  GVariantBuilder options;
+  const char *app_id;
+  const char *session_token;
+  gboolean allowed;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(XdpImplRequest) impl_request = NULL;
+  guint32 response = XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS;
+
+  app_id = (const char *)g_object_get_data (G_OBJECT (request), "app-id");
+  session_token = (const char *)g_object_get_data (G_OBJECT (request), "token");
+
+  allowed = emulated_input_query_permission_sync (app_id, request);
+
+  REQUEST_AUTOLOCK (request);
+
+  g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
+
+  if (!allowed) {
+      response = XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED;
+      goto out;
+  }
+
+  impl_request =
+    xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                     G_DBUS_PROXY_FLAGS_NONE,
+                                     g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                     request->id,
+                                     NULL, &error);
+  if (!impl_request)
+    {
+      response = XDG_DESKTOP_PORTAL_RESPONSE_OTHER;
+      goto out;
+    }
+
+  request_set_impl_request (request, impl_request);
+
+  session = (Session *)emulated_input_session_new (session_token, request, &error);
+  if (!session)
+    {
+      response = XDG_DESKTOP_PORTAL_RESPONSE_OTHER;
+      goto out;
+    }
+
+  g_variant_builder_add (&results, "{sv}", "session_handle", g_variant_new ("s", session->id));
+
+  g_object_set_qdata_full (G_OBJECT (request),
+                           quark_request_session,
+                           g_object_ref (session),
+                           g_object_unref);
+
+  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
+  xdp_impl_emulated_input_call_create_session (impl,
+                                               request->id,
+                                               session->id,
+                                               xdp_app_info_get_id (request->app_info),
+                                               g_variant_builder_end (&options),
+                                               NULL,
+                                               create_session_done,
+                                               g_object_ref (request));
+
+  /* On success, the response is sent by create_session_done */
+  return;
+
+out:
+  if (request->exported)
+    {
+      g_debug ("Emulated Input: sending response %d", response);
+      xdp_request_emit_response (XDP_REQUEST (request),
+                                 response,
+                                 g_variant_builder_end (&results));
+      request_unexport (request);
+    }
+}
+
+static gboolean
+handle_create_session (XdpEmulatedInput *object,
+                       GDBusMethodInvocation *invocation,
+                       GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GTask) task = NULL;
+  const char *app_id;
+  const char *session_token;
+
+  REQUEST_AUTOLOCK (request);
+
+  /* First, check for lockdown and return immediately */
+  if (xdp_impl_lockdown_get_disable_emulated_input (lockdown))
+    {
+      g_debug ("Emulated Input access disabled");
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             "Emulated Input access disabled");
+      return TRUE;
+    }
+
+  /* Store the appid in the request */
+  app_id = xdp_app_info_get_id (request->app_info);
+  g_object_set_data_full (G_OBJECT (request), "app-id", g_strdup (app_id), g_free);
+  session_token = lookup_session_token (arg_options);
+  g_object_set_data_full (G_OBJECT (request), "token", g_strdup (session_token), g_free);
+
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  xdp_emulated_input_complete_create_session (object, invocation, request->id);
+
+  task = g_task_new (object, NULL, NULL, NULL);
+  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
+  g_task_run_in_thread (task, handle_create_session_in_thread_func);
+
+  return TRUE;
+}
+
+static gboolean
+handle_connect_to_eis (XdpEmulatedInput *object,
+                       GDBusMethodInvocation *invocation,
+                       GUnixFDList *in_fd_list,
+                       const char *arg_session_handle,
+                       GVariant *arg_options)
+{
+  Call *call = call_from_invocation (invocation);
+  Session *session;
+  EmulatedInputSession *emulated_input_session;
+  g_autoptr(GError) error = NULL;
+  GVariantBuilder unused;
+  GVariantBuilder results_builder;
+  GVariant *results = NULL;
+  g_autoptr(GUnixFDList) out_fd_list = NULL;
+  guint response = 1;
+
+  session = acquire_session_from_call (arg_session_handle, call);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  SESSION_AUTOLOCK_UNREF (session);
+
+  if (!is_emulated_input_session (session))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  emulated_input_session = (EmulatedInputSession *)session;
+  switch (emulated_input_session->state)
+    {
+    case EMULATED_INPUT_SESSION_STATE_STARTED:
+      break;
+    case EMULATED_INPUT_SESSION_STATE_INIT:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Session not started");
+      return TRUE;
+    case EMULATED_INPUT_SESSION_STATE_STARTING:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Can only start once");
+      return TRUE;
+    case EMULATED_INPUT_SESSION_STATE_CLOSED:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Invalid session");
+      return TRUE;
+    }
+
+  /* We don't have any options yet on the impl */
+  g_variant_builder_init (&unused, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+
+  if (!xdp_impl_emulated_input_call_connect_to_eis_sync (impl,
+                                                         arg_session_handle,
+                                                         xdp_app_info_get_id (call->app_info),
+                                                         g_variant_builder_end (&unused),
+                                                         in_fd_list,
+                                                         &response,
+                                                         &results,
+                                                         &out_fd_list,
+                                                         NULL,
+                                                         &error))
+    {
+      g_warning ("Failed to ConnectToEIS on impl: %s", error->message);
+      out_fd_list = g_unix_fd_list_new();
+    }
+
+  if (response == 0)
+    {
+      gint out_fd;
+      if (g_variant_lookup (results, "fd", "h", &out_fd))
+        {
+          g_variant_builder_add (&results_builder, "{sv}",
+                                 "fd", g_variant_new("h", out_fd));
+         response = 0;
+        }
+      else
+        {
+          g_error ("Key 'fd' missing in results");
+        }
+    }
+
+  xdp_emulated_input_complete_connect_to_eis (object,
+                                              invocation,
+                                              out_fd_list,
+                                              response,
+                                              g_variant_builder_end(&results_builder));
+  return TRUE;
+}
+
+static void
+emulated_input_iface_init (XdpEmulatedInputIface *iface)
+{
+  iface->handle_create_session = handle_create_session;
+  iface->handle_connect_to_eis = handle_connect_to_eis;
+}
+
+static void
+emulated_input_finalize (GObject *object)
+{
+  G_OBJECT_CLASS (emulated_input_parent_class)->finalize (object);
+}
+
+static void
+emulated_input_init (EmulatedInput *emulated_input)
+{
+  xdp_emulated_input_set_version (XDP_EMULATED_INPUT (emulated_input), 1);
+}
+
+static void
+emulated_input_class_init (EmulatedInputClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = emulated_input_finalize;
+
+  quark_request_session =
+    g_quark_from_static_string ("-xdp-request-emulated-input-session");
+}
+
+GDBusInterfaceSkeleton *
+emulated_input_create (GDBusConnection *connection,
+                       const char *dbus_name,
+                       gpointer lockdown_proxy)
+{
+  g_autoptr(GError) error = NULL;
+
+  lockdown = lockdown_proxy;
+
+  impl_access = xdp_impl_access_proxy_new_sync (connection,
+                                                G_DBUS_PROXY_FLAGS_NONE,
+                                                dbus_name,
+                                                DESKTOP_PORTAL_OBJECT_PATH,
+                                                NULL,
+                                                &error);
+
+  if (impl_access == NULL)
+  {
+      g_warning ("Failed to create access proxy: %s", error->message);
+      return NULL;
+  }
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl_access), G_MAXINT);
+
+  impl = xdp_impl_emulated_input_proxy_new_sync (connection,
+                                                 G_DBUS_PROXY_FLAGS_NONE,
+                                                 dbus_name,
+                                                 DESKTOP_PORTAL_OBJECT_PATH,
+                                                 NULL,
+                                                 &error);
+  if (impl == NULL)
+    {
+      g_warning ("Failed to create emulated input proxy: %s", error->message);
+      return NULL;
+    }
+
+  impl_version = xdp_impl_emulated_input_get_version (impl);
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl), G_MAXINT);
+
+  emulated_input = g_object_new (emulated_input_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (emulated_input);
+}
+
+static void
+emulated_input_session_close (Session *session)
+{
+  EmulatedInputSession *emulated_input_session = (EmulatedInputSession *)session;
+
+  emulated_input_session->state = EMULATED_INPUT_SESSION_STATE_CLOSED;
+
+  g_debug ("emulated input session owned by '%s' closed", session->sender);
+}
+
+static void
+emulated_input_session_finalize (GObject *object)
+{
+  G_OBJECT_CLASS (emulated_input_session_parent_class)->finalize (object);
+}
+
+static void
+emulated_input_session_init (EmulatedInputSession *emulated_input_session)
+{
+}
+
+static void
+emulated_input_session_class_init (EmulatedInputSessionClass *klass)
+{
+  GObjectClass *object_class;
+  SessionClass *session_class;
+
+  object_class = G_OBJECT_CLASS (klass);
+  object_class->finalize = emulated_input_session_finalize;
+
+  session_class = (SessionClass *)klass;
+  session_class->close = emulated_input_session_close;
+}

--- a/src/emulated-input.c
+++ b/src/emulated-input.c
@@ -31,10 +31,6 @@
 #include "xdp-impl-dbus.h"
 #include "xdp-utils.h"
 
-/* The permission table is "emulated-input" : $appid */
-#define PERMISSION_TABLE "emulated-input"
-
-static XdpImplAccess *impl_access;
 static XdpImplLockdown *lockdown;
 static XdpImplEmulatedInput *impl;
 static int impl_version;
@@ -193,182 +189,18 @@ out:
 }
 
 static gboolean
-emulated_input_query_permission_sync (const char *app_id,
-                                      Request    *request)
-{
-  Permission permission = PERMISSION_UNSET;
-  gboolean allowed;
-
-  /* If we don't have an app-id we can't check for anything */
-  if (app_id == NULL || app_id[0] == '\0')
-      return TRUE;
-
-  if (permission == PERMISSION_ASK || permission == PERMISSION_UNSET)
-    {
-      GVariantBuilder opt_builder;
-      g_autofree char *title = NULL;
-      g_autofree char *subtitle = NULL;
-      g_autofree char *body = NULL;
-      guint32 response = 2;
-      g_autoptr(GVariant) results = NULL;
-      g_autoptr(GError) error = NULL;
-      g_autoptr(GAppInfo) info = NULL;
-      g_autoptr(XdpImplRequest) impl_request = NULL;
-
-      if (app_id[0] != 0)
-        {
-          g_autofree char *desktop_id;
-          desktop_id = g_strconcat (app_id, ".desktop", NULL);
-          info = (GAppInfo*)g_desktop_app_info_new (desktop_id);
-        }
-
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
-      g_variant_builder_add (&opt_builder, "{sv}", "icon", g_variant_new_string ("input-mouse-symbolic"));
-
-      title = g_strdup (_("Allow Emulated Input?"));
-      body = g_strdup (_("Permissions to allow emulated input can be changed "
-                         "at any time from the privacy settings."));
-
-      if (info == NULL)
-          subtitle = g_strdup (_("An application wants to emulate input."));
-      else
-          subtitle = g_strdup_printf (_("%s wants to emulate input."), g_app_info_get_display_name (info));
-
-      impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl_access)),
-                                                      G_DBUS_PROXY_FLAGS_NONE,
-                                                      g_dbus_proxy_get_name (G_DBUS_PROXY (impl_access)),
-                                                      request->id,
-                                                      NULL, &error);
-      if (!impl_request)
-        return FALSE;
-
-      request_set_impl_request (request, impl_request);
-
-      g_debug ("Calling backend for emulated input permission for: %s", app_id);
-
-      if (!xdp_impl_access_call_access_dialog_sync (impl_access,
-                                                    request->id,
-                                                    app_id,
-                                                    "",
-                                                    title,
-                                                    subtitle,
-                                                    body,
-                                                    g_variant_builder_end (&opt_builder),
-                                                    &response,
-                                                    &results,
-                                                    NULL,
-                                                    &error))
-        {
-          g_warning ("A backend call failed: %s", error ? error->message : "internal dbus error");
-        }
-
-      allowed = response == 0;
-
-      if (permission == PERMISSION_UNSET)
-        set_permission_sync (app_id, PERMISSION_TABLE, app_id, allowed ? PERMISSION_YES : PERMISSION_NO);
-    }
-  else
-    allowed = permission == PERMISSION_YES ? TRUE : FALSE;
-
-  g_debug ("Allowed? %d", allowed);
-  return allowed;
-}
-
-static void
-handle_create_session_in_thread_func (GTask *task,
-                                      gpointer source_object,
-                                      gpointer task_data,
-                                      GCancellable *cancellable)
-{
-  Request *request = (Request *)task_data;
-  Session *session = NULL;
-  GVariantBuilder results;
-  GVariantBuilder options;
-  const char *app_id;
-  const char *session_token;
-  gboolean allowed;
-  g_autoptr(GError) error = NULL;
-  g_autoptr(XdpImplRequest) impl_request = NULL;
-  guint32 response = XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS;
-
-  app_id = (const char *)g_object_get_data (G_OBJECT (request), "app-id");
-  session_token = (const char *)g_object_get_data (G_OBJECT (request), "token");
-
-  allowed = emulated_input_query_permission_sync (app_id, request);
-
-  REQUEST_AUTOLOCK (request);
-
-  g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
-
-  if (!allowed) {
-      response = XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED;
-      goto out;
-  }
-
-  impl_request =
-    xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                     G_DBUS_PROXY_FLAGS_NONE,
-                                     g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
-                                     request->id,
-                                     NULL, &error);
-  if (!impl_request)
-    {
-      response = XDG_DESKTOP_PORTAL_RESPONSE_OTHER;
-      goto out;
-    }
-
-  request_set_impl_request (request, impl_request);
-
-  session = (Session *)emulated_input_session_new (session_token, request, &error);
-  if (!session)
-    {
-      response = XDG_DESKTOP_PORTAL_RESPONSE_OTHER;
-      goto out;
-    }
-
-  g_variant_builder_add (&results, "{sv}", "session_handle", g_variant_new ("s", session->id));
-
-  g_object_set_qdata_full (G_OBJECT (request),
-                           quark_request_session,
-                           g_object_ref (session),
-                           g_object_unref);
-
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
-  xdp_impl_emulated_input_call_create_session (impl,
-                                               request->id,
-                                               session->id,
-                                               xdp_app_info_get_id (request->app_info),
-                                               g_variant_builder_end (&options),
-                                               NULL,
-                                               create_session_done,
-                                               g_object_ref (request));
-
-  /* On success, the response is sent by create_session_done */
-  return;
-
-out:
-  if (request->exported)
-    {
-      g_debug ("Emulated Input: sending response %d", response);
-      xdp_request_emit_response (XDP_REQUEST (request),
-                                 response,
-                                 g_variant_builder_end (&results));
-      request_unexport (request);
-    }
-}
-
-static gboolean
 handle_create_session (XdpEmulatedInput *object,
                        GDBusMethodInvocation *invocation,
                        GVariant *arg_options)
 {
   Request *request = request_from_invocation (invocation);
+  g_autoptr(XdpImplRequest) impl_request = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GTask) task = NULL;
-  const char *app_id;
+  Session *session;
+  GVariantBuilder options_builder;
+  GVariant *options;
   const char *session_token;
-
-  REQUEST_AUTOLOCK (request);
 
   /* First, check for lockdown and return immediately */
   if (xdp_impl_lockdown_get_disable_emulated_input (lockdown))
@@ -381,19 +213,50 @@ handle_create_session (XdpEmulatedInput *object,
       return TRUE;
     }
 
-  /* Store the appid in the request */
-  app_id = xdp_app_info_get_id (request->app_info);
-  g_object_set_data_full (G_OBJECT (request), "app-id", g_strdup (app_id), g_free);
-  session_token = lookup_session_token (arg_options);
-  g_object_set_data_full (G_OBJECT (request), "token", g_strdup (session_token), g_free);
 
+  REQUEST_AUTOLOCK (request);
+
+  impl_request =
+    xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                     G_DBUS_PROXY_FLAGS_NONE,
+                                     g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                     request->id,
+                                     NULL, &error);
+  if (!impl_request)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  xdp_emulated_input_complete_create_session (object, invocation, request->id);
+  session_token = lookup_session_token (arg_options);
+  session = (Session *)emulated_input_session_new (session_token, request, &error);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
 
-  task = g_task_new (object, NULL, NULL, NULL);
-  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
-  g_task_run_in_thread (task, handle_create_session_in_thread_func);
+  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  options = g_variant_builder_end (&options_builder);
+
+  g_object_set_qdata_full (G_OBJECT (request),
+                           quark_request_session,
+                           g_object_ref (session),
+                           g_object_unref);
+
+  xdp_impl_emulated_input_call_create_session (impl,
+                                               request->id,
+                                               session->id,
+                                               xdp_app_info_get_id (request->app_info),
+                                               options,
+                                               NULL,
+                                               create_session_done,
+                                               g_object_ref (request));
+
+  xdp_emulated_input_complete_create_session (object, invocation, request->id);
 
   return TRUE;
 }
@@ -541,21 +404,6 @@ emulated_input_create (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
 
   lockdown = lockdown_proxy;
-
-  impl_access = xdp_impl_access_proxy_new_sync (connection,
-                                                G_DBUS_PROXY_FLAGS_NONE,
-                                                dbus_name,
-                                                DESKTOP_PORTAL_OBJECT_PATH,
-                                                NULL,
-                                                &error);
-
-  if (impl_access == NULL)
-  {
-      g_warning ("Failed to create access proxy: %s", error->message);
-      return NULL;
-  }
-
-  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl_access), G_MAXINT);
 
   impl = xdp_impl_emulated_input_proxy_new_sync (connection,
                                                  G_DBUS_PROXY_FLAGS_NONE,

--- a/src/emulated-input.h
+++ b/src/emulated-input.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2020 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * emulated_input_create (GDBusConnection *connection,
+                                                const char *dbus_name,
+                                                gpointer         lockdown_proxy);

--- a/src/request.c
+++ b/src/request.c
@@ -189,6 +189,22 @@ get_token (GDBusMethodInvocation *invocation)
     {
       options = g_variant_get_child_value (parameters, 1);
     }
+  else if (strcmp (interface, "org.freedesktop.portal.EmulatedInput") == 0)
+    {
+      if (strcmp (method, "CreateSession") == 0 )
+        {
+          options = g_variant_get_child_value (parameters, 0);
+        }
+      else if (strcmp (method, "ConnectToEIS") == 0)
+        {
+          options = g_variant_get_child_value (parameters, 1);
+        }
+      else
+        {
+          g_warning ("Support for %s::%s missing in %s",
+                     interface, method, G_STRLOC);
+        }
+    }
   else if (strcmp (interface, "org.freedesktop.portal.FileChooser") == 0)
     {
       options = g_variant_get_child_value (parameters, 2);
@@ -321,6 +337,22 @@ get_token (GDBusMethodInvocation *invocation)
           options = g_variant_get_child_value (parameters, 0);
         }
       else if (strcmp (method, "OpenPipewireRemote") == 0)
+        {
+          // no request objects
+        }
+      else
+        {
+          g_warning ("Support for %s::%s missing in %s",
+                     interface, method, G_STRLOC);
+        }
+    }
+  else if (strcmp (interface, "org.freedesktop.portal.EmulatedInput") == 0)
+    {
+      if (strcmp (method, "EmulateInput") == 0 )
+        {
+          options = g_variant_get_child_value (parameters, 0);
+        }
+      else if (strcmp (method, "Connect") == 0)
         {
           // no request objects
         }

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -304,7 +304,7 @@ on_bus_acquired (GDBusConnection *connection,
 
     }
   implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.EmulatedInput");
-  if (implementation != NULL && implementation2 != NULL) {
+  if (implementation2 != NULL) {
       export_portal_implementation (connection, emulated_input_create (connection,
                                                                        implementation2->dbus_name,
                                                                        lockdown));

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -48,6 +48,7 @@
 #include "device.h"
 #include "account.h"
 #include "email.h"
+#include "emulated-input.h"
 #include "screen-cast.h"
 #include "remote-desktop.h"
 #include "trash.h"
@@ -126,6 +127,20 @@ method_needs_request (GDBusMethodInvocation *invocation)
   if (strcmp (interface, "org.freedesktop.portal.Camera") == 0)
     {
       if (strcmp (method, "OpenPipeWireRemote") == 0)
+        return FALSE;
+      else
+        return TRUE;
+    }
+  if (strcmp (interface, "org.freedesktop.portal.EmulatedInput") == 0)
+    {
+      if (strcmp (method, "ConnectToEIS") == 0)
+        return FALSE;
+      else
+        return TRUE;
+    }
+  if (strcmp (interface, "org.freedesktop.impl.portal.EmulatedInput") == 0)
+    {
+      if (strcmp (method, "ConnectToEIS") == 0)
         return FALSE;
       else
         return TRUE;
@@ -274,7 +289,6 @@ on_bus_acquired (GDBusConnection *connection,
                                   inhibit_create (connection, implementation->dbus_name));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Access");
-  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Background");
   if (implementation != NULL)
     {
       export_portal_implementation (connection,
@@ -287,8 +301,16 @@ on_bus_acquired (GDBusConnection *connection,
 #ifdef HAVE_PIPEWIRE
       export_portal_implementation (connection, camera_create (connection, lockdown));
 #endif
-    }
 
+    }
+  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.EmulatedInput");
+  if (implementation != NULL && implementation2 != NULL) {
+      export_portal_implementation (connection, emulated_input_create (connection,
+                                                                       implementation2->dbus_name,
+                                                                       lockdown));
+  }
+
+  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Background");
   if (implementation != NULL && implementation2 != NULL)
     export_portal_implementation (connection,
                                   background_create (connection,

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -50,6 +50,8 @@ test_portals_SOURCES += \
         tests/camera.h \
 	tests/email.c \
 	tests/email.h \
+	tests/emulated-input.c \
+	tests/emulated-input.h \
 	tests/filechooser.c \
 	tests/filechooser.h \
         tests/inhibit.c \

--- a/tests/backend/Makefile.am.inc
+++ b/tests/backend/Makefile.am.inc
@@ -19,6 +19,8 @@ tests_test_backends_SOURCES = \
 	tests/backend/background.h \
 	tests/backend/email.c \
 	tests/backend/email.h \
+	tests/backend/emulated-input.c \
+	tests/backend/emulated-input.h \
 	tests/backend/filechooser.c \
 	tests/backend/filechooser.h \
 	tests/backend/inhibit.c \

--- a/tests/backend/emulated-input.c
+++ b/tests/backend/emulated-input.c
@@ -1,0 +1,179 @@
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <gio/gio.h>
+
+#include "src/xdp-impl-dbus.h"
+
+#include "request.h"
+#include "emulated-input.h"
+
+typedef struct {
+  XdpImplEmulatedInput *impl;
+  GDBusMethodInvocation *invocation;
+  Request *request;
+  GKeyFile *keyfile;
+  char *app_id;
+  guint timeout;
+} EmulatedInputHandle;
+
+static void
+emulated_input_handle_free (EmulatedInputHandle *handle)
+{
+  g_object_unref (handle->impl);
+  g_object_unref (handle->request);
+  g_key_file_unref (handle->keyfile);
+  g_free (handle->app_id);
+  if (handle->timeout)
+    g_source_remove (handle->timeout);
+
+  g_free (handle);
+}
+
+static gboolean
+send_response (gpointer data)
+{
+  EmulatedInputHandle *handle = data;
+  GVariantBuilder opt_builder;
+  int response;
+  g_autofree char *uri = NULL;
+
+  if (g_key_file_get_boolean (handle->keyfile, "backend", "expect-close", NULL))
+    g_assert_not_reached ();
+
+  response = g_key_file_get_integer (handle->keyfile, "backend", "response", NULL);
+
+  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+
+  if (response == 0)
+    {
+#if 0
+      if (handle->is_emulated_input)
+        {
+          uri = g_key_file_get_string (handle->keyfile, "result", "uri", NULL);
+          g_variant_builder_add (&opt_builder, "{sv}", "uri", g_variant_new_string (uri));
+        }
+      else
+        {
+          red = g_key_file_get_double (handle->keyfile,"result", "red", NULL);
+          green = g_key_file_get_double (handle->keyfile,"result", "green", NULL);
+          blue = g_key_file_get_double (handle->keyfile,"result", "blue", NULL);
+          g_variant_builder_add (&opt_builder, "{sv}", "color", g_variant_new ("(ddd)", red, green, blue));
+        }
+#endif
+    }
+
+  if (handle->request->exported)
+    request_unexport (handle->request);
+
+  g_debug ("send response %d", response);
+
+  xdp_impl_emulated_input_complete_create_session (handle->impl,
+                                                   handle->invocation,
+                                                   response,
+                                                   g_variant_builder_end (&opt_builder));
+
+  handle->timeout = 0;
+
+  emulated_input_handle_free (handle);
+
+  return G_SOURCE_REMOVE;
+}
+
+static gboolean
+handle_close (XdpImplRequest *object,
+              GDBusMethodInvocation *invocation,
+              EmulatedInputHandle *handle)
+{
+  GVariantBuilder opt_builder;
+
+  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+  g_debug ("handling Close");
+  xdp_impl_emulated_input_complete_create_session (handle->impl,
+                                                   handle->invocation,
+                                                   2,
+                                                   g_variant_builder_end (&opt_builder));
+
+  emulated_input_handle_free (handle);
+
+  return FALSE;
+}
+
+
+static gboolean
+handle_create_session (XdpImplEmulatedInput *object,
+                       GDBusMethodInvocation *invocation,
+                       const char *arg_handle,
+                       const char *arg_app_id,
+                       GVariant *arg_options)
+{
+  const char *sender;
+  const char *dir;
+  g_autofree char *path = NULL;
+  g_autoptr(GKeyFile) keyfile = NULL;
+  g_autoptr(GError) error = NULL;
+  int delay;
+  EmulatedInputHandle *handle;
+  g_autoptr(Request) request = NULL;
+
+  g_debug ("Handling %s", g_dbus_method_invocation_get_method_name (invocation));
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+
+  dir = g_getenv ("XDG_DATA_HOME");
+  path = g_build_filename (dir, "emulated-input", NULL);
+  keyfile = g_key_file_new ();
+  g_key_file_load_from_file (keyfile, path, 0, &error);
+  g_assert_no_error (error);
+
+  request = request_new (sender, arg_app_id, arg_handle);
+
+  handle = g_new0 (EmulatedInputHandle, 1);
+  handle->impl = g_object_ref (object);
+  handle->invocation = invocation;
+  handle->request = g_object_ref (request);
+  handle->keyfile = g_key_file_ref (keyfile);
+  handle->app_id = g_strdup (arg_app_id);
+
+  g_signal_connect (request, "handle-close", G_CALLBACK (handle_close), handle);
+
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  if (g_key_file_has_key (keyfile, "backend", "delay", NULL))
+    delay = g_key_file_get_integer (keyfile, "backend", "delay", NULL);
+  else
+    delay = 200;
+
+  g_debug ("delay %d", delay);
+
+  if (delay == 0)
+    send_response (handle);
+  else
+    handle->timeout = g_timeout_add (delay, send_response, handle);
+
+  return TRUE;
+}
+
+void
+emulated_input_init (GDBusConnection *connection,
+                     const char *object_path)
+{
+  g_autoptr(GError) error = NULL;
+  GDBusInterfaceSkeleton *helper;
+
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_emulated_input_skeleton_new ());
+
+  g_signal_connect (helper, "handle-create-session", G_CALLBACK (handle_create_session), NULL);
+
+  if (!g_dbus_interface_skeleton_export (helper, connection, object_path, &error))
+    {
+      g_error ("Failed to export %s skeleton: %s\n",
+               g_dbus_interface_skeleton_get_info (helper)->name,
+               error->message);
+      exit (1);
+    }
+
+  g_debug ("providing %s at %s", g_dbus_interface_skeleton_get_info (helper)->name, object_path);
+}

--- a/tests/backend/emulated-input.h
+++ b/tests/backend/emulated-input.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void emulated_input_init (GDBusConnection *connection, const char *object_path);

--- a/tests/backend/test-backends.c
+++ b/tests/backend/test-backends.c
@@ -10,6 +10,7 @@
 #include "appchooser.h"
 #include "background.h"
 #include "email.h"
+#include "emulated-input.h"
 #include "filechooser.h"
 #include "inhibit.h"
 #include "lockdown.h"
@@ -34,6 +35,7 @@ on_bus_acquired (GDBusConnection *connection,
   appchooser_init (connection, BACKEND_OBJECT_PATH);
   background_init (connection, BACKEND_OBJECT_PATH);
   email_init (connection, BACKEND_OBJECT_PATH);
+  emulated_input_init (connection, BACKEND_OBJECT_PATH);
   file_chooser_init (connection, BACKEND_OBJECT_PATH);
   inhibit_init (connection, BACKEND_OBJECT_PATH);
   lockdown_init (connection, BACKEND_OBJECT_PATH);

--- a/tests/emulated-input.c
+++ b/tests/emulated-input.c
@@ -1,0 +1,85 @@
+#include <config.h>
+
+#include "emulated-input.h"
+
+#include <libportal/portal.h>
+#include "src/xdp-utils.h"
+#include "src/xdp-impl-dbus.h"
+
+#include "utils.h"
+
+extern XdpImplPermissionStore *permission_store;
+extern XdpImplLockdown *lockdown;
+
+static int got_info;
+
+extern char outdir[];
+
+static void
+emulated_input_cb (GObject      *obj,
+                   GAsyncResult *result,
+                   gpointer      data)
+{
+  XdpPortal *portal = XDP_PORTAL (obj);
+  g_autoptr(GError) error = NULL;
+  GKeyFile *keyfile = data;
+  int response;
+  int domain;
+  int code;
+  gboolean ret;
+
+  response = g_key_file_get_integer (keyfile, "result", "response", NULL);
+  domain = g_key_file_get_integer (keyfile, "result", "error_domain", NULL);
+  code = g_key_file_get_integer (keyfile, "result", "error_code", NULL);
+
+  ret = xdp_portal_emulated_input_finish (portal, result, &error);
+
+  g_debug ("emulated_input cb: %d", g_key_file_get_integer (keyfile, "result", "marker", NULL));
+  if (response == 0)
+    {
+      g_assert_true (ret);
+      g_assert_no_error (error);
+    }
+  else if (response == 1)
+    {
+      g_assert_false (ret);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_CANCELLED);
+    }
+  else if (response == 2)
+    {
+      g_assert_false (ret);
+      g_assert_error (error, domain, code);
+    }
+  else
+    g_assert_not_reached ();
+
+  got_info++;
+
+  g_main_context_wakeup (NULL);
+}
+
+void
+test_emulated_input_basic (void)
+{
+  g_autoptr(XdpPortal) portal = NULL;
+  g_autoptr(GKeyFile) keyfile = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autofree char *path = NULL;
+
+  keyfile = g_key_file_new ();
+  g_key_file_set_integer (keyfile, "backend", "delay", 0);
+  g_key_file_set_integer (keyfile, "backend", "response", 0);
+  g_key_file_set_integer (keyfile, "result", "response", 0);
+
+  path = g_build_filename (outdir, "emulated-input", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+
+  portal = xdp_portal_new ();
+
+  got_info = 0;
+  xdp_portal_emulated_input (portal, 0, NULL, emulated_input_cb, keyfile);
+
+  while (!got_info)
+    g_main_context_iteration (NULL, TRUE);
+}

--- a/tests/emulated-input.h
+++ b/tests/emulated-input.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void test_emulated_input_basic (void);

--- a/tests/portals/test.portal
+++ b/tests/portals/test.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.Test
-Interfaces=org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Settings;
+Interfaces=org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.EmulatedInput;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Settings;
 UseIn=test

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -13,6 +13,7 @@
 #include "background.h"
 #include "camera.h"
 #include "email.h"
+#include "emulated-input.h"
 #include "filechooser.h"
 #include "inhibit.h"
 #include "location.h"
@@ -423,6 +424,7 @@ DEFINE_TEST_EXISTS(account, ACCOUNT, 1)
 DEFINE_TEST_EXISTS(background, BACKGROUND, 1)
 DEFINE_TEST_EXISTS(camera, CAMERA, 1)
 DEFINE_TEST_EXISTS(email, EMAIL, 3)
+DEFINE_TEST_EXISTS(emulated_input, EMULATED_INPUT, 1)
 DEFINE_TEST_EXISTS(file_chooser, FILE_CHOOSER, 3)
 DEFINE_TEST_EXISTS(game_mode, GAME_MODE, 3)
 DEFINE_TEST_EXISTS(inhibit, INHIBIT, 3)
@@ -451,6 +453,7 @@ main (int argc, char **argv)
   g_test_add_func ("/portal/background/exists", test_background_exists);
   g_test_add_func ("/portal/camera/exists", test_camera_exists);
   g_test_add_func ("/portal/email/exists", test_email_exists);
+  g_test_add_func ("/portal/emulated_input/exists", test_emulated_input_exists);
   g_test_add_func ("/portal/filechooser/exists", test_file_chooser_exists);
   g_test_add_func ("/portal/gamemode/exists", test_game_mode_exists);
   g_test_add_func ("/portal/inhibit/exists", test_inhibit_exists);
@@ -481,6 +484,8 @@ main (int argc, char **argv)
   g_test_add_func ("/portal/email/address", test_email_address);
   g_test_add_func ("/portal/email/subject", test_email_subject);
   g_test_add_func ("/portal/email/parallel", test_email_parallel);
+
+  g_test_add_func ("/portal/emulated_input/basic", test_emulated_input_basic);
 
   g_test_add_func ("/portal/screenshot/basic", test_screenshot_basic);
   g_test_add_func ("/portal/screenshot/delay", test_screenshot_delay);


### PR DESCRIPTION
*Note: filing this as Draft to get some early review please. I can't really say I fully know what I'm doing here, it was a lot of copy/paste and fixing, so I may have missed something obvious.*

This PR adds a new portal: `org.freedesktop.portal.EmulatedInput` together with its `impl` equivalent.
Two calls:
- `CreateSession` to determine if a client may emulate input
- `ConnectToEIS` which connects to an [EIS implementation](https://gitlab.freedesktop.org/libinput/libei/) and passes the socket back to the application. After that is done, the application talks directly to the EIS implementation, similar to pipewire.

Note that this is just a gateway portal, there is no actual events being sent through the portal, this is all handled through libeis/libei.

We need an `impl.portal` here because there may be multiple EIS implementations running, so we rely on the implementation to know which one we actually need to connect to. I'm planning to add this to mutter.