### PR TITLE
Fix cases where the portal id is assumed to match the .desktop file name

### DIFF
--- a/src/location.c
+++ b/src/location.c
@@ -531,12 +531,10 @@ handle_start_in_thread_func (GTask *task,
 
       if (g_strcmp0 (app_id, "") != 0)
         {
-          g_autoptr(GDesktopAppInfo) info = NULL;
-          g_autofree gchar *id = NULL;
+          g_autoptr(GAppInfo) info = NULL;
           const gchar *name = NULL;
 
-          id = g_strconcat (app_id, ".desktop", NULL);
-          info = g_desktop_app_info_new (id);
+          info = xdp_app_info_load_app_info (request->app_info);
 
           if (info)
             name = g_app_info_get_display_name (G_APP_INFO (info));
@@ -545,8 +543,8 @@ handle_start_in_thread_func (GTask *task,
 
           title = g_strdup_printf (_("Give %s Access to Your Location?"), name);
 
-          if (info && g_desktop_app_info_has_key (info, "X-Geoclue-Reason"))
-            subtitle = g_desktop_app_info_get_string (info, "X-Geoclue-Reason");
+          if (info && g_desktop_app_info_has_key (G_DESKTOP_APP_INFO (info), "X-Geoclue-Reason"))
+            subtitle = g_desktop_app_info_get_string (G_DESKTOP_APP_INFO (info), "X-Geoclue-Reason");
           else
             subtitle = g_strdup_printf (_("%s wants to use your location."), name);
         }

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -213,7 +213,7 @@ get_app_id (GAppInfo *info)
 
   desktop_id = g_app_info_get_id (info);
 
-  return g_strndup (desktop_id, strlen (desktop_id) - strlen (".desktop"));
+  return xdp_get_app_id_from_desktop_id (desktop_id);
 }
 
 static gboolean

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -185,12 +185,10 @@ handle_set_wallpaper_in_thread_func (GTask *task,
 
       if (g_strcmp0 (app_id, "") != 0)
         {
-          g_autoptr(GDesktopAppInfo) info = NULL;
-          g_autofree gchar *id = NULL;
+          g_autoptr(GAppInfo) info = NULL;
           const gchar *name = NULL;
 
-          id = g_strconcat (app_id, ".desktop", NULL);
-          info = g_desktop_app_info_new (id);
+          info = xdp_app_info_load_app_info (request->app_info);
 
           if (info)
             name = g_app_info_get_display_name (G_APP_INFO (info));

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -1405,6 +1405,15 @@ xdp_is_valid_app_id (const char *string)
   return TRUE;
 }
 
+char *
+xdp_get_app_id_from_desktop_id (const char *desktop_id)
+{
+  const gchar *suffix = ".desktop";
+  if (g_str_has_suffix (desktop_id, suffix))
+    return g_strndup (desktop_id, strlen (desktop_id) - strlen (suffix));
+  else
+    return g_strdup (desktop_id);
+}
 
 char *
 xdp_quote_argv (const char *argv[])

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -60,6 +60,8 @@ gint xdp_mkstempat (int    dir_fd,
 
 gboolean xdp_is_valid_app_id (const char *string);
 
+char *xdp_get_app_id_from_desktop_id (const char *desktop_id);
+
 gboolean xdp_validate_serialized_icon (GVariant  *v,
                                        gboolean   bytes_only,
                                        char     **out_format,


### PR DESCRIPTION
There are a number of cases where there is an assumption that the portal ID + ".desktop" will match the desktop file for an application.

In the case of snaps, this cases a NULL app info with the following error:
```
(/usr/libexec/xdg-desktop-portal:1958136): GLib-GIO-CRITICAL **: 10:27:05.777: g_app_info_get_display_name: assertion 'G_IS_APP_INFO (appinfo)' failed

(/usr/libexec/xdg-desktop-portal:1958136): GLib-GIO-CRITICAL **: 10:27:05.777: g_desktop_app_info_has_key: assertion 'G_IS_DESKTOP_APP_INFO (info)' failed
```

And the access dialog in the shell fails due to it making the same assumption:
```
** (/usr/libexec/xdg-desktop-portal:1958136): WARNING **: 10:27:05.779: Failed to show access dialog: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Only the focused app is allowed to show a system access dialog
```

This may also be an issue with Flatpaks, as suggested in the comment in the OpenURI portral:
```
We cant' just use the flatpak ID, since flatpaks are allowed to export 'sub ids', like the org.libreoffice.LibreOffice flatpak exporting org.libreoffice.LibreOffice.Impress.desktop, and we need to track the actual handlers.
```

Note that the device portal also likely has the same issue, but I haven't added it to this PR since it's got a different structure and I haven't been able to test the change there yet. That can be resolved in another PR.