### PR TITLE
pipewire: Ensure roundtrips have a timeout

### DIFF
--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -47,6 +47,8 @@ struct _PipeWireRemote
   struct pw_core *core;
   struct spa_hook core_listener;
 
+  struct spa_source *roundtrip_timeout;
+
   int sync_seq;
 
   struct spa_hook registry_listener;


### PR DESCRIPTION
This ensures the portal itself can still start successfully (albeit with
reduced abilities) if PipeWire itself is non-functional.

Note that this is not just hypothetical, as I have seen various reports
of this over time.