### PR TITLE
CI: Use a privileged docker container to support FUSE tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ jobs:
       CFLAGS: -fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -Wp,-D_FORTIFY_SOURCE=2
       BUILD_CONTAINER: ${{ matrix.compiler }}-build-container
       RUN_CMD: docker exec -t -w /src -e TEST_IN_CI -e ASAN_OPTIONS -e G_MESSAGES_DEBUG -e XDG_DATA_DIRS ${{ matrix.compiler }}-build-container
+      AS_USER: runuser -u tester --
 
     steps:
     - name: Prepare container
@@ -46,15 +47,20 @@ jobs:
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v2
 
+    - name: Setup test user
+      run: |
+        $RUN_CMD adduser --disabled-password --gecos "" tester
+        $RUN_CMD chown tester:tester . -R
+
     - name: Configure xdg-desktop-portal
-      run: $RUN_CMD ./autogen.sh --disable-dependency-tracking --enable-installed-tests
+      run: $RUN_CMD $AS_USER ./autogen.sh --disable-dependency-tracking --enable-installed-tests
 
     - name: Build xdg-desktop-portal
-      run: $RUN_CMD make -j $(getconf _NPROCESSORS_ONLN)
+      run: $RUN_CMD $AS_USER make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run xdg-desktop-portal tests
       # TODO: Build with -j (currently ends up with hangs in the tests)
-      run: $RUN_CMD timeout ${TESTS_TIMEOUT}m make check
+      run: $RUN_CMD $AS_USER timeout ${TESTS_TIMEOUT}m make check
       env:
         TEST_IN_CI: 1
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
@@ -64,8 +70,9 @@ jobs:
 
     - name: Run xdg-desktop-portal installed-tests
       run: |
-        test -n "$($RUN_CMD gnome-desktop-testing-runner -l xdg-desktop-portal)"
-        $RUN_CMD env TEST_INSTALLED_IN_CI=1 XDG_DATA_DIRS=/src/tests/share/:$XDG_DATA_DIRS \
+        test -n "$($RUN_CMD $AS_USER gnome-desktop-testing-runner -l xdg-desktop-portal)"
+        $RUN_CMD $AS_USER \
+          env TEST_INSTALLED_IN_CI=1 XDG_DATA_DIRS=/src/tests/share/:$XDG_DATA_DIRS \
           gnome-desktop-testing-runner --report-directory installed-test-logs/ \
             -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
       env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   DEBIAN_FRONTEND: noninteractive
+  TESTS_TIMEOUT: 5 # in minutes
 
 jobs:
   check:
@@ -38,7 +39,7 @@ jobs:
 
     - name: Run xdg-desktop-portal tests
       # TODO: Build with -j (currently ends up with hangs in the tests)
-      run: make check
+      run: timeout ${TESTS_TIMEOUT}m make check
       env:
         TEST_IN_CI: 1
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
@@ -49,7 +50,8 @@ jobs:
     - name: Run xdg-desktop-portal installed-tests
       run: |
         mkdir installed-test-logs/
-        gnome-desktop-testing-runner --report-directory installed-test-logs/ xdg-desktop-portal
+        gnome-desktop-testing-runner --report-directory installed-test-logs/ \
+          -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
       env:
         G_MESSAGES_DEBUG: all
         TEST_IN_CI: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,7 +64,7 @@ jobs:
         name: test logs
         path: |
           tests/*.log
-          test-suite.log
+          test-*.log
           installed-test-logs/
 
   xenial:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,8 @@ jobs:
       run: |
         apt-get update
         apt-get upgrade -y
-        apt-get install -y make automake autoconf libtool gettext autopoint ${{ matrix.compiler }} \
+        apt-get install -y -y --no-install-recommends \
+          make automake autoconf libtool gettext autopoint ${{ matrix.compiler }} \
           gtk-doc-tools shared-mime-info desktop-file-utils gnome-desktop-testing xmlto \
           libglib2.0-dev libgeoclue-2-dev libjson-glib-dev libfontconfig1-dev libfuse-dev libportal-dev libpipewire-0.3-dev
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,52 +8,66 @@ env:
 
 jobs:
   check:
-    name: Ubuntu 21.04 build
+    name: Ubuntu 21.10 build
     runs-on: ubuntu-latest
-    container: ubuntu:21.04
     strategy:
       matrix:
         compiler: ['gcc', 'clang']
 
     env:
+      UBUNTU_VERSION: impish
       CC: ${{ matrix.compiler }}
       CFLAGS: -fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -Wp,-D_FORTIFY_SOURCE=2
+      BUILD_CONTAINER: ${{ matrix.compiler }}-build-container
+      RUN_CMD: docker exec -t -w /src -e TEST_IN_CI -e ASAN_OPTIONS -e G_MESSAGES_DEBUG -e XDG_DATA_DIRS ${{ matrix.compiler }}-build-container
 
     steps:
+    - name: Prepare container
+      run: |
+        docker run --name $BUILD_CONTAINER \
+          --tty --device /dev/fuse --cap-add SYS_ADMIN \
+          --security-opt apparmor:unconfined \
+          -v $(pwd):/src \
+          -e DEBIAN_FRONTEND \
+          -e DEBCONF_NONINTERACTIVE_SEEN=true \
+          -e TERM=dumb \
+          -e CC -e CFLAGS \
+          -d ubuntu:$UBUNTU_VERSION sleep infinity
+
     - name: Install dependencies
       run: |
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y -y --no-install-recommends \
+        $RUN_CMD apt-get update
+        $RUN_CMD apt-get upgrade -y
+        $RUN_CMD apt-get install -y --no-install-recommends \
           make automake autoconf libtool gettext autopoint ${{ matrix.compiler }} \
-          gtk-doc-tools shared-mime-info desktop-file-utils gnome-desktop-testing xmlto \
+          gtk-doc-tools shared-mime-info desktop-file-utils gnome-desktop-testing xmlto fuse \
           libglib2.0-dev libgeoclue-2-dev libjson-glib-dev libfontconfig1-dev libfuse-dev libportal-dev libpipewire-0.3-dev
 
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v2
 
     - name: Configure xdg-desktop-portal
-      run: ./autogen.sh --disable-dependency-tracking --enable-installed-tests
+      run: $RUN_CMD ./autogen.sh --disable-dependency-tracking --enable-installed-tests
 
     - name: Build xdg-desktop-portal
-      run: make -j $(getconf _NPROCESSORS_ONLN)
+      run: $RUN_CMD make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run xdg-desktop-portal tests
       # TODO: Build with -j (currently ends up with hangs in the tests)
-      run: timeout ${TESTS_TIMEOUT}m make check
+      run: $RUN_CMD timeout ${TESTS_TIMEOUT}m make check
       env:
         TEST_IN_CI: 1
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
 
     - name: Install xdg-desktop-portal
-      run: make install
+      run: $RUN_CMD make install
 
     - name: Run xdg-desktop-portal installed-tests
       run: |
-        test -n "$(gnome-desktop-testing-runner -l xdg-desktop-portal)"
-        env XDG_DATA_DIRS=$PWD/tests/share/:$XDG_DATA_DIRS \
+        test -n "$($RUN_CMD gnome-desktop-testing-runner -l xdg-desktop-portal)"
+        $RUN_CMD env TEST_INSTALLED_IN_CI=1 XDG_DATA_DIRS=/src/tests/share/:$XDG_DATA_DIRS \
           gnome-desktop-testing-runner --report-directory installed-test-logs/ \
-          -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
+            -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
       env:
         G_MESSAGES_DEBUG: all
         TEST_IN_CI: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,6 +63,7 @@ jobs:
       run: $RUN_CMD $AS_USER timeout ${TESTS_TIMEOUT}m make check
       env:
         TEST_IN_CI: 1
+        G_MESSAGES_DEBUG: all
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
 
     - name: Install xdg-desktop-portal

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Configure xdg-desktop-portal
-      run: ./autogen.sh --disable-dependency-tracking
+      run: ./autogen.sh --disable-dependency-tracking --enable-installed-tests
 
     - name: Build xdg-desktop-portal
       run: make -j $(getconf _NPROCESSORS_ONLN)
@@ -49,12 +49,14 @@ jobs:
 
     - name: Run xdg-desktop-portal installed-tests
       run: |
-        mkdir installed-test-logs/
-        gnome-desktop-testing-runner --report-directory installed-test-logs/ \
+        test -n "$(gnome-desktop-testing-runner -l xdg-desktop-portal)"
+        env XDG_DATA_DIRS=$PWD/tests/share/:$XDG_DATA_DIRS \
+          gnome-desktop-testing-runner --report-directory installed-test-logs/ \
           -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
       env:
         G_MESSAGES_DEBUG: all
         TEST_IN_CI: 1
+        XDG_DATA_DIRS: /usr/local/share:/usr/share
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
 
     - name: Upload test logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,6 +32,7 @@ jobs:
           -e DEBIAN_FRONTEND \
           -e DEBCONF_NONINTERACTIVE_SEEN=true \
           -e TERM=dumb \
+          -e MAKEFLAGS="-j $(getconf _NPROCESSORS_ONLN)" \
           -e CC -e CFLAGS \
           -d ubuntu:$UBUNTU_VERSION sleep infinity
 
@@ -56,10 +57,9 @@ jobs:
       run: $RUN_CMD $AS_USER ./autogen.sh --disable-dependency-tracking --enable-installed-tests
 
     - name: Build xdg-desktop-portal
-      run: $RUN_CMD $AS_USER make -j $(getconf _NPROCESSORS_ONLN)
+      run: $RUN_CMD $AS_USER make
 
     - name: Run xdg-desktop-portal tests
-      # TODO: Build with -j (currently ends up with hangs in the tests)
       run: $RUN_CMD $AS_USER timeout ${TESTS_TIMEOUT}m make check
       env:
         TEST_IN_CI: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,16 +13,33 @@ jobs:
     strategy:
       matrix:
         compiler: ['gcc', 'clang']
+        sanitizer: ['address']
+        include:
+          - compiler: gcc
+            sanitizer: ['thread']
 
     env:
       UBUNTU_VERSION: impish
       CC: ${{ matrix.compiler }}
-      CFLAGS: -fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -Wp,-D_FORTIFY_SOURCE=2
+      BASE_CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
       BUILD_CONTAINER: ${{ matrix.compiler }}-build-container
       RUN_CMD: docker exec -t -w /src -e TEST_IN_CI -e ASAN_OPTIONS -e G_MESSAGES_DEBUG -e XDG_DATA_DIRS ${{ matrix.compiler }}-build-container
       AS_USER: runuser -u tester --
 
     steps:
+    - name: Prepare environment
+      id: env-setup
+      run: |
+        if [ "${{ matrix.sanitizer }}" == "address" ]; then
+          echo "::set-output name=cflags::$BASE_CFLAGS" \
+            "-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address";
+        elif [ "${{ matrix.sanitizer }}" == "thread" ]; then
+          echo "::set-output name=cflags::$BASE_CFLAGS" \
+            "-fsanitize=thread";
+        else
+          echo "::set-output name=cflags::$BASE_CFLAGS";
+        fi
+
     - name: Prepare container
       run: |
         docker run --name $BUILD_CONTAINER \
@@ -33,7 +50,7 @@ jobs:
           -e DEBCONF_NONINTERACTIVE_SEEN=true \
           -e TERM=dumb \
           -e MAKEFLAGS="-j $(getconf _NPROCESSORS_ONLN)" \
-          -e CC -e CFLAGS \
+          -e CC -e CFLAGS="${{ steps.env-setup.outputs.cflags }}" \
           -d ubuntu:$UBUNTU_VERSION sleep infinity
 
     - name: Install dependencies

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -23,6 +23,8 @@ test_doc_portal_SOURCES = \
 	tests/can-use-fuse.c \
 	tests/can-use-fuse.h \
 	tests/test-doc-portal.c \
+	tests/utils.c \
+	tests/utils.h \
 	$(NULL)
 nodist_test_doc_portal_SOURCES = document-portal/document-portal-dbus.c
 
@@ -66,8 +68,6 @@ test_portals_SOURCES += \
 	tests/trash.h \
 	tests/wallpaper.c \
 	tests/wallpaper.h \
-	tests/utils.c \
-	tests/utils.h \
         tests/glib-backports.c \
         tests/glib-backports.h \
 	$(NULL)
@@ -77,6 +77,8 @@ nodist_test_portals_SOURCES = \
 	src/xdp-impl-dbus.c \
 	src/xdp-utils.c \
         document-portal/permission-store-dbus.c \
+		tests/utils.c \
+		tests/utils.h \
 	$(NULL)
 test_programs += test-portals
 
@@ -86,7 +88,11 @@ test_permission_store_LDADD = \
 	$(BASE_LIBS) \
 	$(NULL)
 test_permission_store_SOURCES = tests/test-permission-store.c
-nodist_test_permission_store_SOURCES = document-portal/permission-store-dbus.c src/xdp-utils.c
+nodist_test_permission_store_SOURCES = \
+	document-portal/permission-store-dbus.c src/xdp-utils.c \
+	tests/utils.c \
+	tests/utils.h \
+	$(NULL)
 
 EXTRA_test_permission_store_DEPENDENCIES = tests/services/org.freedesktop.impl.portal.PermissionStore.service tests/services/org.freedesktop.portal.Documents.service
 

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -16,6 +16,7 @@
 #include "document-portal/document-portal-dbus.h"
 
 #include "can-use-fuse.h"
+#include "utils.h"
 
 char outdir[] = "/tmp/xdp-test-XXXXXX";
 
@@ -708,6 +709,9 @@ global_setup (void)
   g_setenv ("XDG_RUNTIME_DIR", outdir, TRUE);
   g_setenv ("XDG_DATA_HOME", outdir, TRUE);
   g_setenv ("TEST_DOCUMENT_PORTAL_FUSE_STATUS", fuse_status_file, TRUE);
+
+  /* Re-defining dbus-monitor with a custom script */
+  setup_dbus_daemon_wrapper (outdir);
 
   dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
   services = g_test_build_filename (G_TEST_BUILT, "services", NULL);

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -661,10 +661,11 @@ def check_directory_doc_perms(doc, app_id):
     real_filepath2 = doc.real_path + "/dir/a-file2"
 
     if writable: # We can create files
-        assertRaises(PermissionError, os.open, dir + "/readonly", os.O_RDWR)
-        os.chmod(dir + "/readonly", 0o700)
-        fd = os.open (dir + "/readonly", os.O_RDWR) # Works now
-        os.close(fd)
+        if os.environ.get('TEST_IN_CI'):
+            assertRaises(PermissionError, os.open, dir + "/readonly", os.O_RDWR)
+            os.chmod(dir + "/readonly", 0o700)
+            fd = os.open (dir + "/readonly", os.O_RDWR) # Works now
+            os.close(fd)
 
         setFileContent(filepath, "filedata")
         assertFileHasContent(filepath, "filedata")

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -661,7 +661,7 @@ def check_directory_doc_perms(doc, app_id):
     real_filepath2 = doc.real_path + "/dir/a-file2"
 
     if writable: # We can create files
-        if os.environ.get('TEST_IN_CI'):
+        if os.environ.get('TEST_IN_ROOTED_CI'):
             assertRaises(PermissionError, os.open, dir + "/readonly", os.O_RDWR)
             os.chmod(dir + "/readonly", 0o700)
             fd = os.open (dir + "/readonly", os.O_RDWR) # Works now

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -14,6 +14,7 @@
 
 #include "src/xdp-utils.h"
 #include "document-portal/permission-store-dbus.h"
+#include "utils.h"
 
 char outdir[] = "/tmp/xdp-test-XXXXXX";
 
@@ -566,6 +567,9 @@ global_setup (void)
 
   g_setenv ("XDG_RUNTIME_DIR", outdir, TRUE);
   g_setenv ("XDG_DATA_HOME", outdir, TRUE);
+
+  /* Re-defining dbus-monitor with a custom script */
+  setup_dbus_daemon_wrapper (outdir);
 
   dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
   services = g_test_build_filename (G_TEST_BUILT, "services", NULL);

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -21,6 +21,7 @@
 #include "print.h"
 #include "screenshot.h"
 #include "trash.h"
+#include "utils.h"
 #include "wallpaper.h"
 #endif
 
@@ -140,6 +141,9 @@ global_setup (void)
 
   g_setenv ("XDG_RUNTIME_DIR", outdir, TRUE);
   g_setenv ("XDG_DATA_HOME", outdir, TRUE);
+
+  /* Re-defining dbus-monitor with a custom script */
+  setup_dbus_daemon_wrapper (outdir);
 
   dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
   services = g_test_build_filename (G_TEST_BUILT, "services", NULL);

--- a/tests/trash.c
+++ b/tests/trash.c
@@ -40,7 +40,7 @@ test_trash_file (void)
 
   expected = FALSE;
   got_info = FALSE;
-  xdp_portal_trash_file (portal, "/etc/passwd", NULL, trash_cb, &expected);
+  xdp_portal_trash_file (portal, "/proc/cmdline", NULL, trash_cb, &expected);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);    

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -2,6 +2,8 @@
 
 #include "utils.h"
 
+#include <glib/gstdio.h>
+
 /*
  * Set a property. Unlike gdbus-codegen-generated wrapper functions, this
  * waits for the property change to take effect.
@@ -25,4 +27,35 @@ tests_set_property_sync (GDBusProxy *proxy,
                                 NULL,
                                 error);
   return (res != NULL);
+}
+
+/* We need this to ensure that dbus-daemon launched by GTestDBus is not
+ * causing our tests to hang (see GNOME/glib#2537), so we are redirecting
+ * all its output to stderr, while reading its pid and address to manage it.
+ * As bonus point, now the services output will be visible in test logs.
+ * This can be removed once GNOME/glib!2354 will be available everywhere.
+ */
+void
+setup_dbus_daemon_wrapper (const char *outdir)
+{
+  g_autofree gchar *file_name = NULL;
+  g_autofree gchar *test_path = NULL;
+  g_autoptr (GError) error = NULL;
+  const char dbus_daemon_script[] = \
+    "#!/usr/bin/env bash\n"
+    "export PATH=\"$ORIGINAL_PATH\"\n"
+    "\n"
+    "[[ \" ${@} \" =~ \" --print-address=\"[0-9]+\" \" ]] && "
+    "  exec dbus-daemon \"$@\"\n"
+    "\n"
+    "exec dbus-daemon \"$@\" --print-address=959 959<&1 1>&2\n";
+
+  test_path = g_strjoin (":", outdir, g_getenv ("PATH"), NULL);
+  g_setenv ("ORIGINAL_PATH", g_getenv ("PATH"), TRUE);
+  g_setenv ("PATH", test_path, TRUE);
+
+  file_name = g_build_filename (outdir, "dbus-daemon", NULL);
+  g_file_set_contents (file_name, dbus_daemon_script, -1, &error);
+  g_chmod (file_name, 0700);
+  g_assert_no_error (error);
 }

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -7,3 +7,5 @@ gboolean tests_set_property_sync (GDBusProxy *proxy,
                                   const char *property,
                                   GVariant *value,
                                   GError **error);
+
+void setup_dbus_daemon_wrapper (const char *outdir);


### PR DESCRIPTION
In order to run various tests, we need a working /dev/fuse, and this is
currently only possible in a privileged container [1].
Github actions workflow doesn't suppport it natively, so we need to
initialize a new one ourself, we just keep it running and execute the
commands when we need them, not to depend on a static image, so that the
github workflow can still be followed as atomic operations.

Also ensuring now that the installed tests are installed and that they're actually running.

/cc @TingPing 

[1] https://github.com/docker/for-linux/issues/321