### PR TITLE
file-chooser: Use GVfs to map remote files locally

### DIFF
--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -152,6 +152,7 @@ open_file_done (GObject *source,
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GTask) task = NULL;
+  g_autoptr(GVariant) new_options = NULL;
 
   if (!xdp_dbus_impl_file_chooser_call_open_file_finish (XDP_DBUS_IMPL_FILE_CHOOSER (source),
                                                          &response,
@@ -161,6 +162,12 @@ open_file_done (GObject *source,
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
+    }
+  else
+    {
+      new_options = xdp_transform_remote_uris_into_local (options);
+      g_variant_unref (options);
+      options = g_variant_ref (new_options);
     }
 
   g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
@@ -542,6 +549,7 @@ save_file_done (GObject *source,
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GTask) task = NULL;
+  g_autoptr(GVariant) new_options = NULL;
 
   if (!xdp_dbus_impl_file_chooser_call_save_file_finish (XDP_DBUS_IMPL_FILE_CHOOSER (source),
                                                          &response,
@@ -551,6 +559,12 @@ save_file_done (GObject *source,
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
+    }
+  else
+    {
+      new_options = xdp_transform_remote_uris_into_local (options);
+      g_variant_unref (options);
+      options = g_variant_ref (new_options);
     }
 
   g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
@@ -649,6 +663,7 @@ save_files_done (GObject *source,
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GTask) task = NULL;
+  g_autoptr(GVariant) new_options = NULL;
 
   if (!xdp_dbus_impl_file_chooser_call_save_files_finish (XDP_DBUS_IMPL_FILE_CHOOSER (source),
                                                           &response,
@@ -658,6 +673,12 @@ save_files_done (GObject *source,
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
+    }
+  else
+    {
+      new_options = xdp_transform_remote_uris_into_local (options);
+      g_variant_unref (options);
+      options = g_variant_ref (new_options);
     }
 
   g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -163,12 +163,14 @@ open_file_done (GObject *source,
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
     }
+#if G_ENCODE_VERSION (GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION (2, 66)
   else
     {
       new_options = xdp_transform_remote_uris_into_local (options);
       g_variant_unref (options);
       options = g_variant_ref (new_options);
     }
+#endif
 
   g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
   if (options)
@@ -560,12 +562,14 @@ save_file_done (GObject *source,
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
     }
+#if G_ENCODE_VERSION (GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION (2, 66)
   else
     {
       new_options = xdp_transform_remote_uris_into_local (options);
       g_variant_unref (options);
       options = g_variant_ref (new_options);
     }
+#endif
 
   g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
   if (options)
@@ -674,12 +678,14 @@ save_files_done (GObject *source,
       g_dbus_error_strip_remote_error (error);
       g_warning ("Backend call failed: %s", error->message);
     }
+#if G_ENCODE_VERSION (GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION (2, 66)
   else
     {
       new_options = xdp_transform_remote_uris_into_local (options);
       g_variant_unref (options);
       options = g_variant_ref (new_options);
     }
+#endif
 
   g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
   if (options)

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -377,6 +377,8 @@ main (int argc, char *argv[])
   /* Note: if you add any more environment variables here, update
    * handle_launch() in dynamic-launcher.c to unset them before launching apps
    */
+  /* Avoid even loading gvfs to avoid accidental confusion */
+  g_setenv ("GIO_USE_VFS", "local", TRUE);
 
   /* Avoid pointless and confusing recursion */
   g_unsetenv ("GTK_USE_PORTAL");

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -377,8 +377,6 @@ main (int argc, char *argv[])
   /* Note: if you add any more environment variables here, update
    * handle_launch() in dynamic-launcher.c to unset them before launching apps
    */
-  /* Avoid even loading gvfs to avoid accidental confusion */
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
 
   /* Avoid pointless and confusing recursion */
   g_unsetenv ("GTK_USE_PORTAL");

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2392,7 +2392,7 @@ xdp_transform_remote_uris_into_local (GVariant *options)
             g_variant_unref (uri_variant);
             if (file_uri == NULL)
               {
-                g_variant_builder_add_value (&out_options, odata);
+                g_variant_builder_add_value (&uri_list, uri_variant);
                 continue;
               }
             if ((0 != g_strcmp0 (g_uri_get_scheme (file_uri), "file")) &&

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2395,7 +2395,6 @@ xdp_transform_remote_uris_into_local (GVariant *options)
                 g_variant_builder_add_value (&out_options, odata);
                 continue;
               }
-#if 1
             if (0 != g_strcmp0 (g_uri_get_scheme (file_uri), "file"))
               {
                 if (fuse_mountpoint == NULL)
@@ -2438,7 +2437,6 @@ xdp_transform_remote_uris_into_local (GVariant *options)
                 uri_variant = g_variant_new_string (uristring);
                 g_free (uristring);
               }
-#endif
             g_variant_builder_add_value (&uri_list, uri_variant);
           }
           g_variant_unref (uris);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2426,7 +2426,6 @@ xdp_transform_remote_uris_into_local (GVariant *options)
                                              g_uri_get_path (file_uri),
                                              NULL);
                 g_uri_unref (file_uri);
-                g_free (fuse_mountpoint);
                 g_string_free (gvfs_folder, TRUE);
                 uristring = g_uri_join (G_URI_FLAGS_NONE,
                                         "file",
@@ -2450,6 +2449,7 @@ xdp_transform_remote_uris_into_local (GVariant *options)
       g_variant_unref (name);
       g_variant_unref (odata);
     }
+  g_free (fuse_mountpoint);
 
   return g_variant_builder_end (&out_options);;
 }

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2395,7 +2395,8 @@ xdp_transform_remote_uris_into_local (GVariant *options)
                 g_variant_builder_add_value (&out_options, odata);
                 continue;
               }
-            if (0 != g_strcmp0 (g_uri_get_scheme (file_uri), "file"))
+            if ((0 != g_strcmp0 (g_uri_get_scheme (file_uri), "file")) &&
+                (g_uri_get_host (file_uri) != NULL))
               {
                 if (fuse_mountpoint == NULL)
                   {
@@ -2425,7 +2426,6 @@ xdp_transform_remote_uris_into_local (GVariant *options)
                                              gvfs_folder->str,
                                              g_uri_get_path (file_uri),
                                              NULL);
-                g_uri_unref (file_uri);
                 g_string_free (gvfs_folder, TRUE);
                 uristring = g_uri_join (G_URI_FLAGS_NONE,
                                         "file",
@@ -2439,6 +2439,7 @@ xdp_transform_remote_uris_into_local (GVariant *options)
                 uri_variant = g_variant_new_string (uristring);
                 g_free (uristring);
               }
+            g_uri_unref (file_uri);
             g_variant_builder_add_value (&uri_list, uri_variant);
           }
           g_variant_unref (uris);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2350,7 +2350,7 @@ xdp_validate_serialized_icon (GVariant  *v,
   return TRUE;
 }
 
-
+#if G_ENCODE_VERSION (GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION (2, 66)
 GVariant *
 xdp_transform_remote_uris_into_local (GVariant *options)
 {
@@ -2421,7 +2421,10 @@ xdp_transform_remote_uris_into_local (GVariant *options)
                                             ",user=%s",
                                             g_uri_get_user (file_uri));
                   }
-                pathtext = g_build_filename (fuse_mountpoint, gvfs_folder->str, g_uri_get_path (file_uri), NULL);
+                pathtext = g_build_filename (fuse_mountpoint,
+                                             gvfs_folder->str,
+                                             g_uri_get_path (file_uri),
+                                             NULL);
                 g_uri_unref (file_uri);
                 g_free (fuse_mountpoint);
                 g_string_free (gvfs_folder, TRUE);
@@ -2450,3 +2453,4 @@ xdp_transform_remote_uris_into_local (GVariant *options)
 
   return g_variant_builder_end (&out_options);;
 }
+#endif

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -196,6 +196,10 @@ gboolean  xdp_has_path_prefix (const char *str,
 /* exposed for the benefit of tests */
 int _xdp_parse_cgroup_file (FILE     *f,
                             gboolean *is_snap);
+
+GVariant *
+xdp_transform_remote_uris_into_local (GVariant *options);
+
 #ifdef HAVE_LIBSYSTEMD
 char *_xdp_parse_app_id_from_unit_name (const char *unit);
 #endif

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -197,8 +197,10 @@ gboolean  xdp_has_path_prefix (const char *str,
 int _xdp_parse_cgroup_file (FILE     *f,
                             gboolean *is_snap);
 
+#if G_ENCODE_VERSION (GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION (2, 66)
 GVariant *
 xdp_transform_remote_uris_into_local (GVariant *options);
+#endif
 
 #ifdef HAVE_LIBSYSTEMD
 char *_xdp_parse_app_id_from_unit_name (const char *unit);


### PR DESCRIPTION
By default, xdg-desktop-portal runs with "GIO_USE_VFS=local" to guarantee that it only sends local URIs, but that also means that the user can't access files that are mounted locally using GVfs.

This patch filters all the URIs sent and replaces, wherever possible, any remote URI (like sftp://, smb://...) with the corresponding one in the local filesystem created by GVfs.

Fix https://github.com/flatpak/xdg-desktop-portal/issues/213