### PR TITLE
Disable GSlice

### DIFF
--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -380,6 +380,11 @@ main (int argc, char *argv[])
   /* Avoid even loading gvfs to avoid accidental confusion */
   g_setenv ("GIO_USE_VFS", "local", TRUE);
 
+  /* GSlice is crashy, disable it. See
+   * https://github.com/flatpak/xdg-desktop-portal/issues/771
+   */
+  g_setenv ("G_SLICE", "always-malloc", TRUE);
+
   /* Avoid pointless and confusing recursion */
   g_unsetenv ("GTK_USE_PORTAL");
 


### PR DESCRIPTION
(Warning: this was only compile-tested)

GSlice is practically unmaintained, and these days various malloc
implementations have caught up to GSlice. There have been reports of
GSlice crashing on multithreaded setups for many years now too [1].

Having the allocator crash an app is already really bad, but crashing
a critical user session service like xdg-desktop-portal is even worse,
since it provides important funcionality for a desktop environment to
work.

Force the GSlice allocator to always use malloc internally.

Closes https://github.com/flatpak/xdg-desktop-portal/issues/771

[1] https://gitlab.gnome.org/GNOME/glib/-/issues/1079