### PR TITLE
Issue #837 - Remap thread ids

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2195,8 +2195,7 @@ xdg_app_info_map_tids (XdpAppInfo  *app_info,
                        guint        n_tids,
                        GError     **error)
 {
-  char proc_dir[31] = {0, };
-  snprintf (proc_dir, sizeof(proc_dir), "/proc/%u/task", (guint) owner_pid);
+  g_autofree char *proc_dir = g_strdup_printf ("/proc/%u/task", (guint) owner_pid);
   return app_info_map_pids (app_info, proc_dir, tids, n_tids, error);
 }
 

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2136,6 +2136,58 @@ xdp_app_info_ensure_pidns (XdpAppInfo  *app_info,
 }
 
 
+gboolean
+xdg_app_info_map_tids (XdpAppInfo  *app_info,
+                       pid_t        owner_pid,
+                       pid_t       *tids,
+                       guint        n_tids,
+                       GError     **error)
+{
+  char proc_dir[31] = {0, };
+  gboolean ok;
+  DIR *proc;
+  uid_t uid;
+  ino_t ns;
+
+  g_return_val_if_fail (app_info != NULL, FALSE);
+  g_return_val_if_fail (tids != NULL, FALSE);
+
+  if (app_info->kind != XDP_APP_INFO_KIND_FLATPAK)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                           "Mapping pids is not supported.");
+      return FALSE;
+    }
+
+  snprintf (proc_dir, sizeof(proc_dir), "/proc/%u/task", (guint) owner_pid);
+  proc = opendir (proc_dir);
+  if (proc == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Could not open '/proc/%u/task: %s", (guint) owner_pid, g_strerror (errno));
+      return FALSE;
+    }
+
+  /* Make sure we know the pid namespace the app is running in */
+  ok = xdp_app_info_ensure_pidns (app_info, proc, error);
+  if (!ok)
+    {
+      g_prefix_error (error, "Could not determine pid namespace: ");
+      goto out;
+    }
+
+  /* we also make sure the real user id matches
+   * to the process owner we are trying to resolve
+   */
+  uid = getuid ();
+
+  ns = app_info->u.flatpak.pidns_id;
+  ok = map_pids (proc, ns, tids, n_tids, uid, error);
+
+ out:
+  closedir (proc);
+  return ok;
+}
 
 gboolean
 xdp_app_info_map_pids (XdpAppInfo  *app_info,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -85,6 +85,11 @@ gboolean    xdp_app_info_map_pids        (XdpAppInfo  *app_info,
                                           pid_t       *pids,
                                           guint        n_pids,
                                           GError     **error);
+gboolean    xdg_app_info_map_tids        (XdpAppInfo  *app_info,
+                                          pid_t        owner_pid,
+                                          pid_t       *tids,
+                                          guint        n_tids,
+                                          GError     **error);
 gboolean    xdp_app_info_pidfds_to_pids (XdpAppInfo  *app_info,
                                          const int   *fds,
                                          pid_t       *pids,


### PR DESCRIPTION
Closes #837 

This is tested from inside flatpak, using freedesktop-sdk 22.08beta, with a Pipewire patch: https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1332#note_1481517

Also a rebuilt version of the Ardour flatpak.

__Update__: this reworked version works fine. Ignore what follows.

__Update2__: Refactored the code a bit more.


~~Two things about this PR:~~

~~- I now get permission error instead of not found error, and Bustle no long shows  the call to `org.freedesktop.RealtimeKit1.MakeThreadRealtimeWithPID` on the system bus.~~

Before (system-bus):
![image](https://user-images.githubusercontent.com/114441/180917926-0df29318-69fc-4666-b0d9-d6593743b149.png)
note the thread id isn't consistent.
The error:
![image](https://user-images.githubusercontent.com/114441/180918028-11b4d239-52ab-449e-b4ce-a00ad264b3cb.png)

After (session-bus):
![image](https://user-images.githubusercontent.com/114441/180918479-c6d4db9b-5eb9-4d96-a10e-34b5fcf87225.png)
![image](https://user-images.githubusercontent.com/114441/180918499-1a6749b8-a2fa-4b6a-bc61-f82d7fed52f6.png)
~~The pid and thread id are consistent with inside the sandbox. The PID in the error is the one of `xdg-dbus-proxy`~~

~~- I am not sure is the way to remap the thread ID is correct. It works for me (F36) and it sound like the difference between a LWP and the PID is the same on both side. Now that I think of it, it's incorrect of the PID happen to wrap around... If there is a better way I'd love to.~~