### PR TITLE
realtime: Fix property types

### DIFF
--- a/data/org.freedesktop.portal.Realtime.xml
+++ b/data/org.freedesktop.portal.Realtime.xml
@@ -56,9 +56,9 @@
         <arg type="i" name="priority" direction="in"/>
       </method>
 
-      <property name="MaxRealtimePriority" type="x" access="read"/>
+      <property name="MaxRealtimePriority" type="i" access="read"/>
       <property name="MinNiceLevel" type="i" access="read"/>
-      <property name="RTTimeUSecMax" type="i" access="read"/>
+      <property name="RTTimeUSecMax" type="x" access="read"/>
 
       <property name="version" type="u" access="read"/>
     </interface>


### PR DESCRIPTION
The types for the properties MaxRealtimePriority and RTTimeUSecMax are incorrect in the D-Bus xml interface file: MaxRealtimePriority should be type 'i' (int32) and RTTimeUSecMax should be type 'x' (int64).  This changes them to match the types used in the realtime.c source file as well as matching the types used by rtkit for these properties.