### PR TITLE
device: Add OpenPipeWireRemote() method

### DIFF
--- a/data/org.freedesktop.portal.Device.xml
+++ b/data/org.freedesktop.portal.Device.xml
@@ -28,7 +28,7 @@
       Not a portal in the strict sense, since the API is not directly
       accessible to applications inside the sandbox.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
     -->
   <interface name="org.freedesktop.portal.Device">
     <!--
@@ -57,6 +57,39 @@
       <arg type="as" name="devices" direction="in"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+        OpenPipeWireRemote:
+        @options: Vardict with optional further information
+        @fd: File descriptor of an open PipeWire remote.
+
+        Open a file descriptor to the PipeWire remote where the microphone,
+        speakers, and camera nodes are available. The file descriptor should be
+        used to create a <classname>pw_core</classname> object, by using
+        <function>pw_context_connect_fd</function>.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>devices as</term>
+            <listitem><para>
+              The devices to access. Supported devices for this call are 'camera',
+              'microphone', and 'speakers'.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        This method will only succeed if the application already has permission
+        to access any one of the devices requested.
+
+        This option was added in version 2 of this interface.
+    -->
+    <method name="OpenPipeWireRemote">
+      <annotation name="org.gtk.GDBus.C.Name" value="open_pipewire_remote"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="h" name="fd" direction="out"/>
     </method>
     <property name="version" type="u" access="read"/>
   </interface>

--- a/data/org.freedesktop.portal.Device.xml
+++ b/data/org.freedesktop.portal.Device.xml
@@ -91,6 +91,33 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>
+
+    <!--
+        IsCameraPresent:
+
+        A boolean stating whether there is any camera available.
+
+        This property was added in version 2 of this interface.
+    -->
+    <property name="IsCameraPresent" type="b" access="read"/>
+
+    <!--
+        IsSpeakerPresent:
+
+        A boolean stating whether there is any speaker available.
+
+        This property was added in version 2 of this interface.
+    -->
+    <property name="IsSpeakerPresent" type="b" access="read"/>
+    <!--
+        IsMicrophonePresent:
+
+        A boolean stating whether there is any microphone available.
+
+        This property was added in version 2 of this interface.
+    -->
+    <property name="IsMicrophonePresent" type="b" access="read"/>
+
     <property name="version" type="u" access="read"/>
   </interface>
 </node>


### PR DESCRIPTION
It works very similarly to the same-named method of the Camera portal, except it receives a list of devices to access.

This new method returns an error if an unsupported device is requested, or if the app doesn't have permission to access any of the requested devices.