### PR TITLE
Small cleanups on xdg-utils.c

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -975,7 +975,7 @@ verify_proc_self_fd (XdpAppInfo *app_info,
   /* File descriptors to actually deleted files have " (deleted)"
      appended to them. This also happens to some fake fd types
      like shmem which are "/<name> (deleted)". All such
-     files are considered invalid. Unfortunatelly this also
+     files are considered invalid. Unfortunately this also
      matches files with filenames that actually end in " (deleted)",
      but there is not much to do about this. */
   if (g_str_has_suffix (path_buffer, " (deleted)"))

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -601,9 +601,9 @@ _xdp_parse_cgroup_file (FILE *f, gboolean *is_snap)
 
       /* Only consider the freezer, systemd group or unified cgroup
        * hierarchies */
-      if ((!strcmp (controller, "freezer:") != 0 ||
-           !strcmp (controller, "name=systemd:") != 0 ||
-           !strcmp (controller, ":") != 0) &&
+      if ((strcmp (controller, "freezer:") == 0 ||
+           strcmp (controller, "name=systemd:") == 0 ||
+           strcmp (controller, ":") == 0) &&
           strstr (cgroup, "/snap.") != NULL)
         {
           *is_snap = TRUE;


### PR DESCRIPTION
See commits. The warnings were a bit annoying.

CC @jhenstridge since this is touching Snap code