### PR TITLE
Adds the option to open a folder as writable

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -86,6 +86,12 @@
               See org.freedesktop.portal.FileChooser.OpenFile() for details.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>writable b</term>
+            <listitem><para>
+              Whether the requested file will have write permission. This only affect directories which are read-only by default.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned via the @results vardict:

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -455,7 +455,8 @@ static XdpOptionKey open_file_options[] = {
   { "directory", G_VARIANT_TYPE_BOOLEAN, NULL },
   { "filters", (const GVariantType *)"a(sa(us))", validate_filters },
   { "current_filter", (const GVariantType *)"(sa(us))", validate_current_filter },
-  { "choices", (const GVariantType *)"a(ssa(ss)s)", validate_choices }
+  { "choices", (const GVariantType *)"a(ssa(ss)s)", validate_choices },
+  { "writable", G_VARIANT_TYPE_BOOLEAN, NULL }
 };
 
 static gboolean


### PR DESCRIPTION
Many apps need to select a folder to store their related data, e.g. set
a Downloads folder for Fragments. This requires write permissions.

See https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/38.
