### PR TITLE
utils: Fix typo

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -1751,7 +1751,7 @@ lookup_ns_from_pid_fd (int    pid_fd,
   struct stat st;
   int r;
 
-  g_return_val_if_fail (ns != NULL, FALSE);
+  g_return_val_if_fail (ns != NULL, -1);
 
   r = fstatat (pid_fd, "ns/pid", &st, 0);
   if (r == -1)


### PR DESCRIPTION
On success lookup_ns_from_pid_fd() is meant to return 0, which is what
FALSE is also defined as.  Therefore, this typo could lead to
surprises in case of a programmer error.