### PR TITLE
Screenshot: Allow deleting the file

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -99,7 +99,7 @@ send_response_in_thread_func (GTask        *task,
       if (xdp_app_info_is_host (request->app_info))
         ruri = g_strdup (image);
       else
-        ruri = register_document (image, xdp_app_info_get_id (request->app_info), FALSE, FALSE, FALSE, FALSE, &error);
+        ruri = register_document (image, xdp_app_info_get_id (request->app_info), DOCUMENT_FLAG_NONE, &error);
 
       if (ruri == NULL)
         g_warning ("Failed to register %s: %s", image, error->message);

--- a/src/account.c
+++ b/src/account.c
@@ -99,7 +99,7 @@ send_response_in_thread_func (GTask        *task,
       if (xdp_app_info_is_host (request->app_info))
         ruri = g_strdup (image);
       else
-        ruri = register_document (image, xdp_app_info_get_id (request->app_info), FALSE, FALSE, FALSE, &error);
+        ruri = register_document (image, xdp_app_info_get_id (request->app_info), FALSE, FALSE, FALSE, FALSE, &error);
 
       if (ruri == NULL)
         g_warning ("Failed to register %s: %s", image, error->message);

--- a/src/documents.c
+++ b/src/documents.c
@@ -56,6 +56,7 @@ register_document (const char *uri,
                    gboolean for_save,
                    gboolean writable,
                    gboolean directory,
+                   gboolean deletable,
                    GError **error)
 {
   g_autofree char *doc_id = NULL;
@@ -104,6 +105,8 @@ register_document (const char *uri,
   if (writable || for_save)
     permissions[i++] = "write";
   permissions[i++] = "grant-permissions";
+  if (deletable)
+    permissions[i++] = "delete";
   permissions[i++] = NULL;
 
   version = xdp_dbus_documents_get_version (documents);

--- a/src/documents.h
+++ b/src/documents.h
@@ -29,6 +29,7 @@ char *register_document (const char *uri,
                          gboolean for_save,
                          gboolean writable,
                          gboolean directory,
+                         gboolean deletable,
                          GError **error);
 
 char *get_real_path_for_doc_path (const char *path,

--- a/src/documents.h
+++ b/src/documents.h
@@ -22,14 +22,19 @@
 
 #include <gio/gio.h>
 
+typedef enum {
+  DOCUMENT_FLAG_NONE      = 0,
+  DOCUMENT_FLAG_FOR_SAVE  = (1 << 0),
+  DOCUMENT_FLAG_WRITABLE  = (1 << 1),
+  DOCUMENT_FLAG_DIRECTORY = (1 << 2),
+  DOCUMENT_FLAG_DELETABLE = (1 << 3),
+} DocumentFlags;
+
 void init_document_proxy (GDBusConnection *connection);
 
 char *register_document (const char *uri,
                          const char *app_id,
-                         gboolean for_save,
-                         gboolean writable,
-                         gboolean directory,
-                         gboolean deletable,
+                         DocumentFlags flags,
                          GError **error);
 
 char *get_real_path_for_doc_path (const char *path,

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -118,7 +118,7 @@ send_response_in_thread_func (GTask        *task,
           if (xdp_app_info_is_host (request->app_info))
             ruri = g_strdup (uris[i]);
           else
-            ruri = register_document (uris[i], xdp_app_info_get_id (request->app_info), for_save, writable, directory, &error);
+            ruri = register_document (uris[i], xdp_app_info_get_id (request->app_info), for_save, writable, directory, FALSE, &error);
 
           if (ruri == NULL)
             {

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -258,7 +258,7 @@ launch_application_with_uri (const char *choice_id,
 
       g_debug ("Registering %s for %s", uri, choice_id);
 
-      ruri = register_document (uri, choice_id, FALSE, writable, FALSE, &local_error);
+      ruri = register_document (uri, choice_id, FALSE, writable, FALSE, FALSE, &local_error);
       if (ruri == NULL)
         {
           g_warning ("Error registering %s for %s: %s", uri, choice_id, local_error->message);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -241,6 +241,7 @@ launch_application_with_uri (const char *choice_id,
   g_autoptr(GDesktopAppInfo) info = g_desktop_app_info_new (desktop_id);
   g_autoptr(GAppLaunchContext) context = g_app_launch_context_new ();
   g_autofree char *ruri = NULL;
+  DocumentFlags flags = DOCUMENT_FLAG_NONE;
   GList uris;
 
   if (info == NULL)
@@ -257,8 +258,10 @@ launch_application_with_uri (const char *choice_id,
       g_autoptr(GError) local_error = NULL;
 
       g_debug ("Registering %s for %s", uri, choice_id);
+      if (writable)
+        flags |= DOCUMENT_FLAG_WRITABLE;
 
-      ruri = register_document (uri, choice_id, FALSE, writable, FALSE, FALSE, &local_error);
+      ruri = register_document (uri, choice_id, flags, &local_error);
       if (ruri == NULL)
         {
           g_warning ("Error registering %s for %s: %s", uri, choice_id, local_error->message);

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -98,7 +98,7 @@ send_response_in_thread_func (GTask *task,
       if (xdp_app_info_is_host (request->app_info))
         ruri = g_strdup (uri);
       else
-        ruri = register_document (uri, xdp_app_info_get_id (request->app_info), FALSE, FALSE, FALSE, TRUE, &error);
+        ruri = register_document (uri, xdp_app_info_get_id (request->app_info), DOCUMENT_FLAG_DELETABLE, &error);
 
       if (ruri == NULL)
         g_warning ("Failed to register %s: %s", uri, error->message);

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -98,7 +98,7 @@ send_response_in_thread_func (GTask *task,
       if (xdp_app_info_is_host (request->app_info))
         ruri = g_strdup (uri);
       else
-        ruri = register_document (uri, xdp_app_info_get_id (request->app_info), FALSE, FALSE, FALSE, &error);
+        ruri = register_document (uri, xdp_app_info_get_id (request->app_info), FALSE, FALSE, FALSE, TRUE, &error);
 
       if (ruri == NULL)
         g_warning ("Failed to register %s: %s", uri, error->message);


### PR DESCRIPTION
In some context where the screenshot could contain sensitive information
like a QR code, it would make sense to allow the application that scans
the resulting screenshot to remove it just after it is done with it.

Use case: https://gitlab.gnome.org/World/Authenticator/-/issues/280