### PR TITLE
notification: Add platform-data (with activation_token) to ActionInvoked

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,13 +71,21 @@ jobs:
           libglib2.0-dev \
           libjson-glib-dev \
           libpipewire-0.3-dev \
-          libportal-dev \
           libsystemd-dev \
           libtool \
           llvm \
           make \
           python3-gi \
           shared-mime-info
+
+    - name: Install libportal
+      run: |
+        git clone https://github.com/3v1n0/libportal.git -b activation-token
+        $RUN_CMD apt-get install -y --no-install-recommends meson
+        $RUN_CMD env -u CFLAGS meson libportal libportal/_build --prefix=/usr --libdir=lib \
+          $meson_options -Dbackends=[] -Dintrospection=false -Dvapi=false -Ddocs=false
+        $RUN_CMD ninja -C libportal/_build install
+        $RUN_CMD rm -rf libportal
 
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v2
@@ -181,7 +189,6 @@ jobs:
           libglib2.0-dev \
           libjson-glib-dev \
           libpipewire-0.3-dev \
-          libportal-dev \
           libsystemd-dev \
           libtool \
           llvm \
@@ -192,6 +199,15 @@ jobs:
 
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v2
+
+    - name: Install libportal
+      run: |
+        $RUN_CMD apt-get install -y --no-install-recommends meson git
+        $RUN_CMD git clone https://github.com/3v1n0/libportal.git -b activation-token
+        $RUN_CMD env -u CFLAGS meson libportal libportal/_build --prefix=/usr --libdir=lib \
+          $meson_options -Dbackends=[] -Dintrospection=false -Dvapi=false -Ddocs=false
+        $RUN_CMD ninja -C libportal/_build install
+        $RUN_CMD rm -rf libportal
 
     - name: Setup test user
       run: |
@@ -287,3 +303,4 @@ jobs:
 
     - name: Build xdg-desktop-portal
       run: make -j $(getconf _NPROCESSORS_ONLN)
+

--- a/data/org.freedesktop.impl.portal.Notification.xml
+++ b/data/org.freedesktop.impl.portal.Notification.xml
@@ -77,5 +77,43 @@
       <arg type="s" name="action"/>
       <arg type="av" name="parameter"/>
     </signal>
+
+  <!--
+        ActionInvoked2:
+        @app_id: App id of the application
+        @id: the application-provided ID for the notification
+        @action: the name of the action
+        @platform_data: array which will contain the platform data
+          such as desktop-startup-id.
+        @parameter: array which will contain the target parameter
+          for the action, if one was specified
+
+        Send to the application when a non-exported action is
+        activated.
+
+        Supported keys in the @platform_data vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>activation_token s</term>
+            <listitem>
+              <para>
+              A token that can be used to activate windows or applications
+              when action is invoked.
+              </para>
+              <para>
+              This can be either an X11-style startup ID or a Wayland
+              xdg-activation token.
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <signal name="ActionInvoked2">
+      <arg type="s" name="app_id"/>
+      <arg type="s" name="id"/>
+      <arg type="s" name="action"/>
+      <arg type="a{sv}" name="platform_data"/>
+      <arg type="av" name="parameter"/>
+    </signal>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -167,6 +167,42 @@
       <arg type="s" name="action"/>
       <arg type="av" name="parameter"/>
     </signal>
+
+    <!--
+        ActionInvoked2:
+        @id: the application-provided ID for the notification
+        @action: the name of the action
+        @platform_data: array which will contain the platform data
+          such as desktop-startup-id.
+        @parameter: array which will contain the target parameter
+          for the action, if one was specified
+
+        Send to the application when a non-exported action is
+        activated.
+
+        Supported keys in the @platform_data vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>activation_token s</term>
+            <listitem>
+              <para>
+              A token that can be used to activate windows or applications
+              when action is invoked.
+              </para>
+              <para>
+              This can be either an X11-style startup ID or a Wayland
+              xdg-activation token.
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+    -->
+    <signal name="ActionInvoked2">
+      <arg type="s" name="id"/>
+      <arg type="s" name="action"/>
+      <arg type="a{sv}" name="platform_data"/>
+      <arg type="av" name="parameter"/>
+    </signal>
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,7 +6,7 @@ portal_built_sources = gnome.gdbus_codegen(
   interface_prefix: 'org.freedesktop.portal',
   namespace: 'XdpDbus',
   docbook: 'portal',
-  autocleanup: 'none',
+  autocleanup: 'objects',
 )
 impl_built_sources = gnome.gdbus_codegen(
   'xdp-impl-dbus',
@@ -14,7 +14,7 @@ impl_built_sources = gnome.gdbus_codegen(
   interface_prefix: 'org.freedesktop.impl.portal',
   namespace: 'XdpDbusImpl',
   docbook: 'portal',
-  autocleanup: 'none',
+  autocleanup: 'objects',
 )
 if have_geoclue
   geoclue_built_sources = gnome.gdbus_codegen(
@@ -22,7 +22,7 @@ if have_geoclue
     sources: 'org.freedesktop.GeoClue2.Client.xml',
     interface_prefix: 'org.freedesktop.GeoClue2',
     namespace: 'Geoclue',
-    autocleanup: 'none',
+    autocleanup: 'objects',
   )
 else
   geoclue_built_sources = []

--- a/tests/backend/notification.c
+++ b/tests/backend/notification.c
@@ -13,6 +13,7 @@ typedef struct {
   char *app_id;
   char *id;
   char *action;
+  gint force_version;
   GVariant *platform_data;
 } ActionData;
 
@@ -24,13 +25,25 @@ invoke_action (gpointer data)
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("av"));
 
-  g_message ("emitting ActionInvoked2");
-  xdp_dbus_impl_notification_emit_action_invoked2 (adata->impl,
-                                                   adata->app_id,
-                                                   adata->id,
-                                                   adata->action,
-                                                   adata->platform_data,
-                                                   g_variant_builder_end (&builder));
+  if (adata->force_version == 1)
+    {
+      g_message ("emitting ActionInvoked");
+      xdp_dbus_impl_notification_emit_action_invoked (adata->impl,
+                                                      adata->app_id,
+                                                      adata->id,
+                                                      adata->action,
+                                                      g_variant_builder_end (&builder));
+    }
+  else
+    {
+      g_message ("emitting ActionInvoked2");
+      xdp_dbus_impl_notification_emit_action_invoked2 (adata->impl,
+                                                       adata->app_id,
+                                                       adata->id,
+                                                       adata->action,
+                                                       adata->platform_data,
+                                                       g_variant_builder_end (&builder));
+    }
 
   g_free (adata->app_id);
   g_free (adata->id);
@@ -97,6 +110,7 @@ handle_add_notification (XdpDbusImplNotification *object,
       data->id = g_strdup (arg_id);
       data->platform_data = g_steal_pointer (&platform_data);
       data->action = g_key_file_get_string (keyfile, "notification", "action", NULL);
+      data->force_version = g_key_file_get_integer (keyfile, "notification", "force-version", NULL);
 
       g_timeout_add (delay, invoke_action, data);
     }

--- a/tests/notification.h
+++ b/tests/notification.h
@@ -2,6 +2,7 @@
 #pragma once
 
 void test_notification_basic (void);
+void test_notification_action_invocation_v1 (void);
 void test_notification_buttons (void);
 void test_notification_bad_arg (void);
 void test_notification_bad_priority (void);

--- a/tests/test-document-fuse.sh.test
+++ b/tests/test-document-fuse.sh.test
@@ -1,0 +1,4 @@
+[Test]
+Type=session
+Exec=/usr/local/libexec/installed-tests/xdg-desktop-portal/test-document-fuse.sh --tap
+Output=TAP

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -138,7 +138,7 @@ global_setup (void)
   g_autoptr(GSubprocessLauncher) launcher = NULL;
   g_autoptr(GSubprocess) subprocess = NULL;
   guint name_timeout;
-  const char *argv[4];
+  const char *argv[4] = {0};
   GQuark portal_errors G_GNUC_UNUSED;
   static gboolean name_appeared;
   guint watch;
@@ -438,7 +438,7 @@ DEFINE_TEST_EXISTS(game_mode, GAME_MODE, 3)
 DEFINE_TEST_EXISTS(inhibit, INHIBIT, 3)
 DEFINE_TEST_EXISTS(location, LOCATION, 1)
 DEFINE_TEST_EXISTS(network_monitor, NETWORK_MONITOR, 3)
-DEFINE_TEST_EXISTS(notification, NOTIFICATION, 1)
+DEFINE_TEST_EXISTS(notification, NOTIFICATION, 2)
 DEFINE_TEST_EXISTS(open_uri, OPEN_URI, 3)
 DEFINE_TEST_EXISTS(print, PRINT, 1)
 DEFINE_TEST_EXISTS(proxy_resolver, PROXY_RESOLVER, 1)

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -588,6 +588,7 @@ main (int argc, char **argv)
   g_test_add_func ("/portal/background/reason", test_background_reason);
 
   g_test_add_func ("/portal/notification/basic", test_notification_basic);
+  g_test_add_func ("/portal/notification/action-invocation-v1", test_notification_action_invocation_v1);
   g_test_add_func ("/portal/notification/buttons", test_notification_buttons);
   g_test_add_func ("/portal/notification/bad-arg", test_notification_bad_arg);
   g_test_add_func ("/portal/notification/bad-priority", test_notification_bad_priority);


### PR DESCRIPTION
Since some time FDO Notifications introduced the ActivationToken signal
to ensure that clients will receive an X11-startup notification ID or a
wayland xdg-activation token in order to support stealing-focus
prevention protocols.

However this isn't supported by xdg-desktop-portal's.
So fill the gap by adding a further activation token.

While it could be added by as an optional parameter, it's just better to
make it explicit.

It needs libportal from https://github.com/flatpak/libportal/pull/88

Implemented in:
 - https://github.com/flatpak/xdg-desktop-portal-gtk/pull/380