### PR TITLE
fix building without systemd

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -125,14 +125,9 @@ xdg_desktop_portal_SOURCES = \
 	src/flatpak-instance.h          \
 	src/portal-impl.h		\
 	src/portal-impl.c		\
-	$(NULL)
-
-if HAVE_LIBSYSTEMD
-xdg_desktop_portal_SOURCES += \
 	src/sd-escape.c		\
 	src/sd-escape.h		\
 	$(NULL)
-endif
 
 if HAVE_PIPEWIRE
 xdg_desktop_portal_SOURCES += \

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -33,13 +33,13 @@
 
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-login.h>
-#include "sd-escape.h"
 #endif
 
 #include <gio/gio.h>
 #include <gio/gunixoutputstream.h>
 #include <gio/gdesktopappinfo.h>
 
+#include "sd-escape.h"
 #include "xdp-utils.h"
 
 #define DBUS_NAME_DBUS "org.freedesktop.DBus"


### PR DESCRIPTION
sd-escape.c and sd-escape.h were skipped when building without systemd,
but they contain functions needed for xdg-desktop-portal to build.
Fortunately, neither file actually requires anything specific to systemd
so they can just always be included as part of the sources.