### PR TITLE
xdp-utils: Include the application name in the SNAP AppInfo ID

### DIFF
--- a/src/permissions.c
+++ b/src/permissions.c
@@ -198,13 +198,12 @@ get_permission_sync (const char *app_id,
                      const char *id)
 {
   g_auto(GStrv) perms = NULL;
-  Permission ret = PERMISSION_UNSET;
 
   perms = get_permissions_sync (app_id, table, id);
   if (perms)
-    ret = permissions_to_tristate (perms);
+    return permissions_to_tristate (perms);
 
-  return ret;
+  return PERMISSION_UNSET;
 }
 
 void set_permission_sync (const char *app_id,

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -775,6 +775,7 @@ parse_app_info_from_snap (pid_t pid, GError **error)
   g_autoptr(GKeyFile) metadata = NULL;
   g_autoptr(XdpAppInfo) app_info = NULL;
   g_autofree char *snap_name = NULL;
+  g_autofree char *app_name = NULL;
 
   /* Check the process's cgroup membership to fail quickly for non-snaps */
   if (!pid_is_snap (pid, error)) return NULL;
@@ -801,8 +802,15 @@ parse_app_info_from_snap (pid_t pid, GError **error)
       return NULL;
     }
 
+  app_name = g_key_file_get_string (metadata, SNAP_METADATA_GROUP_INFO,
+                                    SNAP_METADATA_KEY_APP_NAME, error);
+  if (app_name == NULL)
+    {
+      return NULL;
+    }
+
   app_info = xdp_app_info_new (XDP_APP_INFO_KIND_SNAP);
-  app_info->id = g_strconcat ("snap.", snap_name, NULL);
+  app_info->id = g_strconcat ("snap.", snap_name, "_", app_name, NULL);
   app_info->u.snap.keyfile = g_steal_pointer (&metadata);
 
   return g_steal_pointer (&app_info);

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -43,6 +43,7 @@
 
 #define SNAP_METADATA_GROUP_INFO "Snap Info"
 #define SNAP_METADATA_KEY_INSTANCE_NAME "InstanceName"
+#define SNAP_METADATA_KEY_APP_NAME "AppName"
 #define SNAP_METADATA_KEY_DESKTOP_FILE "DesktopFile"
 #define SNAP_METADATA_KEY_NETWORK "HasNetworkStatus"
 


### PR DESCRIPTION
Snaps may contain mutiple applications in the whole snap, but we're
currently granting permissions and emitting IDs for the main snap in all
the cases, so that an application inside the snap could benefit of the
same permissions of all the others.

Other than providing wrong information about the application-id to our
customers, that may not be able to retrieve the desktop-id properly.

As per this, always include the application name in the snapped
applications ids.

It may help in future with #769

Also add support for migrating old permissions.

Ideally we may just include it to snaps that use sub-applications names, but I think it's safer to just use it in all the cases. Also because it would provide a better way to compute the original desktop ID to customers.

/cc @jhenstridge 