### PR TITLE
Change generated D-Bus code namespace to XdpDbus(Impl)

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -22,7 +22,7 @@ BUILT_SOURCES += $(xdp_dbus_built_sources) $(xdp_impl_dbus_built_sources) $(geoc
 $(xdp_dbus_built_sources) : $(PORTAL_IFACE_FILES)
 	$(AM_V_GEN) $(GDBUS_CODEGEN)                            \
 		--interface-prefix org.freedesktop.portal.      \
-		--c-namespace Xdp                               \
+		--c-namespace XdpDbus                           \
 		--generate-c-code $(builddir)/src/xdp-dbus      \
 		$^ \
 		$(NULL)
@@ -30,7 +30,7 @@ $(xdp_dbus_built_sources) : $(PORTAL_IFACE_FILES)
 $(xdp_impl_dbus_built_sources) : $(PORTAL_IMPL_IFACE_FILES)
 	$(AM_V_GEN) $(GDBUS_CODEGEN)                            \
 		--interface-prefix org.freedesktop.impl.portal. \
-		--c-namespace XdpImpl                           \
+		--c-namespace XdpDbusImpl                           \
 		--generate-c-code $(builddir)/src/xdp-impl-dbus \
 		$^ \
 		$(NULL)

--- a/src/device.c
+++ b/src/device.c
@@ -46,23 +46,24 @@ typedef struct _DeviceClass DeviceClass;
 
 struct _Device
 {
-  XdpDeviceSkeleton parent_instance;
+  XdpDbusDeviceSkeleton parent_instance;
 };
 
 struct _DeviceClass
 {
-  XdpDeviceSkeletonClass parent_class;
+  XdpDbusDeviceSkeletonClass parent_class;
 };
 
-static XdpImplAccess *impl;
+static XdpDbusImplAccess *impl;
 static Device *device;
-static XdpImplLockdown *lockdown;
+static XdpDbusImplLockdown *lockdown;
 
 GType device_get_type (void) G_GNUC_CONST;
-static void device_iface_init (XdpDeviceIface *iface);
+static void device_iface_init (XdpDbusDeviceIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (Device, device, XDP_TYPE_DEVICE_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_DEVICE, device_iface_init));
+G_DEFINE_TYPE_WITH_CODE (Device, device, XDP_DBUS_TYPE_DEVICE_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_DEVICE,
+                                                device_iface_init));
 
 static const char *known_devices[] = {
   "microphone",
@@ -97,7 +98,7 @@ device_query_permission_sync (const char *app_id,
       g_autoptr(GVariant) results = NULL;
       g_autoptr(GError) error = NULL;
       g_autoptr(GAppInfo) info = NULL;
-      g_autoptr(XdpImplRequest) impl_request = NULL;
+      g_autoptr(XdpDbusImplRequest) impl_request = NULL;
 
       if (app_id[0] != 0)
         {
@@ -148,11 +149,11 @@ device_query_permission_sync (const char *app_id,
             subtitle = g_strdup_printf (_("%s wants to use your camera."), g_app_info_get_display_name (info));
         }
 
-      impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                      G_DBUS_PROXY_FLAGS_NONE,
-                                                      g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
-                                                      request->id,
-                                                      NULL, &error);
+      impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                                           G_DBUS_PROXY_FLAGS_NONE,
+                                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                                           request->id,
+                                                           NULL, &error);
       if (!impl_request)
         return FALSE;
 
@@ -160,18 +161,18 @@ device_query_permission_sync (const char *app_id,
 
       g_debug ("Calling backend for device access to: %s", device);
 
-      if (!xdp_impl_access_call_access_dialog_sync (impl,
-                                                    request->id,
-                                                    app_id,
-                                                    "",
-                                                    title,
-                                                    subtitle,
-                                                    body,
-                                                    g_variant_builder_end (&opt_builder),
-                                                    &response,
-                                                    &results,
-                                                    NULL,
-                                                    &error))
+      if (!xdp_dbus_impl_access_call_access_dialog_sync (impl,
+                                                         request->id,
+                                                         app_id,
+                                                         "",
+                                                         title,
+                                                         subtitle,
+                                                         body,
+                                                         g_variant_builder_end (&opt_builder),
+                                                         &response,
+                                                         &results,
+                                                         NULL,
+                                                         &error))
         {
           g_warning ("A backend call failed: %s", error->message);
         }
@@ -210,15 +211,16 @@ handle_access_device_in_thread (GTask *task,
       GVariantBuilder results;
 
       g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
-      xdp_request_emit_response (XDP_REQUEST (request),
-                                 allowed ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED,
-                                 g_variant_builder_end (&results));
+      xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
+                                      allowed ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS
+                                              : XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED,
+                                      g_variant_builder_end (&results));
       request_unexport (request);
     }
 }
 
 static gboolean
-handle_access_device (XdpDevice *object,
+handle_access_device (XdpDbusDevice *object,
                       GDBusMethodInvocation *invocation,
                       guint32 pid,
                       const char * const *devices,
@@ -227,7 +229,7 @@ handle_access_device (XdpDevice *object,
   Request *request = request_from_invocation (invocation);
   g_autoptr(XdpAppInfo) app_info = NULL;
   g_autoptr(GError) error = NULL;
-  g_autoptr(XdpImplRequest) impl_request = NULL;
+  g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   g_autoptr(GTask) task = NULL;
 
   if (g_strv_length ((char **)devices) != 1 || !g_strv_contains (known_devices, devices[0]))
@@ -240,7 +242,7 @@ handle_access_device (XdpDevice *object,
     }
 
   if (g_str_equal (devices[0], "microphone") &&
-      xdp_impl_lockdown_get_disable_microphone (lockdown))
+      xdp_dbus_impl_lockdown_get_disable_microphone (lockdown))
     {
       g_debug ("Microphone access disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -250,7 +252,7 @@ handle_access_device (XdpDevice *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
   if (g_str_equal (devices[0], "camera") &&
-      xdp_impl_lockdown_get_disable_camera (lockdown))
+      xdp_dbus_impl_lockdown_get_disable_camera (lockdown))
     {
       g_debug ("Camera access disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -260,7 +262,7 @@ handle_access_device (XdpDevice *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
   if (g_str_equal (devices[0], "speakers") &&
-      xdp_impl_lockdown_get_disable_sound_output (lockdown))
+      xdp_dbus_impl_lockdown_get_disable_sound_output (lockdown))
     {
       g_debug ("Speaker access disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -294,11 +296,11 @@ handle_access_device (XdpDevice *object,
   g_object_set_data_full (G_OBJECT (request), "app-id", g_strdup (xdp_app_info_get_id (app_info)), g_free);
   g_object_set_data_full (G_OBJECT (request), "device", g_strdup (devices[0]), g_free);
 
-  impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                  G_DBUS_PROXY_FLAGS_NONE,
-                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
-                                                  request->id,
-                                                  NULL, &error);
+  impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                                       request->id,
+                                                       NULL, &error);
   if (!impl_request)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -308,7 +310,7 @@ handle_access_device (XdpDevice *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  xdp_device_complete_access_device (object, invocation, request->id);
+  xdp_dbus_device_complete_access_device (object, invocation, request->id);
 
   task = g_task_new (object, NULL, NULL, NULL);
   g_task_set_task_data (task, g_object_ref (request), g_object_unref);
@@ -318,7 +320,7 @@ handle_access_device (XdpDevice *object,
 }
 
 static void
-device_iface_init (XdpDeviceIface *iface)
+device_iface_init (XdpDbusDeviceIface *iface)
 {
   iface->handle_access_device = handle_access_device;
 }
@@ -326,7 +328,7 @@ device_iface_init (XdpDeviceIface *iface)
 static void
 device_init (Device *device)
 {
-  xdp_device_set_version (XDP_DEVICE (device), 1);
+  xdp_dbus_device_set_version (XDP_DBUS_DEVICE (device), 1);
 }
 
 static void
@@ -343,12 +345,12 @@ device_create (GDBusConnection *connection,
 
   lockdown = lockdown_proxy;
 
-  impl = xdp_impl_access_proxy_new_sync (connection,
-                                         G_DBUS_PROXY_FLAGS_NONE,
-                                         dbus_name,
-                                         DESKTOP_PORTAL_OBJECT_PATH,
-                                         NULL,
-                                         &error);
+  impl = xdp_dbus_impl_access_proxy_new_sync (connection,
+                                              G_DBUS_PROXY_FLAGS_NONE,
+                                              dbus_name,
+                                              DESKTOP_PORTAL_OBJECT_PATH,
+                                              NULL,
+                                              &error);
   if (impl == NULL)
     {
       g_warning ("Failed to create access proxy: %s", error->message);

--- a/src/gamemode.c
+++ b/src/gamemode.c
@@ -51,46 +51,46 @@
 typedef struct _GameMode GameMode;
 typedef struct _GameModeClass GameModeClass;
 
-static gboolean handle_query_status (XdpGameMode *object,
+static gboolean handle_query_status (XdpDbusGameMode *object,
                                      GDBusMethodInvocation *invocation,
                                      gint pid);
 
-static gboolean handle_register_game (XdpGameMode *object,
+static gboolean handle_register_game (XdpDbusGameMode *object,
                                       GDBusMethodInvocation *invocation,
                                       gint pid);
 
-static  gboolean handle_unregister_game (XdpGameMode *object,
+static  gboolean handle_unregister_game (XdpDbusGameMode *object,
                                          GDBusMethodInvocation *invocation,
                                          gint pid);
 
-static gboolean handle_query_status_by_pid (XdpGameMode *object,
+static gboolean handle_query_status_by_pid (XdpDbusGameMode *object,
                                             GDBusMethodInvocation *invocation,
                                             gint target,
                                             gint requester);
 
-static gboolean handle_register_game_by_pid (XdpGameMode *object,
+static gboolean handle_register_game_by_pid (XdpDbusGameMode *object,
                                              GDBusMethodInvocation *invocation,
                                              gint target,
                                              gint requester);
 
-static gboolean handle_unregister_game_by_pid (XdpGameMode *object,
+static gboolean handle_unregister_game_by_pid (XdpDbusGameMode *object,
                                                GDBusMethodInvocation *invocation,
                                                gint target,
                                                gint requester);
 
-static gboolean handle_query_status_by_pidfd (XdpGameMode *object,
+static gboolean handle_query_status_by_pidfd (XdpDbusGameMode *object,
                                               GDBusMethodInvocation *invocation,
                                               GUnixFDList *fd_list,
                                               GVariant *arg_target,
                                               GVariant *arg_requester);
 
-static gboolean handle_register_game_by_pidfd (XdpGameMode *object,
+static gboolean handle_register_game_by_pidfd (XdpDbusGameMode *object,
                                                GDBusMethodInvocation *invocation,
                                                GUnixFDList *fd_list,
                                                GVariant *arg_target,
                                                GVariant *arg_requester);
 
-static gboolean handle_unregister_game_by_pidfd (XdpGameMode *object,
+static gboolean handle_unregister_game_by_pidfd (XdpDbusGameMode *object,
                                                  GDBusMethodInvocation *invocation,
                                                  GUnixFDList *fd_list,
                                                  GVariant *arg_target,
@@ -105,7 +105,7 @@ static GameMode *gamemode;
 
 struct _GameMode
 {
-  XdpGameModeSkeleton parent_instance;
+  XdpDbusGameModeSkeleton parent_instance;
 
   /*  */
   GDBusProxy *client;
@@ -113,17 +113,18 @@ struct _GameMode
 
 struct _GameModeClass
 {
-  XdpGameModeSkeletonClass parent_class;
+  XdpDbusGameModeSkeletonClass parent_class;
 };
 
 GType game_mode_get_type (void) G_GNUC_CONST;
-static void game_mode_iface_init (XdpGameModeIface *iface);
+static void game_mode_iface_init (XdpDbusGameModeIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (GameMode, game_mode, XDP_TYPE_GAME_MODE_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_GAME_MODE, game_mode_iface_init));
+G_DEFINE_TYPE_WITH_CODE (GameMode, game_mode, XDP_DBUS_TYPE_GAME_MODE_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_GAME_MODE,
+                                                game_mode_iface_init));
 
 static void
-game_mode_iface_init (XdpGameModeIface *iface)
+game_mode_iface_init (XdpDbusGameModeIface *iface)
 {
   iface->handle_query_status = handle_query_status;
   iface->handle_register_game = handle_register_game;
@@ -143,7 +144,7 @@ game_mode_iface_init (XdpGameModeIface *iface)
 static void
 game_mode_init (GameMode *gamemode)
 {
-  xdp_game_mode_set_version (XDP_GAME_MODE (gamemode), 3);
+  xdp_dbus_game_mode_set_version (XDP_DBUS_GAME_MODE (gamemode), 3);
 }
 
 static void
@@ -162,13 +163,13 @@ game_mode_is_allowed_for_app (const char *app_id, GError **error)
   const char **stored;
   gboolean ok;
 
-  ok = xdp_impl_permission_store_call_lookup_sync (get_permission_store (),
-                                                   PERMISSION_TABLE,
-                                                   PERMISSION_ID,
-                                                   &perms,
-                                                   &data,
-                                                   NULL,
-                                                   &err);
+  ok = xdp_dbus_impl_permission_store_call_lookup_sync (get_permission_store (),
+                                                        PERMISSION_TABLE,
+                                                        PERMISSION_ID,
+                                                        &perms,
+                                                        &data,
+                                                        NULL,
+                                                        &err);
 
   if (!ok)
     {
@@ -357,7 +358,7 @@ handle_call_thread (GTask        *task,
 }
 
 static void
-handle_call_in_thread_fds (XdpGameMode           *object,
+handle_call_in_thread_fds (XdpDbusGameMode       *object,
                            const char            *method,
                            GDBusMethodInvocation *invocation,
                            GUnixFDList           *fdlist)
@@ -387,7 +388,7 @@ handle_call_in_thread_fds (XdpGameMode           *object,
 }
 
 static void
-handle_call_in_thread (XdpGameMode           *object,
+handle_call_in_thread (XdpDbusGameMode       *object,
                        const char            *method,
                        GDBusMethodInvocation *invocation,
                        gint                   target,
@@ -420,7 +421,7 @@ handle_call_in_thread (XdpGameMode           *object,
 
 /* dbus */
 static gboolean
-handle_query_status (XdpGameMode           *object,
+handle_query_status (XdpDbusGameMode       *object,
                      GDBusMethodInvocation *invocation,
                      gint                   pid)
 {
@@ -429,7 +430,7 @@ handle_query_status (XdpGameMode           *object,
 }
 
 static gboolean
-handle_register_game (XdpGameMode           *object,
+handle_register_game (XdpDbusGameMode       *object,
                       GDBusMethodInvocation *invocation,
                       gint                   pid)
 {
@@ -438,7 +439,7 @@ handle_register_game (XdpGameMode           *object,
 }
 
 static  gboolean
-handle_unregister_game (XdpGameMode *object,
+handle_unregister_game (XdpDbusGameMode *object,
                         GDBusMethodInvocation *invocation,
                         gint pid)
 {
@@ -447,7 +448,7 @@ handle_unregister_game (XdpGameMode *object,
 }
 
 static gboolean
-handle_query_status_by_pid (XdpGameMode *object,
+handle_query_status_by_pid (XdpDbusGameMode *object,
                             GDBusMethodInvocation *invocation,
                             gint target,
                             gint requester)
@@ -461,7 +462,7 @@ handle_query_status_by_pid (XdpGameMode *object,
 }
 
 static gboolean
-handle_register_game_by_pid (XdpGameMode *object,
+handle_register_game_by_pid (XdpDbusGameMode *object,
                              GDBusMethodInvocation *invocation,
                              gint target,
                              gint requester)
@@ -475,7 +476,7 @@ handle_register_game_by_pid (XdpGameMode *object,
 }
 
 static gboolean
-handle_unregister_game_by_pid (XdpGameMode *object,
+handle_unregister_game_by_pid (XdpDbusGameMode *object,
                                GDBusMethodInvocation *invocation,
                                gint target,
                                gint requester)
@@ -490,7 +491,7 @@ handle_unregister_game_by_pid (XdpGameMode *object,
 
 /* pidfd based APIs */
 static gboolean
-handle_query_status_by_pidfd (XdpGameMode *object,
+handle_query_status_by_pidfd (XdpDbusGameMode *object,
                               GDBusMethodInvocation *invocation,
                               GUnixFDList *fd_list,
                               GVariant *arg_target,
@@ -505,7 +506,7 @@ handle_query_status_by_pidfd (XdpGameMode *object,
 }
 
 static gboolean
-handle_register_game_by_pidfd (XdpGameMode *object,
+handle_register_game_by_pidfd (XdpDbusGameMode *object,
                                GDBusMethodInvocation *invocation,
                                GUnixFDList *fd_list,
                                GVariant *arg_target,
@@ -520,7 +521,7 @@ handle_register_game_by_pidfd (XdpGameMode *object,
 }
 
 static gboolean
-handle_unregister_game_by_pidfd (XdpGameMode *object,
+handle_unregister_game_by_pidfd (XdpDbusGameMode *object,
                                  GDBusMethodInvocation *invocation,
                                  GUnixFDList *fd_list,
                                  GVariant *arg_target,

--- a/src/memory-monitor.c
+++ b/src/memory-monitor.c
@@ -38,7 +38,7 @@ typedef struct _MemoryMonitorClass MemoryMonitorClass;
 
 struct _MemoryMonitor
 {
-  XdpMemoryMonitorSkeleton parent_instance;
+  XdpDbusMemoryMonitorSkeleton parent_instance;
 
 #ifdef HAS_MEMORY_MONITOR
   GMemoryMonitor *monitor;
@@ -47,19 +47,21 @@ struct _MemoryMonitor
 
 struct _MemoryMonitorClass
 {
-  XdpMemoryMonitorSkeletonClass parent_class;
+  XdpDbusMemoryMonitorSkeletonClass parent_class;
 };
 
 static MemoryMonitor *memory_monitor;
 
 GType memory_monitor_get_type (void) G_GNUC_CONST;
-static void memory_monitor_iface_init (XdpMemoryMonitorIface *iface);
+static void memory_monitor_iface_init (XdpDbusMemoryMonitorIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (MemoryMonitor, memory_monitor, XDP_TYPE_MEMORY_MONITOR_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_MEMORY_MONITOR, memory_monitor_iface_init));
+G_DEFINE_TYPE_WITH_CODE (MemoryMonitor, memory_monitor,
+                         XDP_DBUS_TYPE_MEMORY_MONITOR_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_MEMORY_MONITOR, 
+                                                memory_monitor_iface_init));
 
 static void
-memory_monitor_iface_init (XdpMemoryMonitorIface *iface)
+memory_monitor_iface_init (XdpDbusMemoryMonitorIface *iface)
 {
 }
 
@@ -69,7 +71,8 @@ low_memory_warning_cb (GObject *object,
                        GMemoryMonitorWarningLevel level,
                        MemoryMonitor *mm)
 {
-  xdp_memory_monitor_emit_low_memory_warning (XDP_MEMORY_MONITOR (mm), level);
+  xdp_dbus_memory_monitor_emit_low_memory_warning (XDP_DBUS_MEMORY_MONITOR (mm),
+                                                   level);
 }
 #endif /* HAS_MEMORY_MONITOR */
 
@@ -81,7 +84,7 @@ memory_monitor_init (MemoryMonitor *mm)
   g_signal_connect (mm->monitor, "low-memory-warning", G_CALLBACK (low_memory_warning_cb), mm);
 #endif /* HAS_MEMORY_MONITOR */
 
-  xdp_memory_monitor_set_version (XDP_MEMORY_MONITOR (mm), 1);
+  xdp_dbus_memory_monitor_set_version (XDP_DBUS_MEMORY_MONITOR (mm), 1);
 }
 
 static void

--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -33,26 +33,28 @@ typedef struct _NetworkMonitorClass NetworkMonitorClass;
 
 struct _NetworkMonitor
 {
-  XdpNetworkMonitorSkeleton parent_instance;
+  XdpDbusNetworkMonitorSkeleton parent_instance;
 
   GNetworkMonitor *monitor;
 };
 
 struct _NetworkMonitorClass
 {
-  XdpNetworkMonitorSkeletonClass parent_class;
+  XdpDbusNetworkMonitorSkeletonClass parent_class;
 };
 
 static NetworkMonitor *network_monitor;
 
 GType network_monitor_get_type (void) G_GNUC_CONST;
-static void network_monitor_iface_init (XdpNetworkMonitorIface *iface);
+static void network_monitor_iface_init (XdpDbusNetworkMonitorIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (NetworkMonitor, network_monitor, XDP_TYPE_NETWORK_MONITOR_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_NETWORK_MONITOR, network_monitor_iface_init));
+G_DEFINE_TYPE_WITH_CODE (NetworkMonitor, network_monitor,
+                         XDP_DBUS_TYPE_NETWORK_MONITOR_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_NETWORK_MONITOR,
+                                                network_monitor_iface_init));
 
 static gboolean
-handle_get_available (XdpNetworkMonitor     *object,
+handle_get_available (XdpDbusNetworkMonitor *object,
                       GDBusMethodInvocation *invocation)
 {
   Request *request = request_from_invocation (invocation);
@@ -76,7 +78,7 @@ handle_get_available (XdpNetworkMonitor     *object,
 }
 
 static gboolean
-handle_get_metered (XdpNetworkMonitor     *object,
+handle_get_metered (XdpDbusNetworkMonitor *object,
                     GDBusMethodInvocation *invocation)
 {
   Request *request = request_from_invocation (invocation);
@@ -100,7 +102,7 @@ handle_get_metered (XdpNetworkMonitor     *object,
 }
 
 static gboolean
-handle_get_connectivity (XdpNetworkMonitor     *object,
+handle_get_connectivity (XdpDbusNetworkMonitor *object,
                          GDBusMethodInvocation *invocation)
 {
   Request *request = request_from_invocation (invocation);
@@ -124,7 +126,7 @@ handle_get_connectivity (XdpNetworkMonitor     *object,
 }
 
 static gboolean
-handle_get_status (XdpNetworkMonitor     *object,
+handle_get_status (XdpDbusNetworkMonitor *object,
                    GDBusMethodInvocation *invocation)
 {
   Request *request = request_from_invocation (invocation);
@@ -174,7 +176,7 @@ can_reach_done (GObject      *source,
 }
 
 static gboolean
-handle_can_reach (XdpNetworkMonitor     *object,
+handle_can_reach (XdpDbusNetworkMonitor *object,
                   GDBusMethodInvocation *invocation,
                   const char            *hostname,
                   guint                  port)
@@ -201,7 +203,7 @@ handle_can_reach (XdpNetworkMonitor     *object,
 }
 
 static void
-network_monitor_iface_init (XdpNetworkMonitorIface *iface)
+network_monitor_iface_init (XdpDbusNetworkMonitorIface *iface)
 {
   iface->handle_get_available = handle_get_available;
   iface->handle_get_metered = handle_get_metered;
@@ -215,7 +217,7 @@ network_changed (GObject *object,
                  gboolean network_available,
                  NetworkMonitor *nm)
 {
-  xdp_network_monitor_emit_changed (XDP_NETWORK_MONITOR (nm));
+  xdp_dbus_network_monitor_emit_changed (XDP_DBUS_NETWORK_MONITOR (nm));
 }
 
 static void
@@ -225,7 +227,7 @@ network_monitor_init (NetworkMonitor *nm)
 
   g_signal_connect (nm->monitor, "network-changed", G_CALLBACK (network_changed), nm);
 
-  xdp_network_monitor_set_version (XDP_NETWORK_MONITOR (nm), 3);
+  xdp_dbus_network_monitor_set_version (XDP_DBUS_NETWORK_MONITOR (nm), 3);
 }
 
 static void

--- a/src/permissions.c
+++ b/src/permissions.c
@@ -24,7 +24,7 @@
 
 #include "permissions.h"
 
-static XdpImplPermissionStore *permission_store = NULL;
+static XdpDbusImplPermissionStore *permission_store = NULL;
 
 char **
 get_permissions_sync (const char *app_id,
@@ -36,13 +36,13 @@ get_permissions_sync (const char *app_id,
   g_autoptr(GVariant) out_data = NULL;
   g_autofree char **permissions = NULL;
 
-  if (!xdp_impl_permission_store_call_lookup_sync (permission_store,
-                                                   table,
-                                                   id,
-                                                   &out_perms,
-                                                   &out_data,
-                                                   NULL,
-                                                   &error))
+  if (!xdp_dbus_impl_permission_store_call_lookup_sync (permission_store,
+                                                        table,
+                                                        id,
+                                                        &out_perms,
+                                                        &out_data,
+                                                        NULL,
+                                                        &error))
     {
       g_dbus_error_strip_remote_error (error);
       g_debug ("No '%s' permissions found: %s", table, error->message);
@@ -122,14 +122,14 @@ set_permissions_sync (const char *app_id,
 {
   g_autoptr(GError) error = NULL;
 
-  if (!xdp_impl_permission_store_call_set_permission_sync (permission_store,
-                                                           table,
-                                                           TRUE,
-                                                           id,
-                                                           app_id,
-                                                           permissions,
-                                                           NULL,
-                                                           &error))
+  if (!xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
+                                                                table,
+                                                                TRUE,
+                                                                id,
+                                                                app_id,
+                                                                permissions,
+                                                                NULL,
+                                                                &error))
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("Error updating permission store: %s", error->message);
@@ -166,16 +166,16 @@ init_permission_store (GDBusConnection *connection)
 {
   g_autoptr(GError) error = NULL;
 
-  permission_store = xdp_impl_permission_store_proxy_new_sync (connection,
-                                                               G_DBUS_PROXY_FLAGS_NONE,
-                                                               "org.freedesktop.impl.portal.PermissionStore",
-                                                               "/org/freedesktop/impl/portal/PermissionStore",
-                                                               NULL, &error);
+  permission_store = xdp_dbus_impl_permission_store_proxy_new_sync (connection,
+                                                                    G_DBUS_PROXY_FLAGS_NONE,
+                                                                    "org.freedesktop.impl.portal.PermissionStore",
+                                                                    "/org/freedesktop/impl/portal/PermissionStore",
+                                                                    NULL, &error);
   if (permission_store == NULL)
     g_warning ("No permission store: %s", error->message);
 }
 
-XdpImplPermissionStore *
+XdpDbusImplPermissionStore *
 get_permission_store (void)
 {
   return permission_store;

--- a/src/permissions.h
+++ b/src/permissions.h
@@ -54,4 +54,4 @@ char **permissions_from_tristate (Permission permission);
 Permission permissions_to_tristate (char **permissions);
 
 void init_permission_store (GDBusConnection *connection);
-XdpImplPermissionStore *get_permission_store (void);
+XdpDbusImplPermissionStore *get_permission_store (void);

--- a/src/power-profile-monitor.c
+++ b/src/power-profile-monitor.c
@@ -37,7 +37,7 @@ typedef struct _PowerProfileMonitorClass PowerProfileMonitorClass;
 
 struct _PowerProfileMonitor
 {
-  XdpPowerProfileMonitorSkeleton parent_instance;
+  XdpDbusPowerProfileMonitorSkeleton parent_instance;
 
 #ifdef HAS_POWER_PROFILE_MONITOR
   GPowerProfileMonitor *monitor;
@@ -46,19 +46,21 @@ struct _PowerProfileMonitor
 
 struct _PowerProfileMonitorClass
 {
-  XdpPowerProfileMonitorSkeletonClass parent_class;
+  XdpDbusPowerProfileMonitorSkeletonClass parent_class;
 };
 
 static PowerProfileMonitor *power_profile_monitor;
 
 GType power_profile_monitor_get_type (void) G_GNUC_CONST;
-static void power_profile_monitor_iface_init (XdpPowerProfileMonitorIface *iface);
+static void power_profile_monitor_iface_init (XdpDbusPowerProfileMonitorIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (PowerProfileMonitor, power_profile_monitor, XDP_TYPE_POWER_PROFILE_MONITOR_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_POWER_PROFILE_MONITOR, power_profile_monitor_iface_init));
+G_DEFINE_TYPE_WITH_CODE (PowerProfileMonitor, power_profile_monitor,
+                         XDP_DBUS_TYPE_POWER_PROFILE_MONITOR_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_POWER_PROFILE_MONITOR,
+                                                power_profile_monitor_iface_init));
 
 static void
-power_profile_monitor_iface_init (XdpPowerProfileMonitorIface *iface)
+power_profile_monitor_iface_init (XdpDbusPowerProfileMonitorIface *iface)
 {
 }
 
@@ -68,8 +70,8 @@ power_saver_enabled_changed_cb (GObject             *gobject,
                                 GParamSpec          *pspec,
                                 PowerProfileMonitor *ppm)
 {
-  xdp_power_profile_monitor_set_power_saver_enabled (XDP_POWER_PROFILE_MONITOR (ppm),
-                                                     g_power_profile_monitor_get_power_saver_enabled (ppm->monitor));
+  xdp_dbus_power_profile_monitor_set_power_saver_enabled (XDP_DBUS_POWER_PROFILE_MONITOR (ppm),
+                                                          g_power_profile_monitor_get_power_saver_enabled (ppm->monitor));
 }
 #endif /* HAS_POWER_PROFILE_MONITOR */
 
@@ -81,7 +83,7 @@ power_profile_monitor_init (PowerProfileMonitor *ppm)
   g_signal_connect (ppm->monitor, "notify::power-saver-enabled", G_CALLBACK (power_saver_enabled_changed_cb), ppm);
 #endif /* HAS_POWER_PROFILE_MONITOR */
 
-  xdp_power_profile_monitor_set_version (XDP_POWER_PROFILE_MONITOR (ppm), 1);
+  xdp_dbus_power_profile_monitor_set_version (XDP_DBUS_POWER_PROFILE_MONITOR (ppm), 1);
 }
 
 static void

--- a/src/print.c
+++ b/src/print.c
@@ -43,23 +43,24 @@ typedef struct _PrintClass PrintClass;
 
 struct _Print
 {
-  XdpPrintSkeleton parent_instance;
+  XdpDbusPrintSkeleton parent_instance;
 };
 
 struct _PrintClass
 {
-  XdpPrintSkeletonClass parent_class;
+  XdpDbusPrintSkeletonClass parent_class;
 };
 
-static XdpImplPrint *impl;
+static XdpDbusImplPrint *impl;
 static Print *print;
-static XdpImplLockdown *lockdown;
+static XdpDbusImplLockdown *lockdown;
 
 GType print_get_type (void) G_GNUC_CONST;
-static void print_iface_init (XdpPrintIface *iface);
+static void print_iface_init (XdpDbusPrintIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (Print, print, XDP_TYPE_PRINT_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_PRINT, print_iface_init));
+G_DEFINE_TYPE_WITH_CODE (Print, print, XDP_DBUS_TYPE_PRINT_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_PRINT,
+                                                print_iface_init));
 
 static void
 print_done (GObject *source,
@@ -73,12 +74,12 @@ print_done (GObject *source,
 
   REQUEST_AUTOLOCK (request);
 
-  if (!xdp_impl_print_call_print_finish (XDP_IMPL_PRINT (source),
-                                         &response,
-                                         &options,
-                                         NULL,
-                                         result,
-                                         &error))
+  if (!xdp_dbus_impl_print_call_print_finish (XDP_DBUS_IMPL_PRINT (source),
+                                              &response,
+                                              &options,
+                                              NULL,
+                                              result,
+                                              &error))
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
@@ -90,9 +91,9 @@ print_done (GObject *source,
 
       g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
 
-      xdp_request_emit_response (XDP_REQUEST (request),
-                                 response,
-                                 g_variant_builder_end (&opt_builder));
+      xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
+                                      response,
+                                      g_variant_builder_end (&opt_builder));
       request_unexport (request);
     }
 }
@@ -103,7 +104,7 @@ static XdpOptionKey print_options[] = {
 };
 
 static gboolean
-handle_print (XdpPrint *object,
+handle_print (XdpDbusPrint *object,
               GDBusMethodInvocation *invocation,
               GUnixFDList *fd_list,
               const gchar *arg_parent_window,
@@ -114,10 +115,10 @@ handle_print (XdpPrint *object,
   Request *request = request_from_invocation (invocation);
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
-  g_autoptr(XdpImplRequest) impl_request = NULL;
+  g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   GVariantBuilder opt_builder;
 
-  if (xdp_impl_lockdown_get_disable_printing (lockdown))
+  if (xdp_dbus_impl_lockdown_get_disable_printing (lockdown))
     {
       g_debug ("Printing disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -130,11 +131,11 @@ handle_print (XdpPrint *object,
 
   REQUEST_AUTOLOCK (request);
 
-  impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                  G_DBUS_PROXY_FLAGS_NONE,
-                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
-                                                  request->id,
-                                                  NULL, &error);
+  impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                                       request->id,
+                                                       NULL, &error);
   if (!impl_request)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -147,19 +148,19 @@ handle_print (XdpPrint *object,
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &opt_builder,
                       print_options, G_N_ELEMENTS (print_options), NULL);
-  xdp_impl_print_call_print(impl,
-                            request->id,
-                            app_id,
-                            arg_parent_window,
-                            arg_title,
-                            arg_fd,
-                            g_variant_builder_end (&opt_builder),
-                            fd_list,
-                            NULL,
-                            print_done,
-                            g_object_ref (request));
+  xdp_dbus_impl_print_call_print(impl,
+                                 request->id,
+                                 app_id,
+                                 arg_parent_window,
+                                 arg_title,
+                                 arg_fd,
+                                 g_variant_builder_end (&opt_builder),
+                                 fd_list,
+                                 NULL,
+                                 print_done,
+                                 g_object_ref (request));
 
-  xdp_print_complete_print (object, invocation, NULL, request->id);
+  xdp_dbus_print_complete_print (object, invocation, NULL, request->id);
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
@@ -182,11 +183,11 @@ prepare_print_done (GObject *source,
 
   REQUEST_AUTOLOCK (request);
 
-  if (!xdp_impl_print_call_prepare_print_finish (XDP_IMPL_PRINT (source),
-                                                 &response,
-                                                 &options,
-                                                 result,
-                                                 &error))
+  if (!xdp_dbus_impl_print_call_prepare_print_finish (XDP_DBUS_IMPL_PRINT (source),
+                                                      &response,
+                                                      &options,
+                                                      result,
+                                                      &error))
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
@@ -203,9 +204,9 @@ prepare_print_done (GObject *source,
                             response_options, G_N_ELEMENTS (response_options),
                             NULL);
 
-      xdp_request_emit_response (XDP_REQUEST (request),
-                                 response,
-                                 g_variant_builder_end (&opt_builder));
+      xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
+                                      response,
+                                      g_variant_builder_end (&opt_builder));
 
       request_unexport (request);
     }
@@ -216,7 +217,7 @@ static XdpOptionKey prepare_print_options[] = {
 };
 
 static gboolean
-handle_prepare_print (XdpPrint *object,
+handle_prepare_print (XdpDbusPrint *object,
                       GDBusMethodInvocation *invocation,
                       const gchar *arg_parent_window,
                       const gchar *arg_title,
@@ -227,10 +228,10 @@ handle_prepare_print (XdpPrint *object,
   Request *request = request_from_invocation (invocation);
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
-  g_autoptr(XdpImplRequest) impl_request = NULL;
+  g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   GVariantBuilder opt_builder;
 
-  if (xdp_impl_lockdown_get_disable_printing (lockdown))
+  if (xdp_dbus_impl_lockdown_get_disable_printing (lockdown))
     {
       g_debug ("Printing disabled");
       g_dbus_method_invocation_return_error (invocation,
@@ -242,11 +243,11 @@ handle_prepare_print (XdpPrint *object,
 
   REQUEST_AUTOLOCK (request);
 
-  impl_request = xdp_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                  G_DBUS_PROXY_FLAGS_NONE,
-                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
-                                                  request->id,
-                                                  NULL, &error);
+  impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
+                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                                       request->id,
+                                                       NULL, &error);
   if (!impl_request)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -259,25 +260,25 @@ handle_prepare_print (XdpPrint *object,
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &opt_builder,
                       prepare_print_options, G_N_ELEMENTS (prepare_print_options), NULL);
-  xdp_impl_print_call_prepare_print (impl,
-                                     request->id,
-                                     app_id,
-                                     arg_parent_window,
-                                     arg_title,
-                                     arg_settings,
-                                     arg_page_setup,
-                                     g_variant_builder_end (&opt_builder),
-                                     NULL,
-                                     prepare_print_done,
-                                     g_object_ref (request));
+  xdp_dbus_impl_print_call_prepare_print (impl,
+                                          request->id,
+                                          app_id,
+                                          arg_parent_window,
+                                          arg_title,
+                                          arg_settings,
+                                          arg_page_setup,
+                                          g_variant_builder_end (&opt_builder),
+                                          NULL,
+                                          prepare_print_done,
+                                          g_object_ref (request));
 
-  xdp_print_complete_prepare_print (object, invocation, request->id);
+  xdp_dbus_print_complete_prepare_print (object, invocation, request->id);
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static void
-print_iface_init (XdpPrintIface *iface)
+print_iface_init (XdpDbusPrintIface *iface)
 {
   iface->handle_print = handle_print;
   iface->handle_prepare_print = handle_prepare_print;
@@ -286,7 +287,7 @@ print_iface_init (XdpPrintIface *iface)
 static void
 print_init (Print *print)
 {
-  xdp_print_set_version (XDP_PRINT (print), 1);
+  xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 1);
 }
 
 static void
@@ -303,12 +304,12 @@ print_create (GDBusConnection *connection,
 
   lockdown = lockdown_proxy;
 
-  impl = xdp_impl_print_proxy_new_sync (connection,
-                                        G_DBUS_PROXY_FLAGS_NONE,
-                                        dbus_name,
-                                        DESKTOP_PORTAL_OBJECT_PATH,
-                                        NULL,
-                                        &error);
+  impl = xdp_dbus_impl_print_proxy_new_sync (connection,
+                                             G_DBUS_PROXY_FLAGS_NONE,
+                                             dbus_name,
+                                             DESKTOP_PORTAL_OBJECT_PATH,
+                                             NULL,
+                                             &error);
   if (impl == NULL)
     {
       g_warning ("Failed to create print proxy: %s", error->message);

--- a/src/proxy-resolver.c
+++ b/src/proxy-resolver.c
@@ -33,26 +33,28 @@ typedef struct _ProxyResolverClass ProxyResolverClass;
 
 struct _ProxyResolver
 {
-  XdpProxyResolverSkeleton parent_instance;
+  XdpDbusProxyResolverSkeleton parent_instance;
 
   GProxyResolver *resolver;
 };
 
 struct _ProxyResolverClass
 {
-  XdpProxyResolverSkeletonClass parent_class;
+  XdpDbusProxyResolverSkeletonClass parent_class;
 };
 
 static ProxyResolver *proxy_resolver;
 
 GType proxy_resolver_get_type (void) G_GNUC_CONST;
-static void proxy_resolver_iface_init (XdpProxyResolverIface *iface);
+static void proxy_resolver_iface_init (XdpDbusProxyResolverIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (ProxyResolver, proxy_resolver, XDP_TYPE_PROXY_RESOLVER_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_PROXY_RESOLVER, proxy_resolver_iface_init));
+G_DEFINE_TYPE_WITH_CODE (ProxyResolver, proxy_resolver,
+                         XDP_DBUS_TYPE_PROXY_RESOLVER_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_PROXY_RESOLVER,
+                                                proxy_resolver_iface_init));
 
 static gboolean
-proxy_resolver_handle_lookup (XdpProxyResolver *object,
+proxy_resolver_handle_lookup (XdpDbusProxyResolver *object,
                               GDBusMethodInvocation *invocation,
                               const char *arg_uri)
 {
@@ -83,7 +85,7 @@ proxy_resolver_handle_lookup (XdpProxyResolver *object,
 }
 
 static void
-proxy_resolver_iface_init (XdpProxyResolverIface *iface)
+proxy_resolver_iface_init (XdpDbusProxyResolverIface *iface)
 {
   iface->handle_lookup = proxy_resolver_handle_lookup;
 }
@@ -93,7 +95,7 @@ proxy_resolver_init (ProxyResolver *resolver)
 {
   resolver->resolver = g_proxy_resolver_get_default ();
 
-  xdp_proxy_resolver_set_version (XDP_PROXY_RESOLVER (resolver), 1);
+  xdp_dbus_proxy_resolver_set_version (XDP_DBUS_PROXY_RESOLVER (resolver), 1);
 }
 
 static void

--- a/src/realtime.c
+++ b/src/realtime.c
@@ -37,22 +37,23 @@ typedef struct _RealtimeClass RealtimeClass;
 
 struct _Realtime
 {
-  XdpRealtimeSkeleton parent_instance;
+  XdpDbusRealtimeSkeleton parent_instance;
   GDBusProxy *rtkit_proxy;
 };
 
 struct _RealtimeClass
 {
-  XdpRealtimeSkeletonClass parent_class;
+  XdpDbusRealtimeSkeletonClass parent_class;
 };
 
 static Realtime *realtime;
 
 GType realtime_get_type (void) G_GNUC_CONST;
-static void realtime_iface_init (XdpRealtimeIface *iface);
+static void realtime_iface_init (XdpDbusRealtimeIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (Realtime, realtime, XDP_TYPE_REALTIME_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_REALTIME, realtime_iface_init));
+G_DEFINE_TYPE_WITH_CODE (Realtime, realtime, XDP_DBUS_TYPE_REALTIME_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_REALTIME,
+                                                realtime_iface_init));
 
 static gboolean
 map_pid_if_needed (XdpAppInfo *app_info, pid_t *pid, GError **error)
@@ -90,7 +91,7 @@ on_call_ready (GObject      *source_object,
 }
 
 static gboolean
-handle_make_thread_realtime_with_pid (XdpRealtime           *object,
+handle_make_thread_realtime_with_pid (XdpDbusRealtime       *object,
                                       GDBusMethodInvocation *invocation,
                                       guint64                process,
                                       guint64                thread,
@@ -140,7 +141,7 @@ handle_make_thread_realtime_with_pid (XdpRealtime           *object,
 }
 
 static gboolean
-handle_make_thread_high_priority_with_pid (XdpRealtime           *object,
+handle_make_thread_high_priority_with_pid (XdpDbusRealtime       *object,
                                            GDBusMethodInvocation *invocation,
                                            guint64                process,
                                            guint64                thread,
@@ -190,7 +191,7 @@ handle_make_thread_high_priority_with_pid (XdpRealtime           *object,
 }
 
 static void
-realtime_iface_init (XdpRealtimeIface *iface)
+realtime_iface_init (XdpDbusRealtimeIface *iface)
 {
   iface->handle_make_thread_realtime_with_pid = handle_make_thread_realtime_with_pid;
   iface->handle_make_thread_high_priority_with_pid = handle_make_thread_high_priority_with_pid;
@@ -199,7 +200,7 @@ realtime_iface_init (XdpRealtimeIface *iface)
 static void
 realtime_init (Realtime *realtime)
 {
-  xdp_realtime_set_version (XDP_REALTIME (realtime), 1);
+  xdp_dbus_realtime_set_version (XDP_DBUS_REALTIME (realtime), 1);
 }
 
 static void
@@ -252,11 +253,14 @@ load_all_properties (GDBusProxy *proxy)
           g_variant_get (result, "(v)", &value);
 
           if (i == MAX_REALTIME_PRIORITY)
-            xdp_realtime_set_max_realtime_priority (XDP_REALTIME (realtime), g_variant_get_int32 (value));
+            xdp_dbus_realtime_set_max_realtime_priority (XDP_DBUS_REALTIME (realtime),
+                                                         g_variant_get_int32 (value));
           else if (i == MIN_NICE_LEVEL)
-            xdp_realtime_set_min_nice_level (XDP_REALTIME (realtime), g_variant_get_int32 (value));
+            xdp_dbus_realtime_set_min_nice_level (XDP_DBUS_REALTIME (realtime),
+                                                  g_variant_get_int32 (value));
           else if (i == RTTIME_USEC_MAX)
-            xdp_realtime_set_rttime_usec_max (XDP_REALTIME (realtime), g_variant_get_int64 (value));
+            xdp_dbus_realtime_set_rttime_usec_max (XDP_DBUS_REALTIME (realtime),
+                                                   g_variant_get_int64 (value));
           else
             g_assert_not_reached ();
 

--- a/src/request.h
+++ b/src/request.h
@@ -36,7 +36,7 @@ typedef struct _RequestClass RequestClass;
 
 struct _Request
 {
-  XdpRequestSkeleton parent_instance;
+  XdpDbusRequestSkeleton parent_instance;
 
   gboolean exported;
   char *id;
@@ -44,12 +44,12 @@ struct _Request
   GMutex mutex;
   XdpAppInfo *app_info;
 
-  XdpImplRequest *impl_request;
+  XdpDbusImplRequest *impl_request;
 };
 
 struct _RequestClass
 {
-  XdpRequestSkeletonClass parent_class;
+  XdpDbusRequestSkeletonClass parent_class;
 };
 
 GType request_get_type (void) G_GNUC_CONST;
@@ -63,10 +63,10 @@ void request_export (Request *request,
 void request_unexport (Request *request);
 void close_requests_for_sender (const char *sender);
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpImplRequest, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpDbusImplRequest, g_object_unref)
 
 void request_set_impl_request (Request *request,
-                               XdpImplRequest *impl_request);
+                               XdpDbusImplRequest *impl_request);
 
 static inline void
 auto_unlock_helper (GMutex **mutex)

--- a/src/session.h
+++ b/src/session.h
@@ -28,7 +28,7 @@ typedef struct _SessionClass SessionClass;
 
 struct _Session
 {
-  XdpSessionSkeleton parent;
+  XdpDbusSessionSkeleton parent;
 
   GMutex mutex;
 
@@ -44,12 +44,12 @@ struct _Session
 
   char *impl_dbus_name;
   GDBusConnection *impl_connection;
-  XdpImplSession *impl_session;
+  XdpDbusImplSession *impl_session;
 };
 
 struct _SessionClass
 {
-  XdpSessionSkeletonClass parent_class;
+  XdpDbusSessionSkeletonClass parent_class;
 
   void (*close) (Session *session);
 };
@@ -57,7 +57,7 @@ struct _SessionClass
 GType session_get_type (void);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (Session, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpImplSession, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpDbusImplSession, g_object_unref)
 
 const char * lookup_session_token (GVariant *options);
 

--- a/src/trash.c
+++ b/src/trash.c
@@ -44,21 +44,22 @@ typedef struct _TrashClass TrashClass;
 
 struct _Trash
 {
-  XdpTrashSkeleton parent_instance;
+  XdpDbusTrashSkeleton parent_instance;
 };
 
 struct _TrashClass
 {
-  XdpTrashSkeletonClass parent_class;
+  XdpDbusTrashSkeletonClass parent_class;
 };
 
 static Trash *trash;
 
 GType trash_get_type (void) G_GNUC_CONST;
-static void trash_iface_init (XdpTrashIface *iface);
+static void trash_iface_init (XdpDbusTrashIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (Trash, trash, XDP_TYPE_TRASH_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_TYPE_TRASH, trash_iface_init));
+G_DEFINE_TYPE_WITH_CODE (Trash, trash, XDP_DBUS_TYPE_TRASH_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_TRASH,
+                                                trash_iface_init));
 
 static guint
 trash_file (XdpAppInfo *app_info,
@@ -95,7 +96,7 @@ trash_file (XdpAppInfo *app_info,
 }
 
 static gboolean
-handle_trash_file (XdpTrash *object,
+handle_trash_file (XdpDbusTrash *object,
                    GDBusMethodInvocation *invocation,
                    GUnixFDList *fd_list,
                    GVariant *arg_fd)
@@ -113,13 +114,13 @@ handle_trash_file (XdpTrash *object,
 
   result = trash_file (request->app_info, request->sender, fd);
 
-  xdp_trash_complete_trash_file (object, invocation, NULL, result);
+  xdp_dbus_trash_complete_trash_file (object, invocation, NULL, result);
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static void
-trash_iface_init (XdpTrashIface *iface)
+trash_iface_init (XdpDbusTrashIface *iface)
 {
   iface->handle_trash_file = handle_trash_file;
 }
@@ -127,7 +128,7 @@ trash_iface_init (XdpTrashIface *iface)
 static void
 trash_init (Trash *trash)
 {
-  xdp_trash_set_version (XDP_TRASH (trash), 1);
+  xdp_dbus_trash_set_version (XDP_DBUS_TRASH (trash), 1);
 }
 
 static void

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -218,7 +218,7 @@ on_bus_acquired (GDBusConnection *connection,
   PortalImplementation *implementation;
   PortalImplementation *implementation2;
   g_autoptr(GError) error = NULL;
-  XdpImplLockdown *lockdown;
+  XdpDbusImplLockdown *lockdown;
   GQuark portal_errors G_GNUC_UNUSED;
   GPtrArray *impls;
 
@@ -231,13 +231,13 @@ on_bus_acquired (GDBusConnection *connection,
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Lockdown");
   if (implementation != NULL)
-    lockdown = xdp_impl_lockdown_proxy_new_sync (connection,
-                                                 G_DBUS_PROXY_FLAGS_NONE,
-                                                 implementation->dbus_name,
-                                                 DESKTOP_PORTAL_OBJECT_PATH,
-                                                 NULL, &error);
+    lockdown = xdp_dbus_impl_lockdown_proxy_new_sync (connection,
+                                                      G_DBUS_PROXY_FLAGS_NONE,
+                                                      implementation->dbus_name,
+                                                      DESKTOP_PORTAL_OBJECT_PATH,
+                                                      NULL, &error);
   else
-    lockdown = xdp_impl_lockdown_skeleton_new ();
+    lockdown = xdp_dbus_impl_lockdown_skeleton_new ();
 
   export_portal_implementation (connection, memory_monitor_create (connection));
   export_portal_implementation (connection, power_profile_monitor_create (connection));

--- a/tests/backend/access.c
+++ b/tests/backend/access.c
@@ -10,7 +10,7 @@
 #include "access.h"
 
 typedef struct {
-  XdpImplAccess *impl;
+  XdpDbusImplAccess *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -57,10 +57,10 @@ send_response (gpointer data)
 
   g_debug ("send response %d", response);
 
-  xdp_impl_access_complete_access_dialog (handle->impl,
-                                          handle->invocation,
-                                          response,
-                                          g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_access_complete_access_dialog (handle->impl,
+                                               handle->invocation,
+                                               response,
+                                               g_variant_builder_end (&opt_builder));
 
   handle->timeout = 0;
 
@@ -70,7 +70,7 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               AccessHandle *handle)
 {
@@ -78,17 +78,17 @@ handle_close (XdpImplRequest *object,
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   g_debug ("AccessDialog handling Close");
-  xdp_impl_access_complete_access_dialog (handle->impl,
-                                          handle->invocation,
-                                          2,
-                                          g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_access_complete_access_dialog (handle->impl,
+                                               handle->invocation,
+                                               2,
+                                               g_variant_builder_end (&opt_builder));
   access_handle_free (handle);
 
   return FALSE;
 }
 
 static gboolean
-handle_access_dialog (XdpImplAccess *object,
+handle_access_dialog (XdpDbusImplAccess *object,
                       GDBusMethodInvocation *invocation,
                       const char *arg_handle,
                       const char *arg_app_id,
@@ -155,7 +155,7 @@ access_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_access_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_access_skeleton_new ());
 
   g_signal_connect (helper, "handle-access-dialog", G_CALLBACK (handle_access_dialog), NULL);
 

--- a/tests/backend/account.c
+++ b/tests/backend/account.c
@@ -9,7 +9,7 @@
 #include "account.h"
 
 typedef struct {
-  XdpImplAccount *impl;
+  XdpDbusImplAccount *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -73,10 +73,10 @@ send_response (gpointer data)
 
   g_debug ("send response %d", response);
 
-  xdp_impl_account_complete_get_user_information (handle->impl,
-                                                  handle->invocation,
-                                                  response,
-                                                  g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_account_complete_get_user_information (handle->impl,
+                                                       handle->invocation,
+                                                       response,
+                                                       g_variant_builder_end (&opt_builder));
 
   handle->timeout = 0;
 
@@ -86,7 +86,7 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               AccountDialogHandle *handle)
 {
@@ -94,10 +94,10 @@ handle_close (XdpImplRequest *object,
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   g_debug ("send response 2");
-  xdp_impl_account_complete_get_user_information (handle->impl,
-                                                  handle->invocation,
-                                                  2,
-                                                  g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_account_complete_get_user_information (handle->impl,
+                                                       handle->invocation,
+                                                       2,
+                                                       g_variant_builder_end (&opt_builder));
   account_dialog_handle_free (handle);
 
   return FALSE;
@@ -105,7 +105,7 @@ handle_close (XdpImplRequest *object,
 
 
 static gboolean
-handle_get_user_information (XdpImplAccount *object,
+handle_get_user_information (XdpDbusImplAccount *object,
                              GDBusMethodInvocation *invocation,
                              const char *arg_handle,
                              const char *arg_app_id,
@@ -170,7 +170,7 @@ account_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_account_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_account_skeleton_new ());
 
   g_signal_connect (helper, "handle-get-user-information", G_CALLBACK (handle_get_user_information), NULL);
 

--- a/tests/backend/appchooser.c
+++ b/tests/backend/appchooser.c
@@ -10,7 +10,7 @@
 #include "appchooser.h"
 
 typedef struct {
-  XdpImplAppChooser *impl;
+  XdpDbusImplAppChooser *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -63,10 +63,10 @@ send_response (gpointer data)
 
   g_debug ("send response %d", response);
 
-  xdp_impl_app_chooser_complete_choose_application (handle->impl,
-                                                    handle->invocation,
-                                                    response,
-                                                    g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_app_chooser_complete_choose_application (handle->impl,
+                                                         handle->invocation,
+                                                         response,
+                                                         g_variant_builder_end (&opt_builder));
 
   handle->timeout = 0;
 
@@ -76,17 +76,17 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               AppChooserHandle *handle)
 {
   GVariantBuilder opt_builder;
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
-  xdp_impl_app_chooser_complete_choose_application (handle->impl,
-                                                    handle->invocation,
-                                                    2,
-                                                    g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_app_chooser_complete_choose_application (handle->impl,
+                                                         handle->invocation,
+                                                         2,
+                                                         g_variant_builder_end (&opt_builder));
   app_chooser_handle_free (handle);
 
   return FALSE;
@@ -94,7 +94,7 @@ handle_close (XdpImplRequest *object,
 
 
 static gboolean
-handle_choose_application (XdpImplAppChooser *object,
+handle_choose_application (XdpDbusImplAppChooser *object,
                            GDBusMethodInvocation *invocation,
                            const char *arg_handle,
                            const char *arg_app_id,
@@ -167,7 +167,7 @@ appchooser_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_app_chooser_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_app_chooser_skeleton_new ());
 
   g_signal_connect (helper, "handle-choose-application", G_CALLBACK (handle_choose_application), NULL);
 

--- a/tests/backend/background.c
+++ b/tests/backend/background.c
@@ -11,7 +11,7 @@
 
 
 static gboolean
-handle_get_app_state (XdpImplBackground *object,
+handle_get_app_state (XdpDbusImplBackground *object,
                       GDBusMethodInvocation *invocation)
 {
   GVariantBuilder builder;
@@ -19,7 +19,7 @@ handle_get_app_state (XdpImplBackground *object,
   g_debug ("background: handle GetAppState");
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
-  xdp_impl_background_complete_get_app_state (object,
+  xdp_dbus_impl_background_complete_get_app_state (object,
                                               invocation,
                                               g_variant_builder_end (&builder));
 
@@ -27,7 +27,7 @@ handle_get_app_state (XdpImplBackground *object,
 }
 
 static gboolean
-handle_notify_background (XdpImplBackground *object,
+handle_notify_background (XdpDbusImplBackground *object,
                           GDBusMethodInvocation *invocation,
                           const char *arg_handle,
                           const char *arg_app_id,
@@ -38,16 +38,16 @@ handle_notify_background (XdpImplBackground *object,
   g_debug ("background: handle NotifyBackground");
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
-  xdp_impl_background_complete_notify_background (object,
-                                                  invocation,
-                                                  2,
-                                                  g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_background_complete_notify_background (object,
+                                                       invocation,
+                                                       2,
+                                                       g_variant_builder_end (&opt_builder));
 
   return TRUE;
 }
 
 static gboolean
-handle_enable_autostart (XdpImplBackground *object,
+handle_enable_autostart (XdpDbusImplBackground *object,
                          GDBusMethodInvocation *invocation,
                          const char *arg_app_id,
                          gboolean arg_enable,
@@ -69,7 +69,7 @@ handle_enable_autostart (XdpImplBackground *object,
 
   g_assert (arg_enable == g_key_file_get_boolean (keyfile, "background", "autostart", NULL));
 
-  xdp_impl_background_complete_enable_autostart (object, invocation, TRUE);
+  xdp_dbus_impl_background_complete_enable_autostart (object, invocation, TRUE);
 
   return TRUE;
 }
@@ -81,7 +81,7 @@ background_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_background_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_background_skeleton_new ());
 
   g_signal_connect (helper, "handle-get-app-state", G_CALLBACK (handle_get_app_state), NULL);
   g_signal_connect (helper, "handle-notify-background", G_CALLBACK (handle_notify_background), NULL);

--- a/tests/backend/email.c
+++ b/tests/backend/email.c
@@ -10,7 +10,7 @@
 #include "request.h"
 
 typedef struct {
-  XdpImplEmail *impl;
+  XdpDbusImplEmail *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -103,10 +103,10 @@ send_response (gpointer data)
 
   g_debug ("send response %d", response);
 
-  xdp_impl_email_complete_compose_email (handle->impl,
-                                         handle->invocation,
-                                         response,
-                                         g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_email_complete_compose_email (handle->impl,
+                                              handle->invocation,
+                                              response,
+                                              g_variant_builder_end (&opt_builder));
 
   handle->timeout = 0;
 
@@ -116,7 +116,7 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               EmailHandle *handle)
 {
@@ -124,17 +124,17 @@ handle_close (XdpImplRequest *object,
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   g_debug ("send response 2");
-  xdp_impl_email_complete_compose_email (handle->impl,
-                                         handle->invocation,
-                                         2,
-                                         g_variant_builder_end (&opt_builder));
+  xdp_dbus_impl_email_complete_compose_email (handle->impl,
+                                              handle->invocation,
+                                              2,
+                                              g_variant_builder_end (&opt_builder));
   email_handle_free (handle);
 
   return FALSE;
 }
 
 static gboolean
-handle_compose_email (XdpImplEmail *object,
+handle_compose_email (XdpDbusImplEmail *object,
                       GDBusMethodInvocation *invocation,
                       const char *arg_handle,
                       const char *arg_app_id,
@@ -196,7 +196,7 @@ email_init (GDBusConnection *bus,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_email_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_email_skeleton_new ());
 
   g_signal_connect (helper, "handle-compose-email", G_CALLBACK (handle_compose_email), NULL);
 

--- a/tests/backend/filechooser.c
+++ b/tests/backend/filechooser.c
@@ -11,7 +11,7 @@
 #include "account.h"
 
 typedef struct {
-  XdpImplFileChooser *impl;
+  XdpDbusImplFileChooser *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -120,15 +120,15 @@ send_response (gpointer data)
   g_debug ("send response %d", response);
 
   if (strcmp (g_dbus_method_invocation_get_method_name (handle->invocation), "OpenFile") == 0)
-    xdp_impl_file_chooser_complete_open_file (handle->impl,
-                                              handle->invocation,
-                                              response,
-                                              g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_file_chooser_complete_open_file (handle->impl,
+                                                   handle->invocation,
+                                                   response,
+                                                   g_variant_builder_end (&opt_builder));
   else
-    xdp_impl_file_chooser_complete_save_file (handle->impl,
-                                              handle->invocation,
-                                              response,
-                                              g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_file_chooser_complete_save_file (handle->impl,
+                                                   handle->invocation,
+                                                   response,
+                                                   g_variant_builder_end (&opt_builder));
 
   handle->timeout = 0;
 
@@ -138,7 +138,7 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               FileChooserHandle *handle)
 {
@@ -147,22 +147,22 @@ handle_close (XdpImplRequest *object,
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   g_debug ("send response 2");
   if (strcmp (g_dbus_method_invocation_get_method_name (handle->invocation), "OpenFile") == 0)
-    xdp_impl_file_chooser_complete_open_file (handle->impl,
-                                              handle->invocation,
-                                              2,
-                                              g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_file_chooser_complete_open_file (handle->impl,
+                                                   handle->invocation,
+                                                   2,
+                                                   g_variant_builder_end (&opt_builder));
   else
-    xdp_impl_file_chooser_complete_save_file (handle->impl,
-                                              handle->invocation,
-                                              2,
-                                              g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_file_chooser_complete_save_file (handle->impl,
+                                                   handle->invocation,
+                                                   2,
+                                                   g_variant_builder_end (&opt_builder));
   file_chooser_handle_free (handle);
 
   return FALSE;
 }
 
 static gboolean
-handle_open_file (XdpImplFileChooser *object,
+handle_open_file (XdpDbusImplFileChooser *object,
                   GDBusMethodInvocation *invocation,
                   const char *arg_handle,
                   const char *arg_app_id,
@@ -226,7 +226,7 @@ file_chooser_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_file_chooser_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_file_chooser_skeleton_new ());
 
   g_signal_connect (helper, "handle-open-file", G_CALLBACK (handle_open_file), NULL);
   g_signal_connect (helper, "handle-save-file", G_CALLBACK (handle_open_file), NULL);

--- a/tests/backend/inhibit.c
+++ b/tests/backend/inhibit.c
@@ -13,7 +13,7 @@
 static GDBusInterfaceSkeleton *inhibit;
 
 typedef struct {
-  XdpImplInhibit *impl;
+  XdpDbusImplInhibit *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -48,7 +48,7 @@ handle_close (Request *object,
   if (object->exported)
     request_unexport (object);
 
-  xdp_impl_request_complete_close (XDP_IMPL_REQUEST (object), invocation);
+  xdp_dbus_impl_request_complete_close (XDP_DBUS_IMPL_REQUEST (object), invocation);
 
   g_debug ("Handling Close");
 
@@ -73,7 +73,7 @@ send_response (gpointer data)
 
   if (response == 0)
     {
-      xdp_impl_inhibit_complete_inhibit (handle->impl, handle->invocation);
+      xdp_dbus_impl_inhibit_complete_inhibit (handle->impl, handle->invocation);
       g_object_set_data (G_OBJECT (handle->request), "handle", NULL);
       handle->request = NULL;
     }
@@ -88,7 +88,7 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_inhibit (XdpImplInhibit *object,
+handle_inhibit (XdpDbusImplInhibit *object,
                 GDBusMethodInvocation *invocation,
                 const char *arg_handle,
                 const char *arg_app_id,
@@ -363,7 +363,7 @@ change_session_state (gpointer data)
 }
 
 static gboolean
-handle_create_monitor (XdpImplInhibit *object,
+handle_create_monitor (XdpDbusImplInhibit *object,
                        GDBusMethodInvocation *invocation,
                        const char *arg_handle,
                        const char *arg_session_handle,
@@ -409,7 +409,7 @@ handle_create_monitor (XdpImplInhibit *object,
     g_timeout_add (delay, change_session_state, g_key_file_ref (keyfile));
 
 out:
-  xdp_impl_inhibit_complete_create_monitor (object, invocation, response);
+  xdp_dbus_impl_inhibit_complete_create_monitor (object, invocation, response);
   if (session)
     emit_state_changed (session);
 
@@ -417,7 +417,7 @@ out:
 }
 
 static gboolean
-handle_query_end_response (XdpImplInhibit *object,
+handle_query_end_response (XdpDbusImplInhibit *object,
                            GDBusMethodInvocation *invocation,
                            const char *arg_session_handle)
 {
@@ -431,7 +431,7 @@ handle_query_end_response (XdpImplInhibit *object,
       maybe_send_quit_response ();
     }
 
-  xdp_impl_inhibit_complete_query_end_response (object, invocation);
+  xdp_dbus_impl_inhibit_complete_query_end_response (object, invocation);
 
   return TRUE;
 }
@@ -442,7 +442,7 @@ inhibit_init (GDBusConnection *connection,
 {
   g_autoptr(GError) error = NULL;
 
-  inhibit = G_DBUS_INTERFACE_SKELETON (xdp_impl_inhibit_skeleton_new ());
+  inhibit = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_inhibit_skeleton_new ());
 
   g_signal_connect (inhibit, "handle-inhibit", G_CALLBACK (handle_inhibit), NULL);
   g_signal_connect (inhibit, "handle-create-monitor", G_CALLBACK (handle_create_monitor), NULL);

--- a/tests/backend/lockdown.c
+++ b/tests/backend/lockdown.c
@@ -27,7 +27,7 @@ lockdown_init (GDBusConnection *bus,
   GDBusInterfaceSkeleton *helper;
   g_autoptr(GError) error = NULL;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_lockdown_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_lockdown_skeleton_new ());
 
   if (!g_dbus_interface_skeleton_export (helper, bus, object_path, &error))
     {

--- a/tests/backend/notification.c
+++ b/tests/backend/notification.c
@@ -9,7 +9,7 @@
 #include "notification.h"
 
 typedef struct {
-  XdpImplNotification *impl;
+  XdpDbusImplNotification *impl;
   char *app_id;
   char *id;
   char *action;
@@ -24,11 +24,11 @@ invoke_action (gpointer data)
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("av"));
 
   g_print ("emitting ActionInvoked\n");
-  xdp_impl_notification_emit_action_invoked (adata->impl,
-                                             adata->app_id,
-                                             adata->id,
-                                             adata->action,
-                                             g_variant_builder_end (&builder));
+  xdp_dbus_impl_notification_emit_action_invoked (adata->impl,
+                                                  adata->app_id,
+                                                  adata->id,
+                                                  adata->action,
+                                                  g_variant_builder_end (&builder));
 
   g_free (adata->app_id);
   g_free (adata->id);
@@ -39,7 +39,7 @@ invoke_action (gpointer data)
 }
 
 static gboolean
-handle_add_notification (XdpImplNotification *object,
+handle_add_notification (XdpDbusImplNotification *object,
                          GDBusMethodInvocation *invocation,
                          const gchar *arg_app_id,
                          const gchar *arg_id,
@@ -80,18 +80,18 @@ handle_add_notification (XdpImplNotification *object,
       g_timeout_add (delay, invoke_action, data);
     }
 
-  xdp_impl_notification_complete_add_notification (object, invocation);
+  xdp_dbus_impl_notification_complete_add_notification (object, invocation);
 
   return TRUE;
 }
 
 static gboolean
-handle_remove_notification (XdpImplNotification *object,
+handle_remove_notification (XdpDbusImplNotification *object,
                             GDBusMethodInvocation *invocation,
                             const gchar *arg_app_id,
                             const gchar *arg_id)
 {
-  xdp_impl_notification_complete_remove_notification (object, invocation);
+  xdp_dbus_impl_notification_complete_remove_notification (object, invocation);
 
   return TRUE;
 }
@@ -103,7 +103,7 @@ notification_init (GDBusConnection *bus,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_notification_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_notification_skeleton_new ());
 
   g_signal_connect (helper, "handle-add-notification", G_CALLBACK (handle_add_notification), NULL);
   g_signal_connect (helper, "handle-remove-notification", G_CALLBACK (handle_remove_notification), NULL);

--- a/tests/backend/print.c
+++ b/tests/backend/print.c
@@ -11,7 +11,7 @@
 #include "print.h"
 
 typedef struct {
-  XdpImplPrint *impl;
+  XdpDbusImplPrint *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -77,16 +77,16 @@ send_response (gpointer data)
   g_debug ("send response %d", response);
  
   if (strcmp (g_dbus_method_invocation_get_method_name (handle->invocation), "Print") == 0)
-    xdp_impl_print_complete_print (handle->impl,
-                                   handle->invocation,
-                                   NULL,
-                                   response,
-                                   g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_print_complete_print (handle->impl,
+                                        handle->invocation,
+                                        NULL,
+                                        response,
+                                        g_variant_builder_end (&opt_builder));
   else
-    xdp_impl_print_complete_prepare_print (handle->impl,
-                                           handle->invocation,
-                                           response,
-                                           g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_print_complete_prepare_print (handle->impl,
+                                                handle->invocation,
+                                                response,
+                                                g_variant_builder_end (&opt_builder));
 
   handle->timeout = 0;
 
@@ -96,7 +96,7 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               PrintHandle *handle)
 {
@@ -105,16 +105,16 @@ handle_close (XdpImplRequest *object,
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   g_debug ("send response 2");
   if (strcmp (g_dbus_method_invocation_get_method_name (handle->invocation), "Print") == 0)
-    xdp_impl_print_complete_print (handle->impl,
-                                   handle->invocation,
-                                   NULL,
-                                   2,
-                                   g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_print_complete_print (handle->impl,
+                                        handle->invocation,
+                                        NULL,
+                                        2,
+                                        g_variant_builder_end (&opt_builder));
   else
-    xdp_impl_print_complete_prepare_print (handle->impl,
-                                           handle->invocation,
-                                           2,
-                                           g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_print_complete_prepare_print (handle->impl,
+                                                handle->invocation,
+                                                2,
+                                                g_variant_builder_end (&opt_builder));
   print_handle_free (handle);
 
   return FALSE;
@@ -122,7 +122,7 @@ handle_close (XdpImplRequest *object,
 
 
 static gboolean
-handle_print (XdpImplPrint *object,
+handle_print (XdpDbusImplPrint *object,
               GDBusMethodInvocation *invocation,
 	      GUnixFDList *fd_list,
               const char *arg_handle,
@@ -180,7 +180,7 @@ handle_print (XdpImplPrint *object,
 }
 
 static gboolean
-handle_prepare_print (XdpImplPrint *object,
+handle_prepare_print (XdpDbusImplPrint *object,
                       GDBusMethodInvocation *invocation,
                       const char *arg_handle,
                       const char *arg_app_id,
@@ -243,7 +243,7 @@ print_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_print_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_print_skeleton_new ());
 
   g_signal_connect (helper, "handle-print", G_CALLBACK (handle_print), NULL);
   g_signal_connect (helper, "handle-prepare-print", G_CALLBACK (handle_prepare_print), NULL);

--- a/tests/backend/request.c
+++ b/tests/backend/request.c
@@ -23,13 +23,14 @@
 
 #include <string.h>
 
-static void request_skeleton_iface_init (XdpImplRequestIface *iface);
+static void request_skeleton_iface_init (XdpDbusImplRequestIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (Request, request, XDP_IMPL_TYPE_REQUEST_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_IMPL_TYPE_REQUEST, request_skeleton_iface_init))
+G_DEFINE_TYPE_WITH_CODE (Request, request, XDP_DBUS_IMPL_TYPE_REQUEST_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_IMPL_TYPE_REQUEST,
+                                                request_skeleton_iface_init))
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation)
 {
   Request *request = (Request *)object;
@@ -37,13 +38,14 @@ handle_close (XdpImplRequest *object,
   if (request->exported)
     request_unexport (request);
 
-  xdp_impl_request_complete_close (XDP_IMPL_REQUEST (request), invocation);
+  xdp_dbus_impl_request_complete_close (XDP_DBUS_IMPL_REQUEST (request),
+                                        invocation);
 
   return TRUE;
 }
 
 static void
-request_skeleton_iface_init (XdpImplRequestIface *iface)
+request_skeleton_iface_init (XdpDbusImplRequestIface *iface)
 {
   iface->handle_close = handle_close;
 }

--- a/tests/backend/request.h
+++ b/tests/backend/request.h
@@ -28,7 +28,7 @@ typedef struct _RequestClass RequestClass;
 
 struct _Request
 {
-  XdpImplRequestSkeleton parent_instance;
+  XdpDbusImplRequestSkeleton parent_instance;
 
   gboolean exported;
   char *sender;
@@ -38,7 +38,7 @@ struct _Request
 
 struct _RequestClass
 {
-  XdpImplRequestSkeletonClass parent_class;
+  XdpDbusImplRequestSkeletonClass parent_class;
 };
 
 GType request_get_type (void) G_GNUC_CONST;

--- a/tests/backend/screenshot.c
+++ b/tests/backend/screenshot.c
@@ -11,7 +11,7 @@
 #include "screenshot.h"
 
 typedef struct {
-  XdpImplScreenshot *impl;
+  XdpDbusImplScreenshot *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -71,15 +71,15 @@ send_response (gpointer data)
   g_debug ("send response %d", response);
 
   if (handle->is_screenshot)
-    xdp_impl_screenshot_complete_screenshot (handle->impl,
-                                             handle->invocation,
-                                             response,
-                                             g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_screenshot_complete_screenshot (handle->impl,
+                                                  handle->invocation,
+                                                  response,
+                                                  g_variant_builder_end (&opt_builder));
   else
-    xdp_impl_screenshot_complete_pick_color (handle->impl,
-                                             handle->invocation,
-                                             response,
-                                             g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_screenshot_complete_pick_color (handle->impl,
+                                                  handle->invocation,
+                                                  response,
+                                                  g_variant_builder_end (&opt_builder));
 
   handle->timeout = 0;
 
@@ -89,7 +89,7 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               ScreenshotHandle *handle)
 {
@@ -98,15 +98,15 @@ handle_close (XdpImplRequest *object,
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   g_debug ("handling Close");
   if (handle->is_screenshot)
-    xdp_impl_screenshot_complete_screenshot (handle->impl,
-                                             handle->invocation,
-                                             2,
-                                             g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_screenshot_complete_screenshot (handle->impl,
+                                                  handle->invocation,
+                                                  2,
+                                                  g_variant_builder_end (&opt_builder));
   else
-    xdp_impl_screenshot_complete_pick_color (handle->impl,
-                                             handle->invocation,
-                                             2,
-                                             g_variant_builder_end (&opt_builder));
+    xdp_dbus_impl_screenshot_complete_pick_color (handle->impl,
+                                                  handle->invocation,
+                                                  2,
+                                                  g_variant_builder_end (&opt_builder));
 
   screenshot_handle_free (handle);
 
@@ -115,7 +115,7 @@ handle_close (XdpImplRequest *object,
 
 
 static gboolean
-handle_screenshot (XdpImplScreenshot *object,
+handle_screenshot (XdpDbusImplScreenshot *object,
                    GDBusMethodInvocation *invocation,
                    const char *arg_handle,
                    const char *arg_app_id,
@@ -180,7 +180,7 @@ screenshot_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_screenshot_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_screenshot_skeleton_new ());
 
   g_signal_connect (helper, "handle-screenshot", G_CALLBACK (handle_screenshot), NULL);
   g_signal_connect (helper, "handle-pick-color", G_CALLBACK (handle_screenshot), NULL);

--- a/tests/backend/session.c
+++ b/tests/backend/session.c
@@ -32,10 +32,10 @@ static GParamSpec *obj_props[PROP_LAST];
 
 static GHashTable *sessions;
 
-static void session_skeleton_iface_init (XdpImplSessionIface *iface);
+static void session_skeleton_iface_init (XdpDbusImplSessionIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (Session, session, XDP_IMPL_TYPE_SESSION_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_IMPL_TYPE_SESSION,
+G_DEFINE_TYPE_WITH_CODE (Session, session, XDP_DBUS_IMPL_TYPE_SESSION_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_IMPL_TYPE_SESSION,
                                                 session_skeleton_iface_init))
 
 #define SESSION_GET_CLASS(o) \
@@ -86,7 +86,7 @@ session_close (Session *session)
 }
 
 static gboolean
-handle_close (XdpImplSession *object,
+handle_close (XdpDbusImplSession *object,
               GDBusMethodInvocation *invocation)
 {
   Session *session = (Session *)object;
@@ -94,13 +94,13 @@ handle_close (XdpImplSession *object,
   if (!session->closed)
     session_close (session);
 
-  xdp_impl_session_complete_close (object, invocation);
+  xdp_dbus_impl_session_complete_close (object, invocation);
 
   return TRUE;
 }
 
 static void
-session_skeleton_iface_init (XdpImplSessionIface *iface)
+session_skeleton_iface_init (XdpDbusImplSessionIface *iface)
 {
   iface->handle_close = handle_close;
 }

--- a/tests/backend/session.h
+++ b/tests/backend/session.h
@@ -25,7 +25,7 @@ typedef struct _SessionClass SessionClass;
 
 struct _Session
 {
-  XdpImplSessionSkeleton parent;
+  XdpDbusImplSessionSkeleton parent;
 
   gboolean exported;
   gboolean closed;
@@ -34,7 +34,7 @@ struct _Session
 
 struct _SessionClass
 {
-  XdpImplSessionSkeletonClass parent_class;
+  XdpDbusImplSessionSkeletonClass parent_class;
 
   void (*close) (Session *session);
 };

--- a/tests/backend/settings.c
+++ b/tests/backend/settings.c
@@ -17,7 +17,7 @@ settings_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_settings_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_settings_skeleton_new ());
 
   if (!g_dbus_interface_skeleton_export (helper, connection, object_path, &error))
     {

--- a/tests/backend/wallpaper.c
+++ b/tests/backend/wallpaper.c
@@ -10,7 +10,7 @@
 #include "wallpaper.h"
 
 typedef struct {
-  XdpImplWallpaper *impl;
+  XdpDbusImplWallpaper *impl;
   GDBusMethodInvocation *invocation;
   Request *request;
   GKeyFile *keyfile;
@@ -62,9 +62,9 @@ send_response (gpointer data)
 
   g_debug ("send response %d", response);
 
-  xdp_impl_wallpaper_complete_set_wallpaper_uri (handle->impl,
-                                                 handle->invocation,
-                                                 response);
+  xdp_dbus_impl_wallpaper_complete_set_wallpaper_uri (handle->impl,
+                                                      handle->invocation,
+                                                      response);
 
   handle->timeout = 0;
 
@@ -74,15 +74,15 @@ send_response (gpointer data)
 }
 
 static gboolean
-handle_close (XdpImplRequest *object,
+handle_close (XdpDbusImplRequest *object,
               GDBusMethodInvocation *invocation,
               WallpaperHandle *handle)
 {
 
   g_debug ("send response 2");
-  xdp_impl_wallpaper_complete_set_wallpaper_uri (handle->impl,
-                                                 handle->invocation,
-                                                 2);
+  xdp_dbus_impl_wallpaper_complete_set_wallpaper_uri (handle->impl,
+                                                      handle->invocation,
+                                                      2);
   wallpaper_handle_free (handle);
 
   return FALSE;
@@ -90,7 +90,7 @@ handle_close (XdpImplRequest *object,
 
 
 static gboolean
-handle_set_wallpaper_uri (XdpImplWallpaper *object,
+handle_set_wallpaper_uri (XdpDbusImplWallpaper *object,
                           GDBusMethodInvocation *invocation,
                           const char *arg_handle,
                           const char *arg_app_id,
@@ -154,7 +154,7 @@ wallpaper_init (GDBusConnection *connection,
   g_autoptr(GError) error = NULL;
   GDBusInterfaceSkeleton *helper;
 
-  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_wallpaper_skeleton_new ());
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_dbus_impl_wallpaper_skeleton_new ());
 
   g_signal_connect (helper, "handle-set-wallpaper-uri", G_CALLBACK (handle_set_wallpaper_uri), NULL);
 

--- a/tests/camera.c
+++ b/tests/camera.c
@@ -12,8 +12,8 @@ extern char outdir[];
 
 static int got_info;
 
-extern XdpImplPermissionStore *permission_store;
-extern XdpImplLockdown *lockdown;
+extern XdpDbusImplPermissionStore *permission_store;
+extern XdpDbusImplLockdown *lockdown;
 
 static void
 set_camera_permissions (const char *permission)
@@ -22,14 +22,14 @@ set_camera_permissions (const char *permission)
   g_autoptr(GError) error = NULL;
 
   permissions[0] = permission;
-  xdp_impl_permission_store_call_set_permission_sync (permission_store,
-                                                      "devices",
-                                                      TRUE,
-                                                      "camera",
-                                                      "",
-                                                      permissions,
-                                                      NULL,
-                                                      &error);
+  xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
+                                                           "devices",
+                                                           TRUE,
+                                                           "camera",
+                                                           "",
+                                                           permissions,
+                                                           NULL,
+                                                           &error);
   g_assert_no_error (error);
 }
 

--- a/tests/filechooser.c
+++ b/tests/filechooser.c
@@ -10,7 +10,7 @@
 
 #include "utils.h"
 
-extern XdpImplLockdown *lockdown;
+extern XdpDbusImplLockdown *lockdown;
 
 extern char outdir[];
 

--- a/tests/inhibit.c
+++ b/tests/inhibit.c
@@ -7,32 +7,32 @@
 
 extern char outdir[];
 
-extern XdpImplPermissionStore *permission_store;
+extern XdpDbusImplPermissionStore *permission_store;
 
 static void
 set_inhibit_permissions (const char **permissions)
 {
   g_autoptr(GError) error = NULL;
 
-  xdp_impl_permission_store_call_set_permission_sync (permission_store,
-                                                      "inhibit",
-                                                      TRUE,
-                                                      "inhibit",
-                                                      "",
-                                                      permissions,
-                                                      NULL,
-                                                      &error);
+  xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
+                                                           "inhibit",
+                                                           TRUE,
+                                                           "inhibit",
+                                                           "",
+                                                           permissions,
+                                                           NULL,
+                                                           &error);
   g_assert_no_error (error);
 }
 
 static void
 unset_inhibit_permissions (void)
 {
-  xdp_impl_permission_store_call_delete_sync (permission_store,
-                                              "inhibit",
-                                              "inhibit",
-                                              NULL,
-                                              NULL);
+  xdp_dbus_impl_permission_store_call_delete_sync (permission_store,
+                                                   "inhibit",
+                                                   "inhibit",
+                                                   NULL,
+                                                   NULL);
   /* Ignore the error here, since this fails if the table doesn't exist */
 }
 

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -8,8 +8,8 @@
 
 #include "utils.h"
 
-extern XdpImplLockdown *lockdown;
-extern XdpImplPermissionStore *permission_store;
+extern XdpDbusImplLockdown *lockdown;
+extern XdpDbusImplPermissionStore *permission_store;
 
 extern char outdir[];
 
@@ -31,31 +31,31 @@ set_openuri_permissions (const char *type,
   permissions[2] = threshold_s;
   permissions[3] = NULL;
 
-  xdp_impl_permission_store_call_delete_sync (permission_store,
-                                              "desktop-used-apps",
-                                              type,
-                                              NULL,
-                                              NULL);
+  xdp_dbus_impl_permission_store_call_delete_sync (permission_store,
+                                                   "desktop-used-apps",
+                                                   type,
+                                                   NULL,
+                                                   NULL);
 
-  xdp_impl_permission_store_call_set_permission_sync (permission_store,
-                                                      "desktop-used-apps",
-                                                      TRUE,
-                                                      type,
-                                                      "",
-                                                      permissions,
-                                                      NULL,
-                                                      &error);
+  xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
+                                                           "desktop-used-apps",
+                                                           TRUE,
+                                                           type,
+                                                           "",
+                                                           permissions,
+                                                           NULL,
+                                                           &error);
   g_assert_no_error (error);
 }
 
 static void
 unset_openuri_permissions (const char *type)
 {
-  xdp_impl_permission_store_call_delete_sync (permission_store,
-                                              "desktop-used-apps",
-                                              type,
-                                              NULL,
-                                              NULL);
+  xdp_dbus_impl_permission_store_call_delete_sync (permission_store,
+                                                   "desktop-used-apps",
+                                                   type,
+                                                   NULL,
+                                                   NULL);
   /* Ignore the error here, since this fails if the table doesn't exist */
 }
 
@@ -67,13 +67,13 @@ enable_paranoid_mode (const char *type)
   /* turn on paranoid mode to ensure we get a backend call */
   g_variant_builder_init (&data_builder, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (&data_builder, "{sv}", "always-ask", g_variant_new_boolean (TRUE));
-  xdp_impl_permission_store_call_set_value_sync (permission_store,
-                                                 "desktop-used-apps",
-                                                 TRUE,
-                                                 type,
-                                                 g_variant_new_variant (g_variant_builder_end (&data_builder)),
-                                                 NULL,
-                                                 NULL);
+  xdp_dbus_impl_permission_store_call_set_value_sync (permission_store,
+                                                      "desktop-used-apps",
+                                                      TRUE,
+                                                      type,
+                                                      g_variant_new_variant (g_variant_builder_end (&data_builder)),
+                                                      NULL,
+                                                      NULL);
 }
 
 static void

--- a/tests/print.c
+++ b/tests/print.c
@@ -8,7 +8,7 @@
 
 #include "utils.h"
 
-extern XdpImplLockdown *lockdown;
+extern XdpDbusImplLockdown *lockdown;
 
 extern char outdir[];
 

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -37,8 +37,8 @@ char outdir[] = "/tmp/xdp-test-XXXXXX";
 static GTestDBus *dbus;
 static GDBusConnection *session_bus;
 static GList *test_procs = NULL;
-XdpImplPermissionStore *permission_store;
-XdpImplLockdown *lockdown;
+XdpDbusImplPermissionStore *permission_store;
+XdpDbusImplLockdown *lockdown;
 
 int
 xdup (int oldfd)
@@ -288,20 +288,20 @@ global_setup (void)
   g_source_remove (name_timeout);
   g_bus_unwatch_name (watch);
 
-  permission_store = xdp_impl_permission_store_proxy_new_sync (session_bus,
-                                                               0,
-                                                               "org.freedesktop.impl.portal.PermissionStore",
-                                                               "/org/freedesktop/impl/portal/PermissionStore",
-                                                               NULL,
-                                                               &error);
+  permission_store = xdp_dbus_impl_permission_store_proxy_new_sync (session_bus,
+                                                                    0,
+                                                                    "org.freedesktop.impl.portal.PermissionStore",
+                                                                    "/org/freedesktop/impl/portal/PermissionStore",
+                                                                    NULL,
+                                                                    &error);
   g_assert_no_error (error);
 
-  lockdown = xdp_impl_lockdown_proxy_new_sync (session_bus,
-                                               0,
-                                               BACKEND_BUS_NAME,
-                                               BACKEND_OBJECT_PATH,
-                                               NULL,
-                                               &error);
+  lockdown = xdp_dbus_impl_lockdown_proxy_new_sync (session_bus,
+                                                    0,
+                                                    BACKEND_BUS_NAME,
+                                                    BACKEND_OBJECT_PATH,
+                                                    NULL,
+                                                    &error);
   g_assert_no_error (error);
 
   /* make sure errors are registered */
@@ -405,18 +405,18 @@ test_##pp##_exists (void) \
  check_pipewire ( #pp ) \
  check_geoclue ( #pp ) \
  \
-  proxy = G_DBUS_PROXY (xdp_##pp##_proxy_new_sync (session_bus, \
-                                                   0, \
-                                                   PORTAL_BUS_NAME, \
-                                                   PORTAL_OBJECT_PATH, \
-                                                   NULL, \
-                                                   &error)); \
+  proxy = G_DBUS_PROXY (xdp_dbus_##pp##_proxy_new_sync (session_bus, \
+                                                        0, \
+                                                        PORTAL_BUS_NAME, \
+                                                        PORTAL_OBJECT_PATH, \
+                                                        NULL, \
+                                                        &error)); \
   g_assert_no_error (error); \
  \
   owner = g_dbus_proxy_get_name_owner (proxy); \
   g_assert_nonnull (owner); \
  \
-  g_assert_cmpuint (xdp_##pp##_get_version (XDP_##PP (proxy)), ==, version); \
+  g_assert_cmpuint (xdp_dbus_##pp##_get_version (XDP_DBUS_##PP (proxy)), ==, version); \
 }
 
 DEFINE_TEST_EXISTS(account, ACCOUNT, 1)

--- a/tests/wallpaper.c
+++ b/tests/wallpaper.c
@@ -9,7 +9,7 @@ extern char outdir[];
 
 static int got_info = 0;
 
-extern XdpImplPermissionStore *permission_store;
+extern XdpDbusImplPermissionStore *permission_store;
 
 static void
 set_wallpaper_permissions (const char *permission)
@@ -18,14 +18,14 @@ set_wallpaper_permissions (const char *permission)
   g_autoptr(GError) error = NULL;
 
   permissions[0] = permission;
-  xdp_impl_permission_store_call_set_permission_sync (permission_store,
-                                                      "wallpaper",
-                                                      TRUE,
-                                                      "wallpaper",
-                                                      "",
-                                                      permissions,
-                                                      NULL,
-                                                      &error);
+  xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
+                                                           "wallpaper",
+                                                           TRUE,
+                                                           "wallpaper",
+                                                           "",
+                                                           permissions,
+                                                           NULL,
+                                                           &error);
   g_assert_no_error (error);
 }
 


### PR DESCRIPTION
Tests compile xdp-dbus.c and xdp-impl-dbus.c, and also link to
libportal. This, as is, isn't possible without symbol conflicts, since
xdp-dbus.c share the same symbol namespace with libportal, meaning it's
not possible to use any types that have the same name, e.g. XdpSession,
as it's likely that the type instance from xdp-dbus.c will be used
instead of the one from libportal.

Fix this by changing the namespace of code generated with gdbus-codegen
to XdpDbus and XdpDbusImpl to avoid these conflicts. The Impl part is
changed too to make things consistent.

------

This was causing issues with tests added by @whot for the input capture portal, where `g_object_new (XDP_TYPE_SESSION, NULL)` failing due to `XDP_TYPE_SESSION` ending up in `xdp_session_get_type()` in `xdp-dbus.c`, instead of the one in libportal.