### PR TITLE
documents: Add support for remote files

### DIFF
--- a/src/documents.c
+++ b/src/documents.c
@@ -61,6 +61,7 @@ register_document (const char *uri,
   g_autofree char *doc_id = NULL;
   g_auto(GStrv) doc_ids = NULL;
   g_autofree char *path = NULL;
+  g_autofree char *translated_uri = NULL;
   g_autofree char *basename = NULL;
   g_autofree char *dirname = NULL;
   GUnixFDList *fd_list = NULL;
@@ -78,6 +79,15 @@ register_document (const char *uri,
 
   file = g_file_new_for_uri (uri);
   path = g_file_get_path (file);
+#if G_ENCODE_VERSION (GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION (2, 66)
+  if (path == NULL)
+    {
+      g_object_unref (file);
+      translated_uri = xdp_transform_remote_uri_into_local (uri);
+      file = g_file_new_for_uri (translated_uri);
+      path = g_file_get_path (file);
+    }
+#endif
   basename = g_path_get_basename (path);
   dirname = g_path_get_dirname (path);
 

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2354,61 +2354,50 @@ xdp_validate_serialized_icon (GVariant  *v,
 gchar *
 xdp_transform_remote_uri_into_local (const gchar *uri)
 {
-  gchar *pathtext = NULL;
+  g_autofree gchar *pathtext = NULL;
+  g_autofree gchar *fuse_mountpoint = NULL;
   gchar *uristring = NULL;
-  gchar *fuse_mountpoint = NULL;
-  GUri *file_uri = NULL;
-  GString *gvfs_folder = NULL;
+  g_autoptr(GUri) file_uri = NULL;
+  g_autoptr(GString) gvfs_folder = NULL;
 
   file_uri = g_uri_parse (uri, G_URI_FLAGS_NONE, NULL);
-  if (file_uri == NULL)
+  if ((file_uri == NULL) || (0 == g_strcmp0 (g_uri_get_scheme (file_uri), "file")) || (g_uri_get_host (file_uri) == NULL))
     {
       return g_strdup(uri);
     }
-  if ((0 != g_strcmp0 (g_uri_get_scheme (file_uri), "file")) &&
-      (g_uri_get_host (file_uri) != NULL))
-    {
-      if (g_get_user_runtime_dir() == g_get_user_cache_dir ())
-        fuse_mountpoint = g_build_filename (g_get_home_dir(), ".gvfs", NULL);
-      else
-        fuse_mountpoint = g_build_filename (g_get_user_runtime_dir(), "gvfs", NULL);
-      gvfs_folder = g_string_new ("");
-      g_string_printf (gvfs_folder,
-                       "%s:host=%s",
-                       g_uri_get_scheme (file_uri),
-                       g_uri_get_host (file_uri));
-      if (g_uri_get_port (file_uri) != -1)
-        {
-          g_string_append_printf (gvfs_folder,
-                                  ",port=%d",
-                                  g_uri_get_port (file_uri));
-        }
-      if (g_uri_get_user (file_uri) != NULL)
-        {
-          g_string_append_printf (gvfs_folder,
-                                  ",user=%s",
-                                  g_uri_get_user (file_uri));
-        }
-      pathtext = g_build_filename (fuse_mountpoint,
-                                   gvfs_folder->str,
-                                   g_uri_get_path (file_uri),
-                                   NULL);
-      g_string_free (gvfs_folder, TRUE);
-      uristring = g_uri_join (G_URI_FLAGS_NONE,
-                              "file",
-                              NULL,
-                              NULL,
-                              -1,
-                                pathtext,
-                              NULL,
-                              NULL);
-      g_free (pathtext);
-    }
+  if (0 == g_strcmp0 (g_get_user_runtime_dir (), g_get_user_cache_dir ()))
+    fuse_mountpoint = g_build_filename (g_get_home_dir(), ".gvfs", NULL);
   else
+    fuse_mountpoint = g_build_filename (g_get_user_runtime_dir(), "gvfs", NULL);
+  gvfs_folder = g_string_new ("");
+  g_string_printf (gvfs_folder,
+                   "%s:host=%s",
+                   g_uri_get_scheme (file_uri),
+                   g_uri_get_host (file_uri));
+  if (g_uri_get_port (file_uri) != -1)
     {
-      uristring = g_strdup (uri);
+      g_string_append_printf (gvfs_folder,
+                              ",port=%d",
+                              g_uri_get_port (file_uri));
     }
-  g_uri_unref (file_uri);
+  if (g_uri_get_user (file_uri) != NULL)
+    {
+      g_string_append_printf (gvfs_folder,
+                              ",user=%s",
+                              g_uri_get_user (file_uri));
+    }
+  pathtext = g_build_filename (fuse_mountpoint,
+                               gvfs_folder->str,
+                               g_uri_get_path (file_uri),
+                               NULL);
+  uristring = g_uri_join (G_URI_FLAGS_NONE,
+                          "file",
+                          NULL,
+                          NULL,
+                          -1,
+                          pathtext,
+                          NULL,
+                          NULL);
 
   return uristring;
 }

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -196,6 +196,12 @@ gboolean  xdp_has_path_prefix (const char *str,
 /* exposed for the benefit of tests */
 int _xdp_parse_cgroup_file (FILE     *f,
                             gboolean *is_snap);
+
+#if G_ENCODE_VERSION (GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION (2, 66)
+gchar *
+xdp_transform_remote_uri_into_local (const gchar *uri);
+#endif
+
 #ifdef HAVE_LIBSYSTEMD
 char *_xdp_parse_app_id_from_unit_name (const char *unit);
 #endif


### PR DESCRIPTION
By default, xdg-desktop-portal runs with "GIO_USE_VFS=local" to guarantee that it only sends local URIs, but that also means that the user can't access files that are mounted locally using GVfs.

This patch filters all the URIs sent and replaces, wherever possible, any remote URI (like sftp://, smb://...) with the corresponding one in the local filesystem created by GVfs.

Fix https://github.com/flatpak/xdg-desktop-portal/issues/213
Fix https://github.com/flatpak/xdg-desktop-portal/issues/820