### PR TITLE
remote-desktop: add the ability to communicate via an EIS socket

### DIFF
--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -351,6 +351,26 @@
       <arg type="u" name="slot" direction="in"/>
     </method>
     <!--
+        ConnectToEIS:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @app_id: App id of the application
+        @options: Vardict with optional further information
+        @fd: A file descriptor to an EIS implementation that can be passed to a
+        sender libei context
+
+        Request a connection to an EIS implementation.
+
+        This method is available in version 2 of this interface.
+    -->
+    <method name="ConnectToEIS">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="h" name="fd" direction="out"/>
+    </method>
+    <!--
         AvailableDeviceTypes:
 
         A bitmask of available source types. Currently defined types are:

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -396,6 +396,37 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="slot" direction="in"/>
     </method>
+
+    <!--
+        ConnectToEIS:
+        @session_handle: Object path for the #org.freedesktop.portal.Session object
+        @options: Vardict with optional further information
+        @fd: A file descriptor to an EIS implementation that can be passed to a libei sender context
+
+        Request a connection to an EIS implementation. The returned handle can
+        be passed to ei_setup_backend_fd() for a libei sender context to
+        complete the connection. All information about available devices and the
+        event flow is subject to libei. Please see the libei documentation for details.
+
+        This method may only be called once per session, where the EIS
+        implementation disconnects the session should be closed.
+
+        This method must be called after #org.freedesktop.portal.RemoteDesktop.Start()
+
+        Once an EIS connection is established, input events must be sent exclusively via
+        the EIS connection. Any events submitted via NotifyPointerMotion,
+        NotifyKeyboardKeycode and other Notify* methods will return an error.
+
+        This method was added in version 2 of this interface.
+    -->
+    <method name="ConnectToEIS">
+      <annotation name="org.gtk.GDBus.C.Name" value="connect_to_eis"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="h" name="fd" direction="out"/>
+    </method>
+
     <!--
         AvailableDeviceTypes:
 

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -774,7 +774,7 @@ handle_notify_pointer_motion (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: pointer");
+                                             "Session is not allowed to call NotifyPointer methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -832,7 +832,7 @@ handle_notify_pointer_motion_absolute (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: pointer");
+                                             "Session is not allowed to call NotifyPointer methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -900,7 +900,7 @@ handle_notify_pointer_button (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: pointer");
+                                             "Session is not allowed to call NotifyPointer methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -963,7 +963,7 @@ handle_notify_pointer_axis (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: pointer");
+                                             "Session is not allowed to call NotifyPointer methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -1021,7 +1021,7 @@ handle_notify_pointer_axis_discrete (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: pointer");
+                                             "Session is not allowed to call NotifyPointer methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -1079,7 +1079,7 @@ handle_notify_keyboard_keycode (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: keyboard");
+                                             "Session is not allowed to call NotifyPointer methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -1137,7 +1137,7 @@ handle_notify_keyboard_keysym (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: keyboard");
+                                             "Session is not allowed to call NotifyKeyboard methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -1197,7 +1197,7 @@ handle_notify_touch_down (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: touchscreen");
+                                             "Session is not allowed to call NotifyTouch methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -1267,7 +1267,7 @@ handle_notify_touch_motion (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: touchscreen");
+                                             "Session is not allowed to call NotifyTouch methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -1334,7 +1334,7 @@ handle_notify_touch_up (XdpDbusRemoteDesktop *object,
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
                                              G_DBUS_ERROR_FAILED,
-                                             "Session doesn't have access to a device of type: touchscreen");
+                                             "Session is not allowed to call NotifyTouch methods");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -28,6 +28,7 @@
 #include "xdp-impl-dbus.h"
 #include "xdp-utils.h"
 
+#include <gio/gunixfdlist.h>
 #include <stdint.h>
 
 typedef struct _RemoteDesktop RemoteDesktop;
@@ -88,6 +89,8 @@ typedef struct _RemoteDesktopSession
   gboolean sources_selected;
 
   gboolean clipboard_enabled;
+
+  gboolean uses_eis;
 } RemoteDesktopSession;
 
 typedef struct _RemoteDesktopSessionClass
@@ -695,7 +698,7 @@ check_notify (Session *session,
 {
   RemoteDesktopSession *remote_desktop_session = (RemoteDesktopSession *)session;
 
-  if (!remote_desktop_session->devices_selected)
+  if (!remote_desktop_session->devices_selected || remote_desktop_session->uses_eis)
     return FALSE;
 
   switch (remote_desktop_session->state)
@@ -1357,6 +1360,105 @@ handle_notify_touch_up (XdpDbusRemoteDesktop *object,
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
+static XdpOptionKey remote_desktop_connect_to_eis_options[] = {
+};
+
+static gboolean
+handle_connect_to_eis (XdpDbusRemoteDesktop *object,
+                       GDBusMethodInvocation *invocation,
+                       GUnixFDList *in_fd_list,
+                       const char *arg_session_handle,
+                       GVariant *arg_options)
+{
+  Call *call = call_from_invocation (invocation);
+  Session *session;
+  RemoteDesktopSession *remote_desktop_session;
+  g_autoptr(GUnixFDList) out_fd_list = NULL;
+  g_autoptr(GError) error = NULL;
+  GVariantBuilder options_builder;
+  GVariant *fd;
+
+  session = acquire_session_from_call (arg_session_handle, call);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid session");
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  SESSION_AUTOLOCK_UNREF (session);
+
+  if (!is_remote_desktop_session (session))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Invalid session");
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  remote_desktop_session = (RemoteDesktopSession *)session;
+
+  if (remote_desktop_session->uses_eis)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Session is already connected");
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  switch (remote_desktop_session->state)
+    {
+    case REMOTE_DESKTOP_SESSION_STATE_STARTED:
+      break;
+    case REMOTE_DESKTOP_SESSION_STATE_INIT:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Session is not ready");
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    case REMOTE_DESKTOP_SESSION_STATE_CLOSED:
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_FAILED,
+                                             "Session is already closed");
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  if (!xdp_filter_options (arg_options, &options_builder,
+                           remote_desktop_connect_to_eis_options,
+                           G_N_ELEMENTS (remote_desktop_connect_to_eis_options),
+                           &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  if (!xdp_dbus_impl_remote_desktop_call_connect_to_eis_sync (impl,
+                                                             arg_session_handle,
+                                                             xdp_app_info_get_id (call->app_info),
+                                                             g_variant_builder_end (&options_builder),
+                                                             in_fd_list,
+                                                             &fd,
+                                                             &out_fd_list,
+                                                             NULL,
+                                                             &error))
+    {
+      g_warning ("Failed to ConnectToEIS: %s", error->message);
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  remote_desktop_session->uses_eis = TRUE;
+
+  xdp_dbus_remote_desktop_complete_connect_to_eis (object, invocation, out_fd_list, fd);
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
 static void
 remote_desktop_iface_init (XdpDbusRemoteDesktopIface *iface)
 {
@@ -1374,6 +1476,8 @@ remote_desktop_iface_init (XdpDbusRemoteDesktopIface *iface)
   iface->handle_notify_touch_down = handle_notify_touch_down;
   iface->handle_notify_touch_motion = handle_notify_touch_motion;
   iface->handle_notify_touch_up = handle_notify_touch_up;
+
+  iface->handle_connect_to_eis = handle_connect_to_eis;
 }
 
 static void

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -121,7 +121,7 @@ method_needs_request (GDBusMethodInvocation *invocation)
     }
   else if (strcmp (interface, "org.freedesktop.portal.RemoteDesktop") == 0)
     {
-      if (strstr (method, "Notify") == method)
+      if (strstr (method, "Notify") == method || strcmp (method, "ConnectToEIS") == 0)
         return FALSE;
       else
         return TRUE;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -297,6 +297,7 @@ if enable_pytest
     pytest,
     args: ['--verbose', '--log-level=DEBUG'],
     suite: ['pytest'],
+    timeout: 60,
   )
 endif
 

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -226,6 +226,6 @@ class TestRemoteDesktop(PortalTest):
                 )
             # Not the best error message but...
             assert (
-                "Session doesn't have access to a device of type"
+                "Session is not allowed to call Notify"
                 in cm.exception.get_dbus_message()
             )

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -7,7 +7,7 @@ from tests import Request, PortalTest, Session
 from gi.repository import GLib
 
 import dbus
-import time
+import socket
 
 
 class TestRemoteDesktop(PortalTest):
@@ -78,3 +78,154 @@ class TestRemoteDesktop(PortalTest):
         mainloop.run()
 
         assert session.closed
+
+    def test_remote_desktop_connect_to_eis(self):
+        self.start_impl_portal()
+        self.start_xdp()
+
+        rd_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "session_handle_token": "session_token0",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+
+        assert response.response == 0
+
+        session = Session.from_response(self.dbus_con, response)
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "types": dbus.UInt32(0x3),
+        }
+        response = request.call(
+            "SelectDevices",
+            session_handle=session.handle,
+            options=options,
+        )
+        assert response.response == 0
+
+        request = Request(self.dbus_con, rd_intf)
+        options = {}
+        response = request.call(
+            "Start",
+            session_handle=session.handle,
+            parent_window="",
+            options=options,
+        )
+        assert response.response == 0
+
+        fd = rd_intf.ConnectToEIS(session.handle, dbus.Dictionary({}, signature="sv"))
+        eis_socket = socket.fromfd(fd.take(), socket.AF_UNIX, socket.SOCK_STREAM)
+        assert eis_socket.recv(10) == b"HELLO"
+
+    def test_remote_desktop_connect_to_eis_fail(self):
+        params = {"fail-connect-to-eis": True}
+        self.start_impl_portal(params=params)
+        self.start_xdp()
+
+        rd_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "session_handle_token": "session_token0",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+
+        assert response.response == 0
+
+        session = Session.from_response(self.dbus_con, response)
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "types": dbus.UInt32(0x3),
+        }
+        response = request.call(
+            "SelectDevices",
+            session_handle=session.handle,
+            options=options,
+        )
+        assert response.response == 0
+
+        request = Request(self.dbus_con, rd_intf)
+        options = {}
+        response = request.call(
+            "Start",
+            session_handle=session.handle,
+            parent_window="",
+            options=options,
+        )
+        assert response.response == 0
+
+        with self.assertRaises(dbus.exceptions.DBusException) as cm:
+            fd = rd_intf.ConnectToEIS(
+                session.handle, dbus.Dictionary({}, signature="sv")
+            )
+        assert "Purposely failing ConnectToEIS" in cm.exception.get_dbus_message()
+
+    def test_remote_desktop_connect_to_eis_fail_notifies(self):
+        self.start_impl_portal()
+        self.start_xdp()
+
+        rd_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "session_handle_token": "session_token0",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+
+        assert response.response == 0
+
+        session = Session.from_response(self.dbus_con, response)
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "types": dbus.UInt32(0x3),
+        }
+        response = request.call(
+            "SelectDevices",
+            session_handle=session.handle,
+            options=options,
+        )
+        assert response.response == 0
+
+        request = Request(self.dbus_con, rd_intf)
+        options = {}
+        response = request.call(
+            "Start",
+            session_handle=session.handle,
+            parent_window="",
+            options=options,
+        )
+        assert response.response == 0
+
+        for notifyfunc in [
+            {"name": "NotifyPointerMotion", "args": (1, 2)},
+            {"name": "NotifyPointerMotionAbsolute", "args": (0, 1, 2)},
+            {"name": "NotifyPointerButton", "args": (1, 1)},
+            {"name": "NotifyPointerAxis", "args": (1, 1)},
+            {"name": "NotifyPointerAxisDiscrete", "args": (1, 1)},
+            {"name": "NotifyKeyboardKeycode", "args": (1, 1)},
+            {"name": "NotifyKeyboardKeysym", "args": (1, 1)},
+            {"name": "NotifyTouchDown", "args": (0, 0, 1, 1)},
+            {"name": "NotifyTouchMotion", "args": (0, 0, 1, 1)},
+            {"name": "NotifyTouchUp", "args": (0,)},
+        ]:
+            with self.assertRaises(dbus.exceptions.DBusException) as cm:
+                func = getattr(rd_intf, notifyfunc["name"])
+                assert func is not None
+                func(
+                    session.handle,
+                    dbus.Dictionary({}, signature="sv"),
+                    *notifyfunc["args"]
+                )
+            # Not the best error message but...
+            assert (
+                "Session doesn't have access to a device of type"
+                in cm.exception.get_dbus_message()
+            )


### PR DESCRIPTION
This is intended as replacement for the `NotifyFoo` methods. libei
provides a more flexible and powerful method of sending input events to
the compositor.

A new method `ConnectToEIS` requests a file descriptor from the compositor
which can then be plugged into libei.

Once established, the communication between compositor and application
is direct, without the need to go through the portal process(es).

To avoid ambiguities between NotifyFoo and input events sent via libei,
any application that uses an EIS connection cannot use the NotifyFoo
methods.

One notable comment: I decided to pass the EIS connection down through the `impl.portal` instead of pipewire's approach of having the portal connect directly. Unlike the single pipewire daemon, an EIS implementation can be provided by multiple processes, so I figured it's easier to pass this down as close as possible to the entity that knows who the EIS implementation 

Eventually (and once libreis is ready) this will have the hooks to auto-set the app-id on the EIS connection as well though strictly speaking it's not necessary since the app-id is passed down to whoever needs to set up the socket anyway.

Noteworthy: there is no keysym event in libei at this point, so there's no equivalent to NotifyKeyboardKeysym

cc @jadahl