### PR TITLE
build: Fix cross-compilation by adjusting pkg-config use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,10 +50,7 @@ AC_SUBST(DBUS_SERVICE_DIR)
 AC_ARG_WITH(flatpak_interfaces_dir,
         AS_HELP_STRING([--with-flatpak-interfaces-dir=PATH],[choose directory for Flatpak interface files, [default=PREFIX/share/dbus-1/interfaces]]),
         [[FLATPAK_INTERFACES_DIR="$withval"]],
-	[PKG_CHECK_VAR([FLATPAK_INTERFACES_DIR], [flatpak], [interfaces_dir])])
-if ! pkg-config --atleast-version "1.5.0" flatpak; then
-        FLATPAK_INTERFACES_DIR=""
-fi
+	[PKG_CHECK_VAR([FLATPAK_INTERFACES_DIR], [flatpak >= 1.5.0], [interfaces_dir])])
 AC_SUBST(FLATPAK_INTERFACES_DIR)
 
 AC_ARG_WITH([systemduserunitdir],


### PR DESCRIPTION
Patch from Helmut Grohne, forwarded from a Debian bug report:

xdg-desktop-portal fails to cross build from source, because configure.ac
hard codes the build architecture pkg-config on one occasion, rather than
taking the host architecture pkg-config from $PKG_CONFIG. The relevant
occasion is unnecessary as the version check can be fused in an earlier
access of the relevant package with the right pkg-config.

[Commit message added by Simon McVittie, based on the text of the
Debian bug report.]

Resolves: https://bugs.debian.org/985411