### PR TITLE
Accent color on settings portal

### DIFF
--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -43,6 +43,14 @@
           Unknown values should be treated as 0 (no preference).
         </para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term>org.freedesktop.appearance accent-color (ddd)</term>
+        <listitem><para>
+          Indicates the system's preferred accent color as a tuple of RGB values
+          in the sRGB color space, in the range [0,1].
+          Out-of-range RGB values should be treated as an unset accent color.
+        </para></listitem>
+      </varlistentry>
     </variablelist>
 
     Implementations can provide other keys; they are entirely

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -43,6 +43,14 @@
           Unknown values should be treated as 0 (no preference).
         </para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term>org.freedesktop.appearance accent-color (ddd)</term>
+        <listitem><para>
+          Indicates the system's preferred accent color as a tuple of RGB values
+          in the sRGB color space, in the range [0,1].
+          Out-of-range RGB values should be treated as an unset accent color.
+        </para></listitem>
+      </varlistentry>
     </variablelist>
 
     Implementations can provide other keys; they are entirely


### PR DESCRIPTION
# Accent Colors

## Introduction

Accent colors provide a way for users to personalize their desktop in a simple, developer-friendly, and effective way. Throughout the community there has been a general interest in the inclusion of accent colors within apps and desktop environments. This proposal aims to standardize an accent color key on the Settings portal.

## Details

A new key on the Settings portal, `accent-color`, would be defined under the `org.freedesktop.appearance` namespace. The value of this key is a variant. In the case that an accent color is requested, the underlying value would be a struct containing three doubles, each being an RGB value in the range of [0,1]. Whereas, if the user has no preference or wants the application to use their own branding colors, the type will be a uint32 with the value 0, representing no preference. Clients may consume this value in order to style their user interface using the requested accent color. Clients should handle an unknown value in the same way they would handle a "no-preference" value.

## Implementation

A reference implementation of the client can be found in tauOS's [libhelium](https://github.com/tau-OS/tau-helium). I have also forked [xdg-desktop-portal-gnome](https://github.com/tau-OS/xdg-desktop-portal-gnome) adding support for the accent-color key.

## Signatories

- Lleyton "Lea" Gray, Fyra Labs
- Paulo "Lains" Galardi, Fyra Labs

## Acks

- [x] @alice-mkh (GNOME)
- [x] @JoshStrobl (Budgie)
- [x] @Sodivad (KDE)
- [x] @jackpot51 (Cosmic)
- [x] @danirabbit (Elementary)
