### PR TITLE
doc: fix links and some formatting in the portal.* interfaces

### DIFF
--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -32,11 +32,9 @@
   <interface name="org.freedesktop.portal.Background">
     <!--
         RequestBackground:
-        @parent_window: Identifier for the application window, see
-            <link linkend="parent_window">Common Conventions</link>
+        @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
         @options: Vardict with optional further information
-        @handle: Object path for the #org.freedesktop.portal.Request
-            object representing this call
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
         Requests that the application is allowed to run in the
         background.

--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -43,7 +43,7 @@
         </variablelist>
 
         Following the #org.freedesktop.portal.Request::Response signal, if
-        granted, #org.freedesktop.org.Camera.OpenPipeWireRemote can be used to
+        granted, org.freedesktop.portal.Camera.OpenPipeWireRemote() can be used to
         open a PipeWire remote.
     -->
     <method name="AccessCamera">

--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -49,7 +49,7 @@
       The D-Bus interface for the document portal is available under the
       bus name org.freedesktop.portal.Documents and the object path
       /org/freedesktop/portal/documents.
- 
+
       This documentation describes version 4 of this interface.
   -->
   <interface name='org.freedesktop.portal.Documents'>
@@ -123,15 +123,15 @@
         contain an empty string.
 
         Additionally, if app_id is specified, it will be given the permissions
-        listed in GrantPermission.
+        listed in org.freedesktop.portal.Documents.GrantPermissions().
 
         The method also returns some extra info that can be used to avoid
         multiple roundtrips. For now it only contains as "mountpoint", the
         fuse mountpoint of the document portal.
 
-        This method was added in version 2 of the org.freedesktop.portal.Documents interface.
+        This method was added in version 2 of the #org.freedesktop.portal.Documents interface.
 
-        Support for exporting directories were added in version 4 of the org.freedesktop.portal.Documents interface.
+        Support for exporting directories were added in version 4 of the #org.freedesktop.portal.Documents interface.
     -->
     <method name="AddFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -161,13 +161,13 @@
         contain an empty string.
 
         Additionally, if app_id is specified, it will be given the permissions
-        listed in GrantPermission.
+        listed in org.freedesktop.portal.Documents.GrantPermissions().
 
         The method also returns some extra info that can be used to avoid
         multiple roundtrips. For now it only contains as "mountpoint", the
         fuse mountpoint of the document portal.
 
-        This method was added in version 3 of the org.freedesktop.portal.Documents interface.
+        This method was added in version 3 of the #org.freedesktop.portal.Documents interface.
     -->
     <method name="AddNamedFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>

--- a/data/org.freedesktop.portal.FileTransfer.xml
+++ b/data/org.freedesktop.portal.FileTransfer.xml
@@ -23,19 +23,20 @@
        org.freedesktop.portal.FileTransfer:
        @short_description: Portal for transferring files between apps
 
-       The FileTransfer portal operates as a middle-man between apps
-       when transferring files via drag-and-drop or copy-paste, taking
-       care of the necessary exporting of files in the document portal.
+       The #org.freedesktop.portal.FileTransfer portal operates as a middle-man
+       between apps when transferring files via drag-and-drop or copy-paste,
+       taking care of the necessary exporting of files in the document portal.
 
        Toolkits are expected to use the application/vnd.portal.filetransfer
        mimetype when using this mechanism for file exchange via copy-paste
        or drag-and-drop.
 
        The data that is transmitted with this mimetype should be the key
-       returned by the StartTransfer method. Upon receiving this mimetype,
-       the target should call RetrieveFiles with the key, to obtain the
-       list of files. The portal will take care of exporting files in
-       the document store as necessary to make them accessible to the
+       returned by the org.freedesktop.portal.FileTransfer.StartTransfer()
+       method. Upon receiving this mimetype, the target should call
+       org.freedesktop.portal.FileTransfer.RetrieveFiles() with the key,
+       to obtain the list of files. The portal will take care of exporting
+       files in the document store as necessary to make them accessible to the
        target.
 
        The D-Bus interface for the this portal is available under the
@@ -48,13 +49,15 @@
     <!--
         StartTransfer:
         @options: Vardict with optional further onformation
-        @key: a key that needs to be passed to RetrieveFiles to obtain the files
+        @key: a key that needs to be passed to org.freedesktop.portal.FileTransfer.RetrieveFiles() to obtain the files
 
         Starts a session for a file transfer.
-        The caller should call AddFiles at least once, to add files to this session.
+        The caller should call org.freedesktop.portal.FileTransfer.AddFiles()
+        at least once, to add files to this session.
 
-        Another application can then call RetrieveFiles to obtain them, if it has
-        the @session and @secret.
+        Another application can then call
+        org.freedesktop.portal.FileTransfer.RetrieveFiles() to obtain them, if
+        it has the @session and @secret.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -73,7 +76,7 @@
             <term>autostop b</term>
             <listitem><para>
               Whether to stop the transfer automatically after the first
-              RetrieveFiles call. Default: True
+              org.freedesktop.portal.FileTransfer.RetrieveFiles() call. Default: True
             </para></listitem>
           </varlistentry>
         </variablelist>
@@ -85,7 +88,7 @@
 
     <!--
         AddFiles:
-        @key: A key returned by StartTransfer
+        @key: A key returned by org.freedesktop.portal.FileTransfer.StartTransfer()
         @fds: File descriptors for the files to register
 
         Adds files to a session. This method can be called multiple times on
@@ -94,7 +97,7 @@
 
         Note that the session bus often has a low limit of file descriptors per
         message (typically, 16), so you may have to send large file lists with
-        multiple AddFiles calls.
+        multiple org.freedesktop.portal.FileTransfer.AddFiles() calls.
     -->
     <method name="AddFiles">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -105,17 +108,17 @@
 
     <!--
         RetrieveFiles:
-        @key: A key returned by StartTransfer
+        @key: A key returned by org.freedesktop.portal.FileTransfer.StartTransfer()
         @options: Vardict with optional further onformation
         @files: list of paths
 
         Retrieves files that were previously added to the session with
-        AddFiles. The files will be exported in the document portal
-        as-needed for the caller, and they will be writable if the
-        owner of the session allowed it.
+        org.freedesktop.portal.FileTransfer.AddFiles(). The files will be
+        exported in the document portal as-needed for the caller, and they
+        will be writable if the owner of the session allowed it.
 
-        After the first RetrieveFiles call, the session will be closed
-        by the portal, unless autostop has been set to False.
+        After the first org.freedesktop.portal.FileTransfer.RetrieveFiles() call,
+        the session will be closed by the portal, unless @autostop has been set to False.
     -->
     <method name="RetrieveFiles">
       <arg type="s" name="key" direction="in"/>
@@ -125,10 +128,10 @@
 
     <!--
         StopTransfer:
-        @key: A key returned by StartTransfer
+        @key: A key returned by org.freedesktop.portal.FileTransfer.StartTransfer()
 
-        Ends the transfer. Further calls to AddFiles or RetrieveFiles
-        for this key will return an error.
+        Ends the transfer. Further calls to org.freedesktop.portal.FileTransfer.AddFiles()
+        or org.freedesktop.portal.FileTransfer.RetrieveFiles() for this key will return an error.
     -->
     <method name="StopTransfer">
       <arg type="s" name="key" direction="in"/>

--- a/data/org.freedesktop.portal.GameMode.xml
+++ b/data/org.freedesktop.portal.GameMode.xml
@@ -30,17 +30,18 @@
       separate process  ids (pids) within two different namespaces
       that both identify same process. One id from the pid namespace
       inside the sandbox and one id from the host pid namespace.
-      Since GameMode expects pids from the host pid namespace but
-      programs inside the sandbox can only know pids from the sandbox
-      namespace, process ids need to be translated from the portal to
-      the host namespace. The portal will do that transparently for
-      all calls where this is necessary.
+      Since org.freedesktop.portal.GameMode expects pids from the host
+      pid namespace but programs inside the sandbox can only know pids
+      from the sandbox namespace, process ids need to be translated from
+      the portal to the host namespace. The portal will do that transparently
+      for all calls where this is necessary.
 
-      Note: GameMode will monitor active clients, i.e. games and
-      other programs that have successfully called 'RegisterGame'.
+      Note: #org.freedesktop.portal.GameMode will monitor active clients,
+      i.e. games and other programs that have successfully called
+      org.freedesktop.portal.GameMode.RegisterGame().
       In the event that a client terminates without a call to the
-      'UnregisterGame' method, GameMode will automatically un-register
-      the client. This might happen with a (small) delay.
+      org.freedesktop.portal.GameMode.UnregisterGame() method, GameMode will
+      automatically un-register the client. This might happen with a (small) delay.
 
       This documentation describes version 3 of this interface.
     -->

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -84,7 +84,7 @@
         A successfully created session can at any time be closed using
         org.freedesktop.portal.Session::Close, or may at any time be closed
         by the portal implementation, which will be signalled via
-        org.freedesktop.portal.Session::Closed.
+        #org.freedesktop.portal.Session::Closed.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -135,7 +135,7 @@
         the session state changes.
 
         When the session state changes to 'Query End', clients with active monitoring
-        sessions are expected to respond by calling 
+        sessions are expected to respond by calling
         org.freedesktop.portal.Inhibit.QueryEndResponse() within a second
         of receiving the StateChanged signal. They may call org.freedesktop.portal.Inhibit.Inhibit()
         first to inhibit logout, to prevent the session from proceeding to the Ending state.

--- a/data/org.freedesktop.portal.Location.xml
+++ b/data/org.freedesktop.portal.Location.xml
@@ -35,10 +35,10 @@
         @handle: Object path for the created #org.freedesktop.portal.Session object
 
         Create a location session. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session::Close, or may
+        any time be closed using org.freedesktop.portal.Session.Close(), or may
         at any time be closed by the portal implementation, which will be
-        signalled via org.freedesktop.portal.Session::Closed.
-`
+        signalled via #org.freedesktop.portal.Session::Closed.
+
         Supported keys in the @options vardict include:
         <variablelist>
           <varlistentry>

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -38,7 +38,7 @@
       exported and will be activated via the ActivateAction()
       method in the org.freedesktop.Application interface. Other
       actions are activated by sending the
-      #org.freedeskop.portal.Notification::ActionInvoked signal
+      #org.freedesktop.portal.Notification::ActionInvoked signal
       to the application.
 
       This documentation describes version 1 of this interface.

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -35,12 +35,12 @@
 
         A remote desktop session is used to allow remote controlling a desktop
         session. It can also be used together with a screen cast session (see
-        org.freedesktop.portal.ScreenCast), but may only be started and stopped
+        #org.freedesktop.portal.ScreenCast), but may only be started and stopped
         with this interface.
 
         To also get a screen content, call the
-        #org.freedesktop.ScreenCast.SelectSources with the
-        #org.freedesktop.Session object created with this method.
+        org.freedesktop.portal.ScreenCast.SelectSources() with the
+        #org.freedesktop.portal.Session object created with this method.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -61,7 +61,7 @@
             </para></listitem>
           </varlistentry>
         </variablelist>
-        
+
         The following results get returned via the #org.freedesktop.portal.Request::Response signal:
         <variablelist>
           <varlistentry>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -32,9 +32,9 @@
         @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
         Create a screen cast session. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session::Close, or may
+        any time be closed using org.freedesktop.portal.Session.Close(), or may
         at any time be closed by the portal implementation, which will be
-        signalled via org.freedesktop.portal.Session::Closed.
+        signalled via #org.freedesktop.portal.Session::Closed.
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -111,7 +111,7 @@
             <term>cursor_mode u</term>
             <listitem><para>
               Determines how the cursor will be drawn in the screen cast stream. It must be
-              one of the curosr modes advertised in
+              one of the cursor modes advertised in
               #org.freedesktop.portal.ScreenCast.AvailableCursorModes. Setting a cursor mode
               not advertised will cause the screen cast session to be closed. The default
               cursor mode is 'Hidden'.
@@ -175,10 +175,11 @@
 
         Start the screen cast session. This will typically result the portal
         presenting a dialog letting the user do the selection set up by
-        SelectSources. An application can only attempt start a session once.
+        org.freedesktop.portal.ScreenCast.SelectSources(). An application can
+        only attempt start a session once.
 
         A screen cast session may only be started after having selected sources
-        using org.freedesktop.portal.ScreenCast::SelectSources.
+        using org.freedesktop.portal.ScreenCast.SelectSources().
 
         Supported keys in the @options vardict include:
         <variablelist>
@@ -203,8 +204,10 @@
               properties.
 
               The array will contain a single stream if 'multiple' (see
-              SelectSources) was set to 'false', or at least one stream if
-              'multiple' was set to 'true' as part of the SelectSources method.
+              org.freedesktop.portal.ScreenCast.SelectSources())
+              was set to 'false', or at least one stream if
+              'multiple' was set to 'true' as part of the
+              org.freedesktop.portal.ScreenCast.SelectSources() method.
             </para></listitem>
           </varlistentry>
           <varlistentry>
@@ -212,7 +215,7 @@
             <listitem><para>
               The restore token. This token is a single use token that can later
               be used to restore a session. See
-              #org.freedesktop.portal.ScreenCast.SelectSources for details.
+              org.freedesktop.portal.ScreenCast.SelectSources() for details.
 
               This response option was added in version 4 of this interface.
             </para></listitem>

--- a/data/org.freedesktop.portal.Secret.xml
+++ b/data/org.freedesktop.portal.Secret.xml
@@ -54,7 +54,7 @@
 
         The portal may return an additional identifier associated with
         the secret in the results vardict of
-        org.freedesktop.portal.Request.Response() call. In the next
+        #org.freedesktop.portal.Request::Response signal. In the next
         call of this method, the application shall indicate it through
         a token element in @options.
 

--- a/data/org.freedesktop.portal.Session.xml
+++ b/data/org.freedesktop.portal.Session.xml
@@ -31,8 +31,8 @@
       The duration of the session is defined by the interface that creates it.
       For convenience, the interface contains a method
       org.freedesktop.portal.Session.Close(), and a signal
-      org.freedesktop.portal.Session::Closed. Whether it is allowed to directly
-      call Close() depends on the interface.
+      #org.freedesktop.portal.Session::Closed. Whether it is allowed to directly
+      call org.freedesktop.portal.Session.Close() depends on the interface.
 
       The handle of a session will be of the form
       /org/freedesktop/portal/desktop/session/SENDER/TOKEN, where SENDER is the

--- a/data/org.freedesktop.portal.Wallpaper.xml
+++ b/data/org.freedesktop.portal.Wallpaper.xml
@@ -31,8 +31,7 @@
   <interface name="org.freedesktop.portal.Wallpaper">
     <!--
         SetWallpaperURI:
-        @parent_window: Identifier for the application window, see
-            <link linkend="parent_window">Common Conventions</link>
+        @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
         @uri: The picture file uri
         @options: Options that influence the behavior of the portal
         @handle: Object path for the #org.freedesktop.portal.Request object representing this call
@@ -40,12 +39,24 @@
         Asks to set a given picture as the desktop background picture.
 
         Note that file: uris are explicitly not supported here. To use a local image file as
-        background, use the SetWallpaperFile method.
+        background, use the org.freedesktop.portal.Wallpaper.SetWallpaperFile() method.
 
-        The following options are supported:
-        show-preview: (b) whether to show a preview of the picture. Note that the portal may
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>show-preview b</term>
+            <listitem><para>
+             whether to show a preview of the picture. Note that the portal may
              decide to show a preview even if this option is not set
-        set-on: (s) where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>set-on s</term>
+            <listitem><para>
+              where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="SetWallpaperURI">
       <arg type="s" name="parent_window" direction="in"/>
@@ -56,18 +67,29 @@
 
     <!--
         SetWallpaperFile:
-        @parent_window: Identifier for the application window, see
-            <link linkend="parent_window">Common Conventions</link>
+        @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
         @fd: File descriptor for the file to open
         @options: Options that influence the behavior of the portal
         @handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
         Asks to set a given local file as the desktop background picture.
 
-        The following options are supported:
-        show-preview: (b) whether to show a preview of the picture. Note that the portal may
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>show-preview b</term>
+            <listitem><para>
+             whether to show a preview of the picture. Note that the portal may
              decide to show a preview even if this option is not set
-        set-on: (s) where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>set-on s</term>
+            <listitem><para>
+              where to set the wallpaper. Possible values are 'background', 'lockscreen' or 'both'
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="SetWallpaperFile">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>


### PR DESCRIPTION
Fix the various links to portals, methods and signals, with the
resulting re-formatting required.

Fix some of the arguments that previously spanned over two lines, this
results in incorrect rendering.

Fix the Wallpaper value lists to use a proper variablelist like the
other portals.

And smuggle in a typo fix or two and some whitespace fixes vim decided
to apply.