### PR TITLE
Revert "pipewire: Destroy registry object with remote"

### DIFF
--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -126,13 +126,17 @@ static gboolean
 discover_node_factory_sync (PipeWireRemote *remote,
                             GError **error)
 {
-  remote->registry = pw_core_get_registry (remote->core, PW_VERSION_REGISTRY, 0);
-  pw_registry_add_listener (remote->registry,
+  struct pw_registry *registry;
+
+  registry = pw_core_get_registry (remote->core, PW_VERSION_REGISTRY, 0);
+  pw_registry_add_listener (registry,
                             &remote->registry_listener,
                             &registry_events,
                             remote);
 
   pipewire_remote_roundtrip (remote);
+
+  pw_proxy_destroy((struct pw_proxy*)registry);
 
   if (remote->node_factory_id == 0)
     {
@@ -242,7 +246,6 @@ pipewire_remote_destroy (PipeWireRemote *remote)
     }
 
   g_clear_pointer (&remote->globals, g_hash_table_destroy);
-  g_clear_pointer ((struct pw_proxy **)&remote->registry, pw_proxy_destroy);
   g_clear_pointer (&remote->core, pw_core_disconnect);
   g_clear_pointer (&remote->context, pw_context_destroy);
   g_clear_pointer (&remote->loop, pw_main_loop_destroy);

--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -51,7 +51,6 @@ struct _PipeWireRemote
 
   int sync_seq;
 
-  struct pw_registry *registry;
   struct spa_hook registry_listener;
 
   GHashTable *globals;


### PR DESCRIPTION
This reverts commit fbe26534e14c48481d578da6908d47a53915b77b.

The commit introduced a crash.