### PR TITLE
Move xdg-permission-store to Background slice

### DIFF
--- a/document-portal/xdg-document-portal.service.in
+++ b/document-portal/xdg-document-portal.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=flatpak document portal service
+PartOf=graphical-session.target
 
 [Service]
 BusName=org.freedesktop.portal.Documents

--- a/document-portal/xdg-permission-store.service.in
+++ b/document-portal/xdg-permission-store.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=sandboxed app permission store
+PartOf=graphical-session.target
 
 [Service]
 BusName=org.freedesktop.impl.portal.PermissionStore

--- a/document-portal/xdg-permission-store.service.in
+++ b/document-portal/xdg-permission-store.service.in
@@ -5,3 +5,4 @@ Description=sandboxed app permission store
 BusName=org.freedesktop.impl.portal.PermissionStore
 ExecStart=@libexecdir@/xdg-permission-store
 Type=dbus
+Slice=session.slice


### PR DESCRIPTION
Follow-up to https://github.com/flatpak/xdg-desktop-portal/pull/614

I think `xdg-permission-store` fits the description from `man:system.special(7)`
>background.slice
> All services running low-priority background tasks should use this slice. This permits resources to be preferentially assigned to the other slices. Examples include non-interactive tasks like file indexing or backup operations where latency is not important.
