### PR TITLE
xdp-utils: Remap /run/flatpak/doc to host

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -335,6 +335,9 @@ xdp_app_info_remap_path (XdpAppInfo *app_info,
       else if (g_str_has_prefix (path, "/run/flatpak/app/"))
         return g_build_filename (g_get_user_runtime_dir (), "app",
                                  path + strlen ("/run/flatpak/app/"), NULL);
+      else if (g_str_has_prefix (path, "/run/flatpak/doc/"))
+        return g_build_filename (g_get_user_runtime_dir (), "doc",
+                                 path + strlen ("/run/flatpak/doc/"), NULL);
       else if (g_str_has_prefix (path, "/var/config/"))
         return g_build_filename (g_get_home_dir (), ".var", "app",
                                  app_info->id, "config",


### PR DESCRIPTION
Flatpak now puts the document portal into `/run/flatpak/doc`, which does not exist on the host, so we need to remap it. Looks like https://github.com/flatpak/xdg-desktop-portal/commit/6692c874c97906ed12d219dfa26f977eb01f47f4 forgot about it.

Fixes #671, tested with my app.