### PR TITLE
DynamicLauncher: fit short_description on one line

### DIFF
--- a/data/org.freedesktop.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.portal.DynamicLauncher.xml
@@ -21,8 +21,7 @@
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <!--
       org.freedesktop.portal.DynamicLauncher:
-      @short_description: Portal for installing application launchers onto the
-        desktop
+      @short_description: Portal for installing application launchers onto the desktop
 
       The DynamicLauncher portal allows sandboxed (or unsandboxed) applications
       to install launchers (.desktop files) which have an icon associated with them


### PR DESCRIPTION
Currently the word 'desktop' is considered a single-word paragraph, and
the short description is truncated in the TOC.