### PR TITLE
CI: install ca-certificates for docs job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
           apt-get update
           apt-get upgrade -y
           apt-get install -y --no-install-recommends \
-          make automake autoconf libtool gettext autopoint gcc git \
+          make automake autoconf libtool gettext autopoint gcc git ca-certificates \
           gtk-doc-tools shared-mime-info desktop-file-utils gnome-desktop-testing xmlto fuse libflatpak-dev \
           libglib2.0-dev libgeoclue-2-dev libjson-glib-dev libfontconfig1-dev libfuse-dev libportal-dev libpipewire-0.3-dev
 


### PR DESCRIPTION
The job works properly once installed, see https://github.com/bilelmoussaoui/xdg-desktop-portal/runs/4499618040?check_suite_focus=true

and can be checked at https://bilelmoussaoui.github.io/xdg-desktop-portal/