### PR TITLE
Get app ID via libsystemd for unsandboxed apps

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,7 @@ jobs:
           gtk-doc-tools shared-mime-info desktop-file-utils gnome-desktop-testing \
           fuse3 libflatpak-dev libglib2.0-dev libgeoclue-2-dev libjson-glib-dev \
           libfontconfig1-dev libfuse3-dev libportal-dev libpipewire-0.3-dev \
-          llvm libgdk-pixbuf-2.0-dev
+          llvm libgdk-pixbuf-2.0-dev libsystemd-dev
 
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v2
@@ -124,7 +124,7 @@ jobs:
         apt-get install -y automake autoconf libtool gettext autopoint gcc \
           gtk-doc-tools shared-mime-info desktop-file-utils \
           libglib2.0-dev libjson-glib-dev libfontconfig1-dev \
-          libgdk-pixbuf2.0-dev
+          libgdk-pixbuf2.0-dev libsystemd-dev
 
     - name: Install libfuse3
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           gtk-doc-tools shared-mime-info desktop-file-utils gnome-desktop-testing \
           xmlto fuse3 libflatpak-dev libglib2.0-dev libgeoclue-2-dev libjson-glib-dev \
           libfontconfig1-dev libfuse3-dev libportal-dev libpipewire-0.3-dev \
-          libgdk-pixbuf2.0-dev
+          libgdk-pixbuf2.0-dev libsystemd-dev
 
       - name: Check out xdg-desktop-portal
         uses: actions/checkout@v2

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,15 @@ if test x$enable_pipewire = xyes ; then
 fi
 AM_CONDITIONAL([HAVE_PIPEWIRE],[test "$enable_pipewire" = "yes"])
 
+AC_ARG_WITH([systemd],
+            AS_HELP_STRING([--with-systemd], [Build with systemd support [default=yes]]),
+            [], [with_systemd=yes])
+if test "x$with_systemd" = "xyes"; then
+	PKG_CHECK_MODULES(SYSTEMD, [libsystemd])
+	AC_DEFINE([HAVE_LIBSYSTEMD], [1], [Define if libsystemd is available])
+fi
+AM_CONDITIONAL([HAVE_LIBSYSTEMD], [test "x$with_systemd" != "xno"])
+
 AC_ARG_ENABLE(docbook-docs,
         [AS_HELP_STRING([--enable-docbook-docs],[build documentation (requires xmlto)])],
         enable_docbook_docs=$enableval, enable_docbook_docs=auto)

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -67,14 +67,16 @@ DB_SOURCES = \
 xdg_permission_store_SOURCES = \
 	src/xdp-utils.c	\
 	src/xdp-utils.h	\
+	src/sd-escape.c	\
+	src/sd-escape.h	\
 	document-portal/permission-store.c	\
 	document-portal/xdg-permission-store.c	\
 	document-portal/xdg-permission-store.h	\
 	$(DB_SOURCES) \
 	$(NULL)
 
-xdg_permission_store_LDADD = $(AM_LDADD) $(BASE_LIBS)
-xdg_permission_store_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal
+xdg_permission_store_LDADD = $(AM_LDADD) $(BASE_LIBS) $(SYSTEMD_LIBS)
+xdg_permission_store_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(SYSTEMD_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal
 
 nodist_xdg_document_portal_SOURCES = \
 	$(nodist_xdg_permission_store_SOURCES) \
@@ -88,6 +90,8 @@ CLEANFILES += $(nodist_xdg_document_portal_SOURCES)
 xdg_document_portal_SOURCES = \
 	src/xdp-utils.c	\
 	src/xdp-utils.h	\
+	src/sd-escape.c	\
+	src/sd-escape.h	\
 	document-portal/document-portal.h		\
 	document-portal/document-portal.c		\
 	document-portal/file-transfer.h			\
@@ -100,5 +104,5 @@ xdg_document_portal_SOURCES = \
 	$(DB_SOURCES) \
 	$(NULL)
 
-xdg_document_portal_LDADD = $(AM_LDADD) $(BASE_LIBS) $(FUSE3_LIBS)
-xdg_document_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)  $(FUSE3_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal
+xdg_document_portal_LDADD = $(AM_LDADD) $(BASE_LIBS) $(FUSE3_LIBS) $(SYSTEMD_LIBS)
+xdg_document_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)  $(FUSE3_CFLAGS) $(SYSTEMD_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -125,6 +125,13 @@ xdg_desktop_portal_SOURCES = \
 	src/portal-impl.c		\
 	$(NULL)
 
+if HAVE_LIBSYSTEMD
+xdg_desktop_portal_SOURCES += \
+	src/sd-escape.c		\
+	src/sd-escape.h		\
+	$(NULL)
+endif
+
 if HAVE_PIPEWIRE
 xdg_desktop_portal_SOURCES += \
 	src/screen-cast.c		\
@@ -149,6 +156,7 @@ xdg_desktop_portal_LDADD = \
 	$(BASE_LIBS) \
 	$(PIPEWIRE_LIBS) \
 	$(GEOCLUE_LIBS) \
+	$(SYSTEMD_LIBS) \
 	$(NULL)
 xdg_desktop_portal_CFLAGS = \
 	-DDATADIR=\"$(datadir)\" \
@@ -157,6 +165,7 @@ xdg_desktop_portal_CFLAGS = \
 	$(BASE_CFLAGS) \
 	$(PIPEWIRE_CFLAGS) \
 	$(GEOCLUE_CFLAGS) \
+	$(SYSTEMD_CFLAGS) \
 	-I$(srcdir)/src \
 	-I$(builddir)/src \
 	-I$(srcdir)/document-portal \

--- a/src/sd-escape.c
+++ b/src/sd-escape.c
@@ -1,0 +1,356 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-escape.h"
+#include <errno.h>
+
+/* The following is copied from these files in systemd with minor
+ * modifications:
+ * - src/basic/escape.c
+ * - src/basic/utf8.c
+ * - src/basic/hexdecoct.c
+ */
+
+static int unhexchar(char c) {
+
+        if (c >= '0' && c <= '9')
+                return c - '0';
+
+        if (c >= 'a' && c <= 'f')
+                return c - 'a' + 10;
+
+        if (c >= 'A' && c <= 'F')
+                return c - 'A' + 10;
+
+        return -EINVAL;
+}
+
+static gboolean
+unichar_is_valid(guint32 ch) {
+
+        if (ch >= 0x110000) /* End of unicode space */
+                return FALSE;
+        if ((ch & 0xFFFFF800) == 0xD800) /* Reserved area for UTF-16 */
+                return FALSE;
+        if ((ch >= 0xFDD0) && (ch <= 0xFDEF)) /* Reserved */
+                return FALSE;
+        if ((ch & 0xFFFE) == 0xFFFE) /* BOM (Byte Order Mark) */
+                return FALSE;
+
+        return TRUE;
+}
+
+static int
+unoctchar(char c) {
+
+        if (c >= '0' && c <= '7')
+                return c - '0';
+
+        return -EINVAL;
+}
+
+int cunescape_one(const char *p, gsize length, guint32 *ret, gboolean *eight_bit, gboolean accept_nul) {
+        int r = 1;
+
+        g_assert(p);
+        g_assert(ret);
+
+        /* Unescapes C style. Returns the unescaped character in ret.
+         * Sets *eight_bit to true if the escaped sequence either fits in
+         * one byte in UTF-8 or is a non-unicode literal byte and should
+         * instead be copied directly.
+         */
+
+        if (length != G_MAXSIZE && length < 1)
+                return -EINVAL;
+
+        switch (p[0]) {
+
+        case 'a':
+                *ret = '\a';
+                break;
+        case 'b':
+                *ret = '\b';
+                break;
+        case 'f':
+                *ret = '\f';
+                break;
+        case 'n':
+                *ret = '\n';
+                break;
+        case 'r':
+                *ret = '\r';
+                break;
+        case 't':
+                *ret = '\t';
+                break;
+        case 'v':
+                *ret = '\v';
+                break;
+        case '\\':
+                *ret = '\\';
+                break;
+        case '"':
+                *ret = '"';
+                break;
+        case '\'':
+                *ret = '\'';
+                break;
+
+        case 's':
+                /* This is an extension of the XDG syntax files */
+                *ret = ' ';
+                break;
+
+        case 'x': {
+                /* hexadecimal encoding */
+                int a, b;
+
+                if (length != G_MAXSIZE && length < 3)
+                        return -EINVAL;
+
+                a = unhexchar(p[1]);
+                if (a < 0)
+                        return -EINVAL;
+
+                b = unhexchar(p[2]);
+                if (b < 0)
+                        return -EINVAL;
+
+                /* Don't allow NUL bytes */
+                if (a == 0 && b == 0 && !accept_nul)
+                        return -EINVAL;
+
+                *ret = (a << 4U) | b;
+                *eight_bit = TRUE;
+                r = 3;
+                break;
+        }
+
+        case 'u': {
+                /* C++11 style 16bit unicode */
+
+                int a[4];
+                gsize i;
+                guint32 c;
+
+                if (length != G_MAXSIZE && length < 5)
+                        return -EINVAL;
+
+                for (i = 0; i < 4; i++) {
+                        a[i] = unhexchar(p[1 + i]);
+                        if (a[i] < 0)
+                                return a[i];
+                }
+
+                c = ((guint32) a[0] << 12U) | ((guint32) a[1] << 8U) | ((guint32) a[2] << 4U) | (guint32) a[3];
+
+                /* Don't allow 0 chars */
+                if (c == 0 && !accept_nul)
+                        return -EINVAL;
+
+                *ret = c;
+                r = 5;
+                break;
+        }
+
+        case 'U': {
+                /* C++11 style 32bit unicode */
+
+                int a[8];
+                gsize i;
+                guint32 c;
+
+                if (length != G_MAXSIZE && length < 9)
+                        return -EINVAL;
+
+                for (i = 0; i < 8; i++) {
+                        a[i] = unhexchar(p[1 + i]);
+                        if (a[i] < 0)
+                                return a[i];
+                }
+
+                c = ((guint32) a[0] << 28U) | ((guint32) a[1] << 24U) | ((guint32) a[2] << 20U) | ((guint32) a[3] << 16U) |
+                    ((guint32) a[4] << 12U) | ((guint32) a[5] <<  8U) | ((guint32) a[6] <<  4U) |  (guint32) a[7];
+
+                /* Don't allow 0 chars */
+                if (c == 0 && !accept_nul)
+                        return -EINVAL;
+
+                /* Don't allow invalid code points */
+                if (!unichar_is_valid(c))
+                        return -EINVAL;
+
+                *ret = c;
+                r = 9;
+                break;
+        }
+
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7': {
+                /* octal encoding */
+                int a, b, c;
+                guint32 m;
+
+                if (length != G_MAXSIZE && length < 3)
+                        return -EINVAL;
+
+                a = unoctchar(p[0]);
+                if (a < 0)
+                        return -EINVAL;
+
+                b = unoctchar(p[1]);
+                if (b < 0)
+                        return -EINVAL;
+
+                c = unoctchar(p[2]);
+                if (c < 0)
+                        return -EINVAL;
+
+                /* don't allow NUL bytes */
+                if (a == 0 && b == 0 && c == 0 && !accept_nul)
+                        return -EINVAL;
+
+                /* Don't allow bytes above 255 */
+                m = ((guint32) a << 6U) | ((guint32) b << 3U) | (guint32) c;
+                if (m > 255)
+                        return -EINVAL;
+
+                *ret = m;
+                *eight_bit = TRUE;
+                r = 3;
+                break;
+        }
+
+        default:
+                return -EINVAL;
+        }
+
+        return r;
+}
+
+/**
+ * utf8_encode_unichar() - Encode single UCS-4 character as UTF-8
+ * @out_utf8: output buffer of at least 4 bytes or NULL
+ * @g: UCS-4 character to encode
+ *
+ * This encodes a single UCS-4 character as UTF-8 and writes it into @out_utf8.
+ * The length of the character is returned. It is not zero-terminated! If the
+ * output buffer is NULL, only the length is returned.
+ *
+ * Returns: The length in bytes that the UTF-8 representation does or would
+ *          occupy.
+ */
+static gsize
+utf8_encode_unichar(char *out_utf8, guint32 g) {
+
+        if (g < (1 << 7)) {
+                if (out_utf8)
+                        out_utf8[0] = g & 0x7f;
+                return 1;
+        } else if (g < (1 << 11)) {
+                if (out_utf8) {
+                        out_utf8[0] = 0xc0 | ((g >> 6) & 0x1f);
+                        out_utf8[1] = 0x80 | (g & 0x3f);
+                }
+                return 2;
+        } else if (g < (1 << 16)) {
+                if (out_utf8) {
+                        out_utf8[0] = 0xe0 | ((g >> 12) & 0x0f);
+                        out_utf8[1] = 0x80 | ((g >> 6) & 0x3f);
+                        out_utf8[2] = 0x80 | (g & 0x3f);
+                }
+                return 3;
+        } else if (g < (1 << 21)) {
+                if (out_utf8) {
+                        out_utf8[0] = 0xf0 | ((g >> 18) & 0x07);
+                        out_utf8[1] = 0x80 | ((g >> 12) & 0x3f);
+                        out_utf8[2] = 0x80 | ((g >> 6) & 0x3f);
+                        out_utf8[3] = 0x80 | (g & 0x3f);
+                }
+                return 4;
+        }
+
+        return 0;
+}
+
+gssize cunescape_length_with_prefix(const char *s, gsize length, const char *prefix, UnescapeFlags flags, char **ret) {
+        g_autofree char *ans = NULL;
+        char *t;
+        const char *f;
+        gsize pl;
+        int r;
+
+        g_assert(s);
+        g_assert(ret);
+
+        /* Undoes C style string escaping, and optionally prefixes it. */
+
+        if (!prefix)
+          pl = 0;
+        else
+          pl = strlen(prefix);
+
+        ans = g_new(char, pl+length+1);
+        if (!ans)
+                return -ENOMEM;
+
+        if (prefix)
+                memcpy(ans, prefix, pl);
+
+        for (f = s, t = ans + pl; f < s + length; f++) {
+                gsize remaining;
+                gboolean eight_bit = FALSE;
+                guint32 u;
+
+                remaining = s + length - f;
+                g_assert(remaining > 0);
+
+                if (*f != '\\') {
+                        /* A literal, copy verbatim */
+                        *(t++) = *f;
+                        continue;
+                }
+
+                if (remaining == 1) {
+                        if (flags & UNESCAPE_RELAX) {
+                                /* A trailing backslash, copy verbatim */
+                                *(t++) = *f;
+                                continue;
+                        }
+
+                        return -EINVAL;
+                }
+
+                r = cunescape_one(f + 1, remaining - 1, &u, &eight_bit, flags & UNESCAPE_ACCEPT_NUL);
+                if (r < 0) {
+                        if (flags & UNESCAPE_RELAX) {
+                                /* Invalid escape code, let's take it literal then */
+                                *(t++) = '\\';
+                                continue;
+                        }
+
+                        return r;
+                }
+
+                f += r;
+                if (eight_bit)
+                        /* One byte? Set directly as specified */
+                        *(t++) = u;
+                else
+                        /* Otherwise encode as multi-byte UTF-8 */
+                        t += utf8_encode_unichar(t, u);
+        }
+
+        *t = 0;
+
+        g_assert(t >= ans); /* Let static analyzers know that the answer is non-negative. */
+        *ret = g_steal_pointer (&ans);
+        return t - *ret;
+}
+

--- a/src/sd-escape.h
+++ b/src/sd-escape.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include <glib.h>
+#include <string.h>
+
+typedef enum UnescapeFlags {
+        UNESCAPE_RELAX      = 1 << 0,
+        UNESCAPE_ACCEPT_NUL = 1 << 1,
+} UnescapeFlags;
+
+gssize cunescape_length_with_prefix(const char *s, gsize length, const char *prefix, UnescapeFlags flags, char **ret);
+static inline gssize cunescape_length(const char *s, gsize length, UnescapeFlags flags, char **ret) {
+        return cunescape_length_with_prefix(s, length, NULL, flags, ret);
+}
+static inline gssize cunescape(const char *s, UnescapeFlags flags, char **ret) {
+        return cunescape_length(s, strlen(s), flags, ret);
+}

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -183,7 +183,7 @@ gboolean  xdp_has_path_prefix (const char *str,
 /* exposed for the benefit of tests */
 int _xdp_parse_cgroup_file (FILE     *f,
                             gboolean *is_snap);
-
+char *_xdp_parse_app_id_from_unit_name (const char *unit);
 
 #if !GLIB_CHECK_VERSION (2, 58, 0)
 static inline gboolean

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -30,11 +30,12 @@ nodist_test_doc_portal_SOURCES = document-portal/document-portal-dbus.c
 
 EXTRA_test_doc_portal_DEPENDENCIES = tests/services/org.freedesktop.impl.portal.PermissionStore.service tests/services/org.freedesktop.portal.Documents.service
 
-test_portals_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(LIBPORTAL_CFLAGS)
+test_portals_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(LIBPORTAL_CFLAGS) $(SYSTEMD_LIBS)
 test_portals_LDADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
 	$(LIBPORTAL_LIBS) \
+	$(SYSTEMD_LIBS) \
 	$(NULL)
 test_portals_SOURCES = tests/test-portals.c
 test_portals_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(libexecdir)\"
@@ -76,20 +77,26 @@ nodist_test_portals_SOURCES = \
 	src/xdp-dbus.c \
 	src/xdp-impl-dbus.c \
 	src/xdp-utils.c \
+	src/sd-escape.c \
+	src/sd-escape.h \
         document-portal/permission-store-dbus.c \
 		tests/utils.c \
 		tests/utils.h \
 	$(NULL)
 test_programs += test-portals
 
-test_permission_store_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
+test_permission_store_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(SYSTEMD_CFLAGS)
 test_permission_store_LDADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
+	$(SYSTEMD_LIBS) \
 	$(NULL)
 test_permission_store_SOURCES = tests/test-permission-store.c
 nodist_test_permission_store_SOURCES = \
-	document-portal/permission-store-dbus.c src/xdp-utils.c \
+	document-portal/permission-store-dbus.c \
+	src/xdp-utils.c \
+	src/sd-escape.c \
+	src/sd-escape.h \
 	tests/utils.c \
 	tests/utils.h \
 	$(NULL)
@@ -97,10 +104,14 @@ nodist_test_permission_store_SOURCES = \
 EXTRA_test_permission_store_DEPENDENCIES = tests/services/org.freedesktop.impl.portal.PermissionStore.service tests/services/org.freedesktop.portal.Documents.service
 
 test_programs += test-xdp-utils
-test_xdp_utils_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
-test_xdp_utils_LDADD = $(AM_LD_ADD) $(BASE_LIBS)
-test_xdp_utils_SOURCES = tests/test-xdp-utils.c src/xdp-utils.c
-
+test_xdp_utils_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(SYSTEMD_CFLAGS)
+test_xdp_utils_LDADD = $(AM_LD_ADD) $(BASE_LIBS) $(SYSTEMD_LIBS)
+test_xdp_utils_SOURCES = \
+	tests/test-xdp-utils.c \
+	src/xdp-utils.c \
+	src/sd-escape.c \
+	src/sd-escape.h \
+	$(NULL)
 
 tests/services/org.freedesktop.portal.Documents.service: document-portal/org.freedesktop.portal.Documents.service.in
 	mkdir -p tests/services

--- a/tests/test-xdp-utils.c
+++ b/tests/test-xdp-utils.c
@@ -127,6 +127,46 @@ test_alternate_doc_path (void)
   xdp_set_documents_mountpoint (NULL);
 }
 
+static void
+test_app_id_via_systemd_unit (void)
+{
+  g_autofree char *app_id = NULL;
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-not-a-well-formed-unit-name");
+  g_assert_cmpstr (app_id, ==, "");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-gnome-org.gnome.Evolution\\x2dalarm\\x2dnotify-2437.scope");
+  /* Note, this is not Evolution's app ID, because the scope is for a background service */
+  g_assert_cmpstr (app_id, ==, "org.gnome.Evolution-alarm-notify");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-gnome-org.gnome.Epiphany-182352.scope");
+  g_assert_cmpstr (app_id, ==, "org.gnome.Epiphany");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-glib-spice\\x2dvdagent-1839.scope");
+  /* App IDs must have two periods */
+  g_assert_cmpstr (app_id, ==, "");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-KDE-org.kde.okular@12345.service");
+  g_assert_cmpstr (app_id, ==, "org.kde.okular");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-org.kde.amarok.service");
+  g_assert_cmpstr (app_id, ==, "org.kde.amarok");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-gnome-org.gnome.SettingsDaemon.DiskUtilityNotify-autostart.service");
+  g_assert_cmpstr (app_id, ==, "org.gnome.SettingsDaemon.DiskUtilityNotify");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-gnome-org.gnome.Terminal-92502.slice");
+  g_assert_cmpstr (app_id, ==, "org.gnome.Terminal");
+  g_clear_pointer (&app_id, g_free);
+}
+
 int main (int argc, char **argv)
 {
   g_test_init (&argc, &argv, NULL);
@@ -135,5 +175,8 @@ int main (int argc, char **argv)
   g_test_add_func ("/parse-cgroup/systemd", test_parse_cgroup_systemd);
   g_test_add_func ("/parse-cgroup/not-snap", test_parse_cgroup_not_snap);
   g_test_add_func ("/alternate-doc-path", test_alternate_doc_path);
+#ifdef HAVE_LIBSYSTEMD
+  g_test_add_func ("/app-id-via-systemd-unit", test_app_id_via_systemd_unit);
+#endif
   return g_test_run ();
 }


### PR DESCRIPTION
This is a rework of #581 and dependent on #718, but I'm marking it as a draft because sadly it doesn't work for the one case I actually need it: GNOME Software.

In the case of, say, non-Flatpak Epiphany, the app ID can be successfully gleaned from the systemd unit which looks like `app-gnome-org.gnome.Epiphany-182352.scope`. But in the case of gnome-software (which runs as `/usr/bin/gnome-software --gapplication-service`) the unit looks like `app-gnome-gnome\x2dsoftware\x2dservice-9502.scope` (where 9502 is the pid in my case) so parsing that in any way is not going to get us the correct app ID of `org.gnome.Software`. So I think we need to look for a better way to get app IDs...