### PR TITLE
Screenshot permission, attempt 2

### DIFF
--- a/data/org.freedesktop.impl.portal.Screenshot.xml
+++ b/data/org.freedesktop.impl.portal.Screenshot.xml
@@ -24,6 +24,8 @@
       @short_description: Screenshot portal backend interface
 
       This screenshot portal lets sandboxed applications request a screenshot.
+
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Screenshot">
     <!--
@@ -50,6 +52,15 @@
             <listitem><para>
               Hint whether the dialog should offer customization before taking a screenshot.
               Defaults to no.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>permission_store_checked b</term>
+            <listitem><para>
+              Hint whether the screenshot portal has checked the 'screenshot' permission for
+              the requesting app. Defaults to no.
+
+              This option was added in version 2 of this interface.
             </para></listitem>
           </varlistentry>
         </variablelist>
@@ -103,5 +114,7 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+
+    <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -51,6 +51,7 @@ struct _ScreenshotClass
 };
 
 static XdpDbusImplScreenshot *impl;
+static XdpDbusImplAccess *access_impl;
 static Screenshot *screenshot;
 
 GType screenshot_get_type (void) G_GNUC_CONST;
@@ -353,13 +354,14 @@ screenshot_class_init (ScreenshotClass *klass)
 
 GDBusInterfaceSkeleton *
 screenshot_create (GDBusConnection *connection,
-                   const char *dbus_name)
+                   const char *dbus_name_access,
+                   const char *dbus_name_screenshot)
 {
   g_autoptr(GError) error = NULL;
 
   impl = xdp_dbus_impl_screenshot_proxy_new_sync (connection,
                                                   G_DBUS_PROXY_FLAGS_NONE,
-                                                  dbus_name,
+                                                  dbus_name_screenshot,
                                                   DESKTOP_PORTAL_OBJECT_PATH,
                                                   NULL,
                                                   &error);
@@ -372,6 +374,13 @@ screenshot_create (GDBusConnection *connection,
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl), G_MAXINT);
 
   screenshot = g_object_new (screenshot_get_type (), NULL);
+
+  access_impl = xdp_dbus_impl_access_proxy_new_sync (connection,
+                                                     G_DBUS_PROXY_FLAGS_NONE,
+                                                     dbus_name_access,
+                                                     DESKTOP_PORTAL_OBJECT_PATH,
+                                                     NULL,
+                                                     &error);
 
   return G_DBUS_INTERFACE_SKELETON (screenshot);
 }

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -318,6 +318,7 @@ query_impl:
                              g_variant_new_boolean (TRUE));
     }
 
+  g_debug ("Calling Screenshot with interactive=%d", interactive);
   xdp_dbus_impl_screenshot_call_screenshot (impl,
                                             request->id,
                                             app_id,

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -61,6 +61,19 @@ G_DEFINE_TYPE_WITH_CODE (Screenshot, screenshot, XDP_DBUS_TYPE_SCREENSHOT_SKELET
                                                 screenshot_iface_init));
 
 static void
+send_response (Request *request,
+               guint response,
+               GVariant *results)
+{
+  if (request->exported)
+    {
+      g_debug ("sending response: %d", response);
+      xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request), response, results);
+      request_unexport (request);
+    }
+}
+
+static void
 send_response_in_thread_func (GTask *task,
                               gpointer source_object,
                               gpointer task_data,
@@ -123,13 +136,7 @@ send_response_in_thread_func (GTask *task,
     }
 
 out:
-  if (request->exported)
-    {
-      xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
-                                      response,
-                                      g_variant_builder_end (&results));
-      request_unexport (request);
-    }
+  send_response (request, response, g_variant_builder_end (&results));
 }
 
 static void

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -23,4 +23,5 @@
 #include <gio/gio.h>
 
 GDBusInterfaceSkeleton * screenshot_create (GDBusConnection *connection,
-                                            const char      *dbus_name);
+                                            const char      *dbus_name_access,
+                                            const char      *dbus_name_screenshot);

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -195,7 +195,7 @@ handle_set_wallpaper_in_thread_func (GTask *task,
       else
         {
           g_autoptr(GDesktopAppInfo) info = NULL;
-          const gchar *id;
+          g_autofree gchar *id = NULL;
           const gchar *name;
 
           id = g_strconcat (app_id, ".desktop", NULL);

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -267,6 +267,14 @@ handle_set_wallpaper_in_thread_func (GTask *task,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);
+
+  if (!impl_request)
+    {
+      g_warning ("Failed to to create wallpaper implementation proxy: %s", error->message);
+      send_response (request, 2);
+      return;
+    }
+
   request_set_impl_request (request, impl_request);
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -266,11 +266,6 @@ on_bus_acquired (GDBusConnection *connection,
     export_portal_implementation (connection,
                                   print_create (connection, implementation->dbus_name, lockdown));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Screenshot");
-  if (implementation != NULL)
-    export_portal_implementation (connection,
-                                  screenshot_create (connection, implementation->dbus_name));
-
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Notification");
   if (implementation != NULL)
     export_portal_implementation (connection,
@@ -282,6 +277,13 @@ on_bus_acquired (GDBusConnection *connection,
                                   inhibit_create (connection, implementation->dbus_name));
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Access");
+  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Screenshot");
+  if (implementation != NULL && implementation2 != NULL)
+    export_portal_implementation (connection,
+                                  screenshot_create (connection,
+                                                     implementation->dbus_name,
+                                                     implementation2->dbus_name));
+
   implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Background");
   if (implementation != NULL)
     {

--- a/tests/screenshot.c
+++ b/tests/screenshot.c
@@ -3,10 +3,37 @@
 #include "screenshot.h"
 
 #include <libportal/portal.h>
+#include "xdp-impl-dbus.h"
 
 extern char outdir[];
 
 static int got_info;
+
+extern XdpDbusImplPermissionStore *permission_store;
+
+static void
+set_screenshot_permissions (const char *permission)
+{
+  const char *permissions[2] = { NULL, NULL };
+  g_autoptr(GError) error = NULL;
+
+  permissions[0] = permission;
+  xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
+                                                           "screenshot",
+                                                           TRUE,
+                                                           "screenshot",
+                                                           "",
+                                                           permissions,
+                                                           NULL,
+                                                           &error);
+  g_assert_no_error (error);
+}
+
+static void
+reset_screenshot_permissions (void)
+{
+  set_screenshot_permissions (NULL);
+}
 
 static void
 screenshot_cb (GObject *obj,
@@ -54,6 +81,15 @@ test_screenshot_basic (void)
 
   g_key_file_set_integer (keyfile, "backend", "delay", 0);
   g_key_file_set_integer (keyfile, "backend", "response", 0);
+  g_key_file_set_integer (keyfile, "result", "response", 0);
+
+  path = g_build_filename (outdir, "access", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+  g_free (path);
+
+  g_key_file_set_integer (keyfile, "backend", "delay", 0);
+  g_key_file_set_integer (keyfile, "backend", "response", 0);
   g_key_file_set_string (keyfile, "result", "uri", "file://test/image");
   g_key_file_set_integer (keyfile, "result", "response", 0);
 
@@ -83,7 +119,19 @@ test_screenshot_delay (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
+  reset_screenshot_permissions ();
+
   keyfile = g_key_file_new ();
+
+  g_key_file_set_integer (keyfile, "backend", "delay", 0);
+  g_key_file_set_integer (keyfile, "backend", "response", 0);
+  g_key_file_set_integer (keyfile, "result", "response", 0);
+
+  path = g_build_filename (outdir, "access", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+  g_free (path);
+
   g_key_file_set_integer (keyfile, "backend", "delay", 200);
   g_key_file_set_integer (keyfile, "backend", "response", 0);
   g_key_file_set_integer (keyfile, "result", "response", 0);
@@ -115,7 +163,19 @@ test_screenshot_cancel (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
+  reset_screenshot_permissions ();
+
   keyfile = g_key_file_new ();
+
+  g_key_file_set_integer (keyfile, "backend", "delay", 0);
+  g_key_file_set_integer (keyfile, "backend", "response", 0);
+  g_key_file_set_integer (keyfile, "result", "response", 0);
+
+  path = g_build_filename (outdir, "access", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+  g_free (path);
+
   g_key_file_set_integer (keyfile, "backend", "delay", 200);
   g_key_file_set_integer (keyfile, "backend", "response", 1);
   g_key_file_set_integer (keyfile, "result", "response", 1);
@@ -159,7 +219,19 @@ test_screenshot_close (void)
   g_autofree char *path = NULL;
   g_autoptr(GCancellable) cancellable = NULL;
 
+  reset_screenshot_permissions ();
+
   keyfile = g_key_file_new ();
+
+  g_key_file_set_integer (keyfile, "backend", "delay", 0);
+  g_key_file_set_integer (keyfile, "backend", "response", 0);
+  g_key_file_set_integer (keyfile, "result", "response", 0);
+
+  path = g_build_filename (outdir, "access", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+  g_free (path);
+
   g_key_file_set_integer (keyfile, "backend", "delay", 200);
   g_key_file_set_integer (keyfile, "backend", "response", 0);
   g_key_file_set_boolean (keyfile, "backend", "expect-close", 1);
@@ -190,7 +262,18 @@ test_screenshot_parallel (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
+  reset_screenshot_permissions ();
+
   keyfile = g_key_file_new ();
+
+  g_key_file_set_integer (keyfile, "backend", "delay", 0);
+  g_key_file_set_integer (keyfile, "backend", "response", 0);
+  g_key_file_set_integer (keyfile, "result", "response", 0);
+
+  path = g_build_filename (outdir, "access", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+  g_free (path);
 
   g_key_file_set_integer (keyfile, "backend", "delay", 0);
   g_key_file_set_integer (keyfile, "backend", "response", 0);
@@ -392,6 +475,8 @@ test_color_parallel (void)
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
+
+  set_screenshot_permissions ("no");
 
   keyfile = g_key_file_new ();
 


### PR DESCRIPTION
This PR implements a new permission table and value for screenshots, which allows portal implementations to skip the sharing dialog.

Closes https://github.com/flatpak/xdg-desktop-portal/issues/649