### PR TITLE
CI: actually run the thread sanitizer jobs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         compiler: ['gcc', 'clang']
         sanitizer: ['address']
-        include:
-          - compiler: gcc
-            sanitizer: 'thread'
 
     env:
       UBUNTU_VERSION: impish
@@ -33,9 +30,6 @@ jobs:
         if [ "${{ matrix.sanitizer }}" == "address" ]; then
           echo "::set-output name=cflags::$BASE_CFLAGS" \
             "-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address";
-        elif [ "${{ matrix.sanitizer }}" == "thread" ]; then
-          echo "::set-output name=cflags::$BASE_CFLAGS" \
-            "-fsanitize=thread";
         else
           echo "::set-output name=cflags::$BASE_CFLAGS";
         fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
         sanitizer: ['address']
         include:
           - compiler: gcc
-            sanitizer: ['thread']
+            sanitizer: 'thread'
 
     env:
       UBUNTU_VERSION: impish


### PR DESCRIPTION
The github syntax for matrix.include requires it to be a single value,
not an array. The result of this was that the value wasn't "thread" but
rather "Array" and never triggered the condition we had for it.