### PR TITLE
DynamicLauncher: Clarify confusing short description

### DIFF
--- a/data/org.freedesktop.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.portal.DynamicLauncher.xml
@@ -21,7 +21,7 @@
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <!--
       org.freedesktop.portal.DynamicLauncher:
-      @short_description: Portal for installing application launchers onto the desktop
+      @short_description: Portal for installing application launchers
 
       The DynamicLauncher portal allows sandboxed (or unsandboxed) applications
       to install launchers (.desktop files) which have an icon associated with them


### PR DESCRIPTION
Launchers are installed into the desktop environment's menu, not to the
desktop.

Fixes #755