### PR TITLE
Add a CI run for the meson build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,8 +75,8 @@ jobs:
           libtool \
           llvm \
           make \
-          shared-mime-info \
-          python3-gi
+          python3-gi \
+          shared-mime-info
 
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v2
@@ -136,20 +136,20 @@ jobs:
         apt-get install -y software-properties-common
         add-apt-repository ppa:alexlarsson/flatpak
         apt-get install -y \
-          automake \
           autoconf \
-          libtool \
-          gettext \
+          automake \
           autopoint \
-          gcc \
-          gtk-doc-tools \
-          shared-mime-info \
           desktop-file-utils \
-          libglib2.0-dev \
-          libjson-glib-dev \
+          gcc \
+          gettext \
+          gtk-doc-tools \
           libfontconfig1-dev \
           libgdk-pixbuf2.0-dev \
-          libsystemd-dev
+          libglib2.0-dev \
+          libjson-glib-dev \
+          libsystemd-dev \
+          libtool \
+          shared-mime-info
 
     - name: Install libfuse3
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -145,16 +145,6 @@ jobs:
       BUILDDIR: builddir
 
     steps:
-    - name: Prepare environment
-      id: env-setup
-      run: |
-        if [ "${{ matrix.sanitizer }}" == "address" ]; then
-          echo "::set-output name=cflags::$BASE_CFLAGS" \
-            "-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address";
-        else
-          echo "::set-output name=cflags::$BASE_CFLAGS";
-        fi
-
     - name: Prepare container
       run: |
         docker run --name $BUILD_CONTAINER \
@@ -209,7 +199,10 @@ jobs:
         $RUN_CMD chown tester:tester . -R
 
     - name: Configure xdg-desktop-portal with meson
-      run: $RUN_CMD $AS_USER meson setup ${BUILDDIR} -Dinstalled-tests=true
+      run: |
+        $RUN_CMD $AS_USER meson setup ${BUILDDIR} $MESON_OPTIONS
+      env:
+        MESON_OPTIONS: -Dinstalled-tests=true -Db_sanitize=${{ matrix.sanitizer }}
 
     - name: Build xdg-desktop-portal with meson
       run: $RUN_CMD $AS_USER meson compile -C ${BUILDDIR}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,8 +7,9 @@ env:
   TESTS_TIMEOUT: 10 # in minutes
 
 jobs:
-  check:
-    name: Ubuntu 21.10 build
+  # identical to the meson job but for the autotools commands
+  check-autotools:
+    name: Ubuntu 21.10 autotools build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -123,6 +124,126 @@ jobs:
         path: |
           tests/*.log
           test-*.log
+          installed-test-logs/
+
+  # identical to the autotools job but for the meson commands
+  check-meson:
+    name: Ubuntu 21.10 meson build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ['gcc', 'clang']
+        sanitizer: ['address']
+
+    env:
+      UBUNTU_VERSION: impish
+      CC: ${{ matrix.compiler }}
+      BASE_CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
+      BUILD_CONTAINER: ${{ matrix.compiler }}-build-container
+      RUN_CMD: docker exec -t -w /src -e TEST_IN_CI -e ASAN_OPTIONS -e G_MESSAGES_DEBUG -e XDG_DATA_DIRS ${{ matrix.compiler }}-build-container
+      AS_USER: runuser -u tester --
+      BUILDDIR: builddir
+
+    steps:
+    - name: Prepare environment
+      id: env-setup
+      run: |
+        if [ "${{ matrix.sanitizer }}" == "address" ]; then
+          echo "::set-output name=cflags::$BASE_CFLAGS" \
+            "-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address";
+        else
+          echo "::set-output name=cflags::$BASE_CFLAGS";
+        fi
+
+    - name: Prepare container
+      run: |
+        docker run --name $BUILD_CONTAINER \
+          --tty --device /dev/fuse --cap-add SYS_ADMIN \
+          --security-opt apparmor:unconfined \
+          -v $(pwd):/src \
+          -e DEBIAN_FRONTEND \
+          -e DEBCONF_NONINTERACTIVE_SEEN=true \
+          -e TERM=dumb \
+          -e MAKEFLAGS="-j $(getconf _NPROCESSORS_ONLN)" \
+          -e CC -e CFLAGS="${{ steps.env-setup.outputs.cflags }}" \
+          -d ubuntu:$UBUNTU_VERSION sleep infinity
+
+    - name: Install dependencies
+      run: |
+        $RUN_CMD apt-get update
+        $RUN_CMD apt-get upgrade -y
+        $RUN_CMD apt-get install -y --no-install-recommends \
+          ${{ matrix.compiler }} \
+          autoconf \
+          automake \
+          autopoint \
+          desktop-file-utils \
+          fuse3 \
+          gettext \
+          gnome-desktop-testing \
+          gtk-doc-tools \
+          libcap2-bin \
+          libflatpak-dev \
+          libfontconfig1-dev \
+          libfuse3-dev \
+          libgdk-pixbuf-2.0-dev \
+          libgeoclue-2-dev \
+          libglib2.0-dev \
+          libjson-glib-dev \
+          libpipewire-0.3-dev \
+          libportal-dev \
+          libsystemd-dev \
+          libtool \
+          llvm \
+          make \
+          meson \
+          python3-gi \
+          shared-mime-info
+
+    - name: Check out xdg-desktop-portal
+      uses: actions/checkout@v2
+
+    - name: Setup test user
+      run: |
+        $RUN_CMD adduser --disabled-password --gecos "" tester
+        $RUN_CMD chown tester:tester . -R
+
+    - name: Configure xdg-desktop-portal with meson
+      run: $RUN_CMD $AS_USER meson setup ${BUILDDIR} -Dinstalled-tests=true
+
+    - name: Build xdg-desktop-portal with meson
+      run: $RUN_CMD $AS_USER meson compile -C ${BUILDDIR}
+
+    - name: Run xdg-desktop-portal tests with meson
+      run: $RUN_CMD $AS_USER timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR}
+      env:
+        TEST_IN_CI: 1
+        G_MESSAGES_DEBUG: all
+        ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
+
+    - name: Install xdg-desktop-portal with meson
+      run: $RUN_CMD meson install -C builddir
+
+    - name: Run xdg-desktop-portal installed-tests
+      run: |
+        test -n "$($RUN_CMD $AS_USER gnome-desktop-testing-runner -l xdg-desktop-portal)"
+        $RUN_CMD $AS_USER \
+          env TEST_INSTALLED_IN_CI=1 XDG_DATA_DIRS=/src/tests/share/:$XDG_DATA_DIRS \
+          gnome-desktop-testing-runner --report-directory installed-test-logs/ \
+            -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
+      env:
+        G_MESSAGES_DEBUG: all
+        TEST_IN_CI: 1
+        XDG_DATA_DIRS: /usr/local/share:/usr/share
+        ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
+
+    - name: Upload test logs
+      uses: actions/upload-artifact@v2
+      if: failure() || cancelled()
+      with:
+        name: test logs
+        path: |
+          builddir/meson-logs/testlog.txt
           installed-test-logs/
 
   xenial:

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -76,7 +76,7 @@ xdg_permission_store_SOURCES = \
 	$(NULL)
 
 xdg_permission_store_LDADD = $(AM_LDADD) $(BASE_LIBS) $(SYSTEMD_LIBS)
-xdg_permission_store_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(SYSTEMD_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal
+xdg_permission_store_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(SYSTEMD_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal -I$(srcdir)/src
 
 nodist_xdg_document_portal_SOURCES = \
 	$(nodist_xdg_permission_store_SOURCES) \
@@ -105,4 +105,4 @@ xdg_document_portal_SOURCES = \
 	$(NULL)
 
 xdg_document_portal_LDADD = $(AM_LDADD) $(BASE_LIBS) $(FUSE3_LIBS) $(SYSTEMD_LIBS)
-xdg_document_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)  $(FUSE3_CFLAGS) $(SYSTEMD_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal
+xdg_document_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)  $(FUSE3_CFLAGS) $(SYSTEMD_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal -I$(srcdir)/src

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -12,6 +12,7 @@
 
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
+#include "glib-backports.h"
 #include "document-portal-dbus.h"
 #include "document-store.h"
 #include "src/xdp-utils.h"
@@ -1606,6 +1607,8 @@ main (int    argc,
   GDBusConnection *session_bus;
   g_autoptr(GOptionContext) context = NULL;
   GDBusMethodInvocation *invocation;
+
+  g_log_writer_default_set_use_stderr (TRUE);
 
   setlocale (LC_ALL, "");
 

--- a/document-portal/permission-store.c
+++ b/document-portal/permission-store.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <gio/gio.h>
+#include "glib-backports.h"
 #include "permission-store-dbus.h"
 #include "xdg-permission-store.h"
 
@@ -90,6 +91,8 @@ main (int    argc,
   GMainLoop *loop;
   GOptionContext *context;
   g_autoptr(GError) error = NULL;
+
+  g_log_writer_default_set_use_stderr (TRUE);
 
   setlocale (LC_ALL, "");
 

--- a/src/glib-backports.h
+++ b/src/glib-backports.h
@@ -51,3 +51,14 @@ guint g_string_replace (GString     *string,
                         const gchar *replace,
                         guint        limit);
 #endif
+
+#if !GLIB_CHECK_VERSION (2, 68, 0)
+static void
+g_log_writer_default_set_use_stderr (gboolean use_stderr)
+{
+  /* Does nothing because outside of the tests we don't really care that it
+   * doesn't work correctly after this call and those tests can run on newer
+   * GLibs
+   */
+}
+#endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -112,6 +112,7 @@ xdg_desktop_portal_deps = common_deps + [
 
 incs_xdg_desktop_portal = [
   include_directories('../document-portal'),
+  src_includes,
   common_includes,
 ]
 

--- a/tests/backend/test-backends.c
+++ b/tests/backend/test-backends.c
@@ -103,6 +103,8 @@ main (int argc, char *argv[])
   g_autoptr(GDBusConnection) session_bus = NULL;
   g_autoptr(GOptionContext) context = NULL;
 
+  g_log_writer_default_set_use_stderr (TRUE);
+
   g_setenv ("GIO_USE_VFS", "local", TRUE);
 
   g_set_prgname (argv[0]);

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -700,6 +700,8 @@ global_setup (void)
       return;
     }
 
+  g_log_writer_default_set_use_stderr (TRUE);
+
   g_mkdtemp (outdir);
   g_debug ("outdir: %s\n", outdir);
 

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -663,6 +663,7 @@ main (int argc, char **argv)
 {
   int res;
 
+  g_log_writer_default_set_use_stderr (TRUE);
   g_test_init (&argc, &argv, NULL);
 
   g_test_add_func ("/permissions/version", test_version);

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -453,6 +453,8 @@ main (int argc, char **argv)
 {
   int res;
 
+  g_log_writer_default_set_use_stderr (TRUE);
+
   setlocale (LC_ALL, NULL);
 
   g_test_init (&argc, &argv, NULL);


### PR DESCRIPTION
Duplicate of the existing autotools run, just using meson instead for build/test/install. However - meson has its own TAP parser which is unhappy with the `G_MESSAGES_DEBUG='all'` output that floods stdout (see also d661854d4c6298976f61438cc6d9bbc1ac9a967f). Adding `g_log_writer_default_set_use_stderr(TRUE)` fixes that and that's probably fine for anything in `tests/`, but I also had to add this to the document portal and the permission store (afaict they're dbus-activated) where it's not fine. 

Any hints on how to convince glib to spew debug to stderr instead would be appreciated, there must be something obvious I'm missing here.