### PR TITLE
utils: Remove unused macro definition

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2078,8 +2078,6 @@ xdp_app_info_get_child_pid (JsonNode *root,
   return pid;
 }
 
-#define xdp_lockguard G_GNUC_UNUSED __attribute__((cleanup(xdp_auto_unlock_helper)))
-
 static gboolean
 xdp_app_info_ensure_pidns (XdpAppInfo  *app_info,
                            DIR         *proc,


### PR DESCRIPTION
Fallout from b19eed79d8f685138ac788d1b158b9e58f9ad4f7