### PR TITLE
Add a dbusmock-based Python test suite

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+#
+
+# Shared setup for portal tests. To test a portal, subclass TestPortal with
+# your portal's name (e.g. TestEmail). This will auto-fill your portal
+# name into some of the functions.
+#
+# Make sure you have a dbusmock template for the impl.portal of your portal in
+# tests/templates. See the dbusmock documentation for details on those
+# templates.
+#
+# Environment variables:
+#   XDP_UNINSTALLED: run from $PWD (with an emulation of the glib test behavior)
+#   LIBEXECDIR: run xdg-desktop-portal from that dir, required if
+#               XDP_UNINSTALLED is unset
+#   XDP_DBUS_MONITOR: if set, starts dbus_monitor on the custom bus, useful
+#                     for debugging
+
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+from itertools import count
+from typing import Any, Dict, Optional, NamedTuple
+from pathlib import Path
+
+import dbus
+import dbusmock
+import fcntl
+import logging
+import os
+import subprocess
+import time
+
+DBusGMainLoop(set_as_default=True)
+
+_counter = count()
+
+ASV = Dict[str, Any]
+
+logger = logging.getLogger("tests")
+
+
+class Response(NamedTuple):
+    """
+    Response as returned by a completed :class:`Request`
+    """
+
+    response: int
+    results: ASV
+
+
+class ResponseTimeout(Exception):
+    """
+    Exception raised by :meth:`Request.call` if the Request did not receive a
+    Response in time.
+    """
+
+    pass
+
+
+class Request:
+    """
+    Helper class for executing methods that use Requests. This calls takes
+    care of subscribing to the signals and invokes the method on the
+    interface with the expected behaviors. A typical invocation is:
+
+            >>> response = Request(connection, interface).call("Foo", bar="bar")
+            >>> assert response.response == 0
+
+    Requests can only be used once, to call a second method you must
+    instantiate a new Request object.
+    """
+
+    def __init__(self, bus: dbus.Bus, interface: dbus.Interface):
+        self.interface = interface
+        self.response: Optional[Response] = None
+        self.used = False
+        # GLib makes assertions in callbacks impossible, so we wrap all
+        # callbacks into a try: except and store the error on the request to
+        # be raised later when we're back in the main context
+        self.error = None
+
+        self._handle_token = f"request{next(_counter)}"
+        self._mainloop: Optional[GLib.MainLoop] = None
+        self._close_after_ms = 0
+        self._closed = False
+        self._impl_request_closed = False
+        self._bus = bus
+
+        def sanitize(name):
+            return name.lstrip(":").replace(".", "_")
+
+        sender_token = sanitize(bus.get_unique_name())
+        self.handle = f"/org/freedesktop/portal/desktop/request/{sender_token}/{self._handle_token}"
+        proxy = bus.get_object("org.freedesktop.portal.Desktop", self.handle)
+        self.mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
+        self._proxy = bus.get_object("org.freedesktop.portal.Desktop", self.handle)
+
+        def cb_response(response: int, results: ASV) -> None:
+            try:
+                logger.debug(f"Response received on {self.handle}")
+                assert not self._closed
+                self.response = Response(response, results)
+                if self._mainloop:
+                    self._mainloop.quit()
+            except Exception as e:
+                self.error = e
+
+        self.request_interface = dbus.Interface(proxy, "org.freedesktop.portal.Request")
+        self.request_interface.connect_to_signal("Response", cb_response)
+
+    @property
+    def closed(self) -> bool:
+        """
+        True if both this request and the impl.Request were closed
+        """
+        return self._closed and self._impl_request_closed
+
+    def close(self) -> None:
+        signal_match = None
+
+        def cb_impl_request_closed_by_portal(handle) -> None:
+            if handle == self.handle:
+                logger.debug(f"ImplRequest {self.handle} was closed")
+                signal_match.remove()  # type: ignore
+                self._impl_request_closed = True
+                if self.closed and self._mainloop:
+                    self._mainloop.quit()
+
+        # See :class:`ImplRequest`, this signal is a side-channel for the
+        # impl.portal template to notify us when the impl.Request was really
+        # closed by the portal.
+        signal_match = self._bus.add_signal_receiver(
+            cb_impl_request_closed_by_portal,
+            "RequestClosed",
+            dbus_interface="org.freedesktop.impl.portal.Test",
+        )
+
+        logger.debug(f"Closing request {self.handle}")
+        self._closed = True
+        self.request_interface.Close()
+
+    @property
+    def handle_token(self) -> dbus.String:
+        """
+        Returns the dbus-ready handle_token, ready to be put into the options
+        """
+        return dbus.String(self._handle_token, variant_level=1)
+
+    def call(self, methodname: str, **kwargs) -> Optional[Response]:
+        """
+        Semi-synchronously call method ``methodname`` on the interface given
+        in the Request's constructor. The kwargs must be specified in the
+        order the DBus method takes them but the handle_token is automatically
+        filled in.
+
+            >>> response = Request(connection, interface).call("Foo", bar="bar")
+            >>> if response.response != 0:
+            ...     print("some error occured")
+
+        The DBus call itself is asynchronous (required for signals to work)
+        but this method does not return until the Response is received, the
+        Request is closed or an error occurs. If the Request is closed, the
+        Response is None.
+
+        If the "reply_handler" and "error_handler" keywords are present, those
+        callbacks are called just like they would be as dbus.service.ProxyObject.
+        """
+        assert not self.used
+        self.used = True
+
+        # Anything that takes longer than 5s needs to fail
+        MAX_TIMEOUT = 5000
+
+        # Make sure options exists and has the handle_token set
+        try:
+            options = kwargs["options"]
+        except KeyError:
+            options = dbus.Dictionary({}, signature="sv")
+
+        if "handle_token" not in options:
+            options["handle_token"] = self.handle_token
+
+        # Anything that takes longer than 5s needs to fail
+        self._mainloop = GLib.MainLoop()
+        GLib.timeout_add(MAX_TIMEOUT, self._mainloop.quit)
+
+        if self._close_after_ms > 0:
+            assert (
+                self._close_after_ms < MAX_TIMEOUT
+            ), "Cannot schedule Close() after the request timeout"
+            GLib.timeout_add(self._close_after_ms, self.close)
+
+        method = getattr(self.interface, methodname)
+        assert method
+
+        reply_handler = kwargs.pop("reply_handler", None)
+        error_handler = kwargs.pop("error_handler", None)
+
+        # Handle the normal method reply which returns is the Request object
+        # path. We don't exit the mainloop here, we're waiting for either the
+        # Response signal on the Request itself or the Close() handling
+        def reply_cb(handle):
+            try:
+                logger.debug(f"Reply to {methodname} with {self.handle}")
+                assert handle == self.handle
+
+                if reply_handler:
+                    reply_handler(handle)
+            except Exception as e:
+                self.error = e
+
+        # Handle any exceptions during the actual method call (not the Request
+        # handling itself). Can exit the mainloop if that happens
+        def error_cb(error):
+            try:
+                logger.debug(f"Error after {methodname} with {error}")
+                if error_handler:
+                    error_handler(error)
+                self.error = error
+            except Exception as e:
+                self.error = e
+            finally:
+                if self._mainloop:
+                    self._mainloop.quit()
+
+        # Method is invoked async, otherwise we can't mix and match signals
+        # and other calls. It's still sync as seen by the caller in that we
+        # have a mainloop that waits for us to finish though.
+        method(
+            *list(kwargs.values()),
+            reply_handler=reply_cb,
+            error_handler=error_cb,
+        )
+
+        self._mainloop.run()
+
+        if self.error:
+            raise self.error
+        elif not self.closed and self.response is None:
+            raise ResponseTimeout(f"Timed out waiting for response from {methodname}")
+
+        return self.response
+
+    def schedule_close(self, timeout_ms=300):
+        """
+        Schedule an automatic Close() on the Request after the given timeout
+        in milliseconds.
+        """
+        assert timeout_ms > 0
+        self._close_after_ms = timeout_ms
+
+
+class PortalTest(dbusmock.DBusTestCase):
+    """
+    Parent class for portal tests.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        logging.basicConfig(
+            format="%(levelname).1s|%(name)s: %(message)s", level=logging.DEBUG
+        )
+        cls.PORTAL_NAME = cls.__name__.removeprefix("Test")
+        cls.INTERFACE_NAME = f"org.freedesktop.portal.{cls.PORTAL_NAME}"
+        cls.start_session_bus()
+        cls.dbus_con = cls.get_dbus(system_bus=False)
+        assert cls.dbus_con
+
+    def setUp(self):
+        self.p_mock = None
+        self.xdp = None
+        self.portal_interfaces = {}
+        self.dbus_monitor = None
+
+    def start_impl_portal(self, params=None, portal=None):
+        """
+        Start the impl.portal for the given portal name. If missing,
+        the portal name is derived from the class name of the test, e.g.
+        ``TestFoo`` will start ``org.freedesktop.impl.portal.Foo``.
+        """
+        portal = portal or self.PORTAL_NAME
+        self.p_mock, self.obj_portal = self.spawn_server_template(
+            template=f"tests/templates/{portal.lower()}.py",
+            parameters=params,
+            stdout=subprocess.PIPE,
+        )
+        flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
+        fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        self.mock_interface = dbus.Interface(self.obj_portal, dbusmock.MOCK_IFACE)
+
+        self.start_dbus_monitor()
+
+    def start_xdp(self):
+        """
+        Start the xdg-desktop-portal process
+        """
+
+        # This roughly resembles test-portals.c and glib's test behavior
+        if os.getenv("XDP_UNINSTALLED", None):
+            builddir = Path(os.getenv("G_TEST_BUILDDIR") or "tests") / ".."
+        else:
+            builddir = os.getenv("LIBEXECDIR")
+            if not builddir:
+                raise NotImplementedError("LIBEXECDIR is not set")
+
+        distdir = os.getenv("G_TEST_SRCDIR") or "tests"
+        portal_dir = Path(distdir) / "portals"
+
+        argv = [Path(builddir) / "xdg-desktop-portal"]
+        env = os.environ.copy()
+        env["G_DEBUG"] = "fatal-criticals"
+        env["XDG_DESKTOP_PORTAL_DIR"] = portal_dir
+
+        xdp = subprocess.Popen(argv, env=env)
+
+        for _ in range(500):
+            if self.dbus_con.name_has_owner("org.freedesktop.portal.Desktop"):
+                break
+            time.sleep(0.1)
+        else:
+            self.fail("Timeout while waiting for xdg-desktop-portal to claim the bus")
+
+        self.xdp = xdp
+
+    def start_dbus_monitor(self):
+        if not os.getenv("XDP_DBUS_MONITOR"):
+            return
+
+        argv = ["dbus-monitor", "--session"]
+        self.dbus_monitor = subprocess.Popen(argv)
+
+    def tearDown(self):
+        if self.dbus_monitor:
+            self.dbus_monitor.terminate()
+            self.dbus_monitor.wait()
+
+        if self.xdp:
+            self.xdp.terminate()
+            self.xdp.wait()
+
+        if self.p_mock:
+            if self.p_mock.stdout:
+                out = (self.p_mock.stdout.read() or b"").decode("utf-8")
+                if out:
+                    print(out)
+                self.p_mock.stdout.close()
+            self.p_mock.terminate()
+            self.p_mock.wait()
+
+    def get_xdp_dbus_object(self) -> dbus.proxies.ProxyObject:
+        """
+        Return the object that is the org.freedesktop.portal.Desktop proxy
+        """
+        try:
+            return self._xdp_dbus_object
+        except AttributeError:
+            obj = self.dbus_con.get_object(
+                "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop"
+            )
+            # Useful for debugging:
+            # print(obj.Introspect(dbus_interface="org.freedesktop.DBus.Introspectable"))
+            assert obj
+            self._xdp_dbus_object: dbus.proxies.ProxyObject = obj
+            return self._xdp_dbus_object
+
+    def get_dbus_interface(self, name=None) -> dbus.Interface:
+        """
+        Return the interface with the given name.
+
+            >>> my_portal_intf = self.get_dbus_interface()
+            >>> rd_portal_intf = self.get_dbus_interface("RemoteDesktop")
+            >>> dbus_intf = self.get_dbus_interface("org.freedesktop.DBus.Introspectable")
+
+        For portals, it's enough to specify the portal name (e.g. "InputCapture").
+        If no name is provided, guess from the test class name.
+        """
+        name = name or self.INTERFACE_NAME
+        if "." not in name:
+            name = f"org.freedesktop.portal.{name}"
+
+        try:
+            intf = self.portal_interfaces[name]
+        except KeyError:
+            intf = dbus.Interface(self.get_xdp_dbus_object(), name)
+            assert intf
+            self.portal_interfaces[name] = intf
+        return intf
+
+    def check_version(self, expected_version):
+        """
+        Helper function to check for a portal's version. Use as:
+
+            >>> class TestFoo(PortalTest):
+            ...     def test_version(self):
+            ...         self.check_version(2)
+            >>>
+        """
+        self.start_xdp()
+        properties_intf = self.get_dbus_interface("org.freedesktop.DBus.Properties")
+        portal_version = properties_intf.Get(self.INTERFACE_NAME, "version")
+        assert int(portal_version) == expected_version

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -199,6 +199,28 @@ test(
   protocol: 'tap',
 )
 
+pytest = find_program('pytest-3', 'pytest', required: false)
+pymod = import('python')
+python = pymod.find_installation(
+  'python3',
+  modules: ['dbus', 'dbusmock', 'gi'],
+  required: false,
+)
+
+if pytest.found() and python.found()
+  test_env = environment()
+  test_env.set('XDP_UNINSTALLED', '1')
+
+  test(
+    'pytest',
+    pytest,
+    args: ['--verbose', '--log-level=DEBUG'],
+    env: test_env,
+    workdir: meson.project_source_root(),
+    suite: ['pytest'],
+  )
+endif
+
 if enable_installed_tests
   # autotools used to symlink to the host files, here we just install our version
   install_data(

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+from typing import Callable, Dict, Optional, NamedTuple
+import dbus
+import dbusmock
+import logging
+
+logger: Optional[logging.Logger] = None
+
+
+class Response(NamedTuple):
+    response: int
+    results: Dict
+
+
+class ImplRequest:
+    """
+    Implementation of a org.freedesktop.impl.portal.Request object. Typically
+    this object needs to be merely exported:
+
+        >>> r = ImplRequest(mock, "org.freedesktop.impl.portal.Test", handle)
+        >>> r.export()
+
+    Where the test or the backend implementation relies on the Closed() method
+    of the ImplRequest, provide a callback to be invoked.
+
+        >>> r.export(close_callback=my_callback)
+
+    Note that the latter only works if the test invokes methods
+    asynchronously.
+
+    .. attribute:: closed
+
+        Set to True if the Close() method on the Request was invoked
+
+    """
+
+    def __init__(self, mock: "dbusmock.DBusMockObject", busname: str, handle: str):
+        self.mock = mock
+        self.handle = handle
+        self.closed = False
+        self._close_callback: Optional[Callable] = None
+
+        bus = mock.connection
+        proxy = bus.get_object(busname, handle)
+        intf = dbus.Interface(proxy, "org.freedesktop.impl.portal.Request")
+        self.proxy = proxy
+        mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
+
+        # Register for the Close() call on the impl.Request. If it gets
+        # called, use the side-channel RequestClosed signal so we can notify
+        # the test that the impl.Request was actually closed by the
+        # xdg-desktop-portal
+        def cb_methodcall(name, args):
+            if name == "Close":
+                self.closed = True
+                logger.debug(f"Close() on {self}")
+                if self._close_callback:
+                    self._close_callback()
+                self.mock.EmitSignal(
+                    "org.freedesktop.impl.portal.Test",
+                    "RequestClosed",
+                    "s",
+                    (self.handle,),
+                )
+                self.mock.RemoveObject(self.handle)
+
+        mock_interface.connect_to_signal("MethodCalled", cb_methodcall)
+
+    def export(self, close_callback: Callable = None):
+        """
+        Create the object on the bus. If close_callback is not None, that
+        callback will be invoked in response to the Close() method called on
+        this object.
+        """
+        self.mock.AddObject(
+            path=self.handle,
+            interface="org.freedesktop.impl.portal.Request",
+            properties={},
+            methods=[
+                (
+                    "Close",
+                    "",
+                    "",
+                    "",
+                )
+            ],
+        )
+        self._close_callback = close_callback
+
+    def __str__(self):
+        return f"ImplRequest {self.handle}"
+
+
+def init_template_logger(name: str):
+    """
+    Common logging setup for the impl.portal templates. Use as:
+
+        >>> from tests.templates import init_template_logger
+        >>> logger = init_template_logger(__name__)
+        >>> logger.debug("foo")
+
+    """
+    logging.basicConfig(
+        format="%(levelname).1s|%(name)s: %(message)s", level=logging.DEBUG
+    )
+    logger = logging.getLogger(f"templates.{name}")
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+logger = init_template_logger("request")

--- a/tests/templates/email.py
+++ b/tests/templates/email.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+from tests.templates import Response, init_template_logger, ImplRequest
+import dbus.service
+
+from gi.repository import GLib
+
+
+BUS_NAME = "org.freedesktop.impl.portal.Test"
+MAIN_OBJ = "/org/freedesktop/portal/desktop"
+SYSTEM_BUS = False
+MAIN_IFACE = "org.freedesktop.impl.portal.Email"
+VERSION = 3
+
+
+logger = init_template_logger(__name__)
+
+
+def load(mock, parameters=None):
+    logger.debug(f"Loading parameters: {parameters}")
+
+    mock.delay: int = parameters.get("delay", 200)
+    mock.response: int = parameters.get("response", 0)
+    mock.expect_close: bool = parameters.get("expect-close", False)
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary(
+            {
+                "version": dbus.UInt32(parameters.get("version", VERSION)),
+            }
+        ),
+    )
+
+
+@dbus.service.method(
+    MAIN_IFACE,
+    in_signature="ossa{sv}",
+    out_signature="ua{sv}",
+    async_callbacks=("cb_success", "cb_error"),
+)
+def ComposeEmail(self, handle, app_id, parent_window, options, cb_success, cb_error):
+    try:
+        logger.debug(f"ComposeEmail({handle}, {app_id}, {parent_window}, {options})")
+
+        response = Response(self.response, {})
+
+        request = ImplRequest(self, BUS_NAME, handle)
+
+        if self.expect_close:
+
+            def closed_callback():
+                response = Response(2, {})
+                logger.debug(f"ComposeEmail Close() response {response}")
+                cb_success(response.response, response.results)
+
+            request.export(closed_callback)
+        else:
+            request.export()
+
+            def reply():
+                logger.debug(f"ComposeEmail with response {response}")
+                cb_success(response.response, response.results)
+
+            logger.debug(f"scheduling delay of {self.delay}")
+            GLib.timeout_add(self.delay, reply)
+    except Exception as e:
+        logger.critical(e)
+        cb_error(e)

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+
+from tests import Request, PortalTest
+from gi.repository import GLib
+
+import dbus
+import time
+
+
+class TestEmail(PortalTest):
+    def test_version(self):
+        self.check_version(3)
+
+    def test_email_basic(self):
+        self.start_impl_portal()
+        self.start_xdp()
+
+        addresses = ["mclasen@redhat.com"]
+        subject = "Re: portal tests"
+        body = "You have to see this"
+
+        email_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, email_intf)
+        options = {
+            "addresses": addresses,
+            "subject": subject,
+            "body": body,
+        }
+        response = request.call(
+            "ComposeEmail",
+            parent_window="",
+            options=options,
+        )
+
+        assert response.response == 0
+
+        # Check the impl portal was called with the right args
+        method_calls = self.mock_interface.GetMethodCalls("ComposeEmail")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert args[2] == ""  # parent window
+        assert args[3]["addresses"] == addresses
+        assert args[3]["subject"] == subject
+        assert args[3]["body"] == body
+
+    def test_email_address(self):
+        """test that an invalid address triggers an error"""
+
+        self.start_impl_portal()
+        self.start_xdp()
+
+        addresses = ["gibberish! not an email address\n%Q"]
+
+        email_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, email_intf)
+        options = {
+            "addresses": addresses,
+        }
+        try:
+            request.call(
+                "ComposeEmail",
+                parent_window="",
+                options=options,
+            )
+
+            self.fail("This statement should not be reached")
+        except dbus.exceptions.DBusException as e:
+            assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
+
+        # Check the impl portal was never called
+        method_calls = self.mock_interface.GetMethodCalls("ComposeEmail")
+        assert len(method_calls) == 0
+
+    def test_email_subject_multiline(self):
+        """test that an multiline subject triggers an error"""
+
+        self.start_impl_portal()
+        self.start_xdp()
+
+        subject = "not\na\nvalid\nsubject line"
+
+        email_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, email_intf)
+        options = {
+            "subject": subject,
+        }
+        try:
+            request.call(
+                "ComposeEmail",
+                parent_window="",
+                options=options,
+            )
+
+            self.fail("This statement should not be reached")
+        except dbus.exceptions.DBusException as e:
+            assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
+
+        # Check the impl portal was never called
+        method_calls = self.mock_interface.GetMethodCalls("ComposeEmail")
+        assert len(method_calls) == 0
+
+    def test_email_subject_too_long(self):
+        """test that a subject line over 200 chars triggers an error"""
+
+        self.start_impl_portal()
+        self.start_xdp()
+
+        subject = "This subject line is too long" + "abc" * 60
+
+        assert len(subject) > 200
+
+        email_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, email_intf)
+        options = {
+            "subject": subject,
+        }
+        try:
+            request.call(
+                "ComposeEmail",
+                parent_window="",
+                options=options,
+            )
+
+            self.fail("This statement should not be reached")
+        except dbus.exceptions.DBusException as e:
+            assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
+
+        # Check the impl portal was never called
+        method_calls = self.mock_interface.GetMethodCalls("ComposeEmail")
+        assert len(method_calls) == 0
+
+    def test_email_delay(self):
+        """
+        Test that everything works as expected when the backend takes some
+        time to send its response, as * is to be expected from a real backend
+        that presents dialogs to the user.
+        """
+
+        params = {"delay": 2000}
+
+        self.start_impl_portal(params)
+        self.start_xdp()
+
+        subject = "delay test"
+        addresses = ["mclasen@redhat.com"]
+
+        email_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, email_intf)
+        options = {
+            "addresses": addresses,
+            "subject": subject,
+        }
+
+        start_time = time.perf_counter()
+
+        response = request.call(
+            "ComposeEmail",
+            parent_window="",
+            options=options,
+        )
+
+        assert response.response == 0
+
+        end_time = time.perf_counter()
+
+        assert end_time - start_time > 2
+
+        # Check the impl portal was called with the right args
+        method_calls = self.mock_interface.GetMethodCalls("ComposeEmail")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert args[2] == ""  # parent window
+        assert args[3]["addresses"] == addresses
+        assert args[3]["subject"] == subject
+
+    def test_email_cancel(self):
+        """
+        Test that user cancellation works as expected.
+        We simulate that the user cancels a hypothetical dialog,
+        by telling the backend to return 1 as response code.
+        And we check that we get the expected G_IO_ERROR_CANCELLED.
+        """
+
+        params = {"response": 1}
+
+        self.start_impl_portal(params)
+        self.start_xdp()
+
+        subject = "cancel test"
+        addresses = ["mclasen@redhat.com"]
+
+        email_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, email_intf)
+        options = {
+            "addresses": addresses,
+            "subject": subject,
+        }
+
+        response = request.call(
+            "ComposeEmail",
+            parent_window="",
+            options=options,
+        )
+
+        assert response.response == 1
+
+        # Check the impl portal was called with the right args
+        method_calls = self.mock_interface.GetMethodCalls("ComposeEmail")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert args[2] == ""  # parent window
+        assert args[3]["addresses"] == addresses
+        assert args[3]["subject"] == subject
+
+    def test_email_close(self):
+        """
+        Test that app-side cancellation works as expected.
+        We cancel the cancellable while while the hypothetical
+        dialog is up, and tell the backend that it should
+        expect a Close call. We rely on the backend to
+        verify that that call actually happened.
+        """
+
+        params = {"expect-close": True}
+
+        self.start_impl_portal(params)
+        self.start_xdp()
+
+        subject = "close test"
+        addresses = ["mclasen@redhat.com"]
+
+        email_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, email_intf)
+        request.schedule_close(1000)
+        options = {
+            "addresses": addresses,
+            "subject": subject,
+        }
+
+        request.call(
+            "ComposeEmail",
+            parent_window="",
+            options=options,
+        )
+
+        # Only true if the impl.Request was closed too
+        assert request.closed
+
+        # Check the impl portal was called with the right args
+        method_calls = self.mock_interface.GetMethodCalls("ComposeEmail")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert args[2] == ""  # parent window
+        assert args[3]["addresses"] == addresses
+        assert args[3]["subject"] == subject

--- a/tests/test_trash.py
+++ b/tests/test_trash.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+
+from tests import PortalTest
+from pathlib import Path
+
+import dbus
+import os
+import time
+import tempfile
+
+
+class TestTrash(PortalTest):
+    def test_version(self):
+        self.check_version(1)
+
+    def test_trash_file_fails(self):
+        self.start_xdp()
+
+        trash_intf = self.get_dbus_interface()
+        with open("/proc/cmdline") as fd:
+            result = trash_intf.TrashFile(fd.fileno())
+
+        assert result == 0
+
+    def test_trash_file(self):
+        self.start_xdp()
+
+        trash_intf = self.get_dbus_interface()
+
+        fd, name = tempfile.mkstemp(prefix="trash_portal_test_", dir=Path.home())
+        result = trash_intf.TrashFile(fd)
+        if result != 1:
+            os.unlink(name)
+        assert result == 1
+        assert not Path(name).exists()


### PR DESCRIPTION
For complex portals like the InputCapture portal, the current test suite
is difficult to use and adapt. A much simpler approach is to use
dbusmock to provide the impl.portal emulation, use Python to poke at the
actual DBus API of the portal and have xdg-desktop-portal sit in
between to negotiate the two.

This patch adds a test suite that provides enough infrastructure to add
tests for other portals in a similar manner - luckily the impl side is
relatively trivial to implement in dbusmock.

Currently implemented are the equivalents to the tests/email.c and
tests/trash.c tests. The email tests is missing the test for parallel
ComposeEmail calls though.

Easiest invoked via pytest, one of XDP_UNINSTALLED or LIBEXECDIR must be
set to run from the git tree or using the installed xdg-desktop-portal,
respectively.

Fixes #761