### PR TITLE
realtime: fix priority type in MakeThreadHighPriority

### DIFF
--- a/src/realtime.c
+++ b/src/realtime.c
@@ -180,7 +180,7 @@ handle_make_thread_high_priority_with_pid (XdpDbusRealtime       *object,
 
   g_dbus_proxy_call (G_DBUS_PROXY (realtime->rtkit_proxy),
                      "MakeThreadHighPriorityWithPID",
-                     g_variant_new ("(ttu)", pids[0], thread, priority),
+                     g_variant_new ("(tti)", pids[0], thread, priority),
                      G_DBUS_CALL_FLAGS_NONE,
                      -1,
                      NULL,


### PR DESCRIPTION
The RTKit argument for the priority in MakeThreadHighPriority is
supposed to be an int, not a uint.

This avoids errors like: Jul 19 11:16:34 wtay rtkit-daemon[1474]:
Failed to parse MakeThreadHighPriority() method call: Argument 2 is
specified to be of type "int32", but is actually of type "uint32"