### PR TITLE
Draft: Add a SessionFactory portal

### DIFF
--- a/Makefile.am.inc
+++ b/Makefile.am.inc
@@ -25,6 +25,7 @@ PORTAL_IFACE_FILES =\
 	$(top_srcdir)/data/org.freedesktop.portal.Screenshot.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.Secret.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.Session.xml \
+	$(top_srcdir)/data/org.freedesktop.portal.SessionFactory.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.Settings.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.Trash.xml \
 	$(top_srcdir)/data/org.freedesktop.portal.Wallpaper.xml \

--- a/data/meson.build
+++ b/data/meson.build
@@ -28,6 +28,7 @@ portal_sources = files(
   'org.freedesktop.portal.Screenshot.xml',
   'org.freedesktop.portal.Secret.xml',
   'org.freedesktop.portal.Session.xml',
+  'org.freedesktop.portal.SessionFactory.xml',
   'org.freedesktop.portal.Settings.xml',
   'org.freedesktop.portal.Trash.xml',
   'org.freedesktop.portal.Wallpaper.xml',

--- a/data/org.freedesktop.portal.Location.xml
+++ b/data/org.freedesktop.portal.Location.xml
@@ -50,6 +50,17 @@
             </para></listitem>
           </varlistentry>
           <varlistentry>
+            <term>session_handle o</term>
+            <listitem><para>
+              Object path for the #org.freedesktop.portal.Session object. See the
+              #org.freedesktop.portal.SessionFactory documentation for more information
+              about creating a session. If a session_handle is present,
+              the session_handle_token SHOULD not be present and is ignored.
+
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
             <term>distance-threshold u</term>
             <listitem><para>
               Distance threshold in meters. Default is 0.

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -23,7 +23,7 @@
 
       The Remote desktop portal allows to create remote desktop sessions.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.RemoteDesktop">
     <!--
@@ -61,6 +61,17 @@
               A string that will be used as the last element of the session handle. Must be a valid
               object path element. See the #org.freedesktop.portal.Session documentation for
               more information about the session handle.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>session_handle o</term>
+            <listitem><para>
+              Object path for the #org.freedesktop.portal.Session object. See the
+              #org.freedesktop.portal.SessionFactory documentation for more information
+              about creating a session. If a session_handle is present,
+              the session_handle_token SHOULD not be present and is ignored.
+
+              This option was added in version 2 of this interface.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -23,7 +23,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes version 5 of this interface.
   -->
   <interface name="org.freedesktop.portal.ScreenCast">
     <!--
@@ -52,6 +52,17 @@
               A string that will be used as the last element of the session handle. Must be a valid
               object path element. See the #org.freedesktop.portal.Session documentation for
               more information about the session handle.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>session_handle o</term>
+            <listitem><para>
+              Object path for the #org.freedesktop.portal.Session object. See the
+              #org.freedesktop.portal.SessionFactory documentation for more information
+              about creating a session. If a session_handle is present,
+              the session_handle_token SHOULD not be present and is ignored.
+
+              This option was added in version 5 of this interface.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/data/org.freedesktop.portal.SessionFactory.xml
+++ b/data/org.freedesktop.portal.SessionFactory.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2017 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Jonas Ådahl <jadahl@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.SessionFactory:
+      @short_description: Shared session creation interface
+
+      The SessionFactory interface allows to create standalone Session that can
+      be used between multiple Portals.
+
+      This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.SessionFactory">
+
+    <!--
+        CreateSession:
+        @options: Vardict with optional further information
+        @handle: Object path for the #org.freedesktop.portal.Request object representing this call
+
+        Create a standalone session that can be used with other Portals.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the @handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Request documentation for
+              more information about the @handle.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>session_handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the session handle. Must be a valid
+              object path element. See the #org.freedesktop.portal.Session documentation for
+              more information about the session handle.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        <variablelist>
+          <varlistentry>
+            <term>session_handle o</term>
+            <listitem><para>
+              The session handle. An object path for the
+              #org.freedesktop.portal.Session object representing the created
+              session.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        This method was added in version 2 of this interface.
+    -->
+    <method name="CreateSession">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/doc/portal-docs.xml.in
+++ b/doc/portal-docs.xml.in
@@ -118,6 +118,7 @@
     <xi:include href="portal-org.freedesktop.portal.Screenshot.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Secret.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Session.xml"/>
+    <xi:include href="portal-org.freedesktop.portal.SessionFactory.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Settings.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Trash.xml"/>
     <xi:include href="portal-org.freedesktop.portal.Wallpaper.xml"/>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -126,6 +126,8 @@ xdg_desktop_portal_SOURCES = \
 	src/gamemode.h			\
 	src/secret.c			\
 	src/secret.h			\
+	src/session-factory.c		\
+	src/session-factory.h		\
 	src/flatpak-instance.c          \
 	src/flatpak-instance.h          \
 	src/portal-impl.h		\

--- a/src/meson.build
+++ b/src/meson.build
@@ -64,6 +64,7 @@ xdg_desktop_portal_sources = files(
   'screenshot.c',
   'secret.c',
   'session.c',
+  'session-factory.c',
   'settings.c',
   'trash.c',
   'wallpaper.c',

--- a/src/request.c
+++ b/src/request.c
@@ -249,6 +249,13 @@ get_token (GDBusMethodInvocation *invocation)
                      interface, method, G_STRLOC);
         }
     }
+  else if (strcmp (interface, "org.freedesktop.portal.SessionFactory") == 0)
+    {
+      if (strcmp (method, "CreateSession") == 0 )
+        {
+          options = g_variant_get_child_value (parameters, 0);
+        }
+    }
   else if (strcmp (interface, "org.freedesktop.portal.RemoteDesktop") == 0)
     {
       if (strcmp (method, "CreateSession") == 0 )

--- a/src/session-factory.c
+++ b/src/session-factory.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2022 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include "session-factory.h"
+
+#include "request.h"
+#include "session.h"
+#include "xdp-dbus.h"
+
+typedef struct _SessionFactory SessionFactory;
+typedef struct _SessionFactoryClass SessionFactoryClass;
+
+struct _SessionFactory
+{
+    XdpDbusSessionFactorySkeleton parent_instance;
+
+};
+
+struct _SessionFactoryClass
+{
+    XdpDbusSessionFactorySkeletonClass parent_class;
+};
+
+static SessionFactory *session_factory;
+
+GType session_factory_get_type (void) G_GNUC_CONST;
+static void session_factory_iface_init (XdpDbusSessionFactoryIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (SessionFactory, session_factory,
+                         XDP_DBUS_TYPE_SESSION_FACTORY_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_SESSION_FACTORY,
+                                                session_factory_iface_init));
+
+static gboolean
+handle_create_session (XdpDbusSessionFactory *object,
+                       GDBusMethodInvocation *invocation,
+                       GVariant *arg_options)
+{
+  Request *request = request_from_invocation (invocation);
+  g_autoptr(GError) error = NULL;
+  Session *session = NULL;
+  guint response = 2;
+  GVariantBuilder results_builder;
+
+  REQUEST_AUTOLOCK (request);
+
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  // FIXME: actually implement the session creation
+#if 0
+  session = session_new (arg_options, request, &error);
+  if (!session)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+#endif
+  response = 0;
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&results_builder, "{sv}",
+                         "session_handle", g_variant_new ("s", "token0")); // FIXME "session->id"));
+
+  xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
+                                  response,
+                                  g_variant_builder_end (&results_builder));
+  request_unexport (request);
+
+  /* FIXME: we can complete the request right here */
+  xdp_dbus_session_factory_complete_create_session (object, invocation, request->id);
+
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+static void
+session_factory_iface_init (XdpDbusSessionFactoryIface *iface)
+{
+  iface->handle_create_session = handle_create_session;
+}
+
+static void
+session_factory_init (SessionFactory *f)
+{
+  xdp_dbus_session_factory_set_version (XDP_DBUS_SESSION_FACTORY (f), 1);
+}
+
+static void
+session_factory_finalize (GObject *object)
+{
+  G_OBJECT_CLASS (session_factory_parent_class)->finalize (object);
+}
+
+static void
+session_factory_class_init (SessionFactoryClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = session_factory_finalize;
+}
+
+GDBusInterfaceSkeleton *
+session_factory_create(GDBusConnection *connection)
+{
+  session_factory = g_object_new (session_factory_get_type (), NULL);
+  return G_DBUS_INTERFACE_SKELETON (session_factory);
+}

--- a/src/session-factory.h
+++ b/src/session-factory.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2022 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * session_factory_create(GDBusConnection *connection);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -57,6 +57,7 @@
 #include "gamemode.h"
 #include "camera.h"
 #include "secret.h"
+#include "session-factory.h"
 #include "wallpaper.h"
 #include "realtime.h"
 #include "dynamic-launcher.h"
@@ -137,6 +138,13 @@ method_needs_request (GDBusMethodInvocation *invocation)
         return TRUE;
       else
         return FALSE;
+    }
+  else if (strcmp (interface, "org.freedesktop.portal.SessionFactory") == 0)
+    {
+        if (strcmp (method, "CreateSession") == 0)
+          return TRUE;
+        else
+          return FALSE;
     }
   else
     {
@@ -239,6 +247,7 @@ on_bus_acquired (GDBusConnection *connection,
   else
     lockdown = xdp_dbus_impl_lockdown_skeleton_new ();
 
+  export_portal_implementation (connection, session_factory_create (connection));
   export_portal_implementation (connection, memory_monitor_create (connection));
   export_portal_implementation (connection, power_profile_monitor_create (connection));
   export_portal_implementation (connection, network_monitor_create (connection));

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -443,6 +443,7 @@ DEFINE_TEST_EXISTS(open_uri, OPEN_URI, 3)
 DEFINE_TEST_EXISTS(print, PRINT, 1)
 DEFINE_TEST_EXISTS(proxy_resolver, PROXY_RESOLVER, 1)
 DEFINE_TEST_EXISTS(screenshot, SCREENSHOT, 2)
+DEFINE_TEST_EXISTS(session_factory, SESSION_FACTORY, 1)
 DEFINE_TEST_EXISTS(settings, SETTINGS, 1)
 DEFINE_TEST_EXISTS(trash, TRASH, 1)
 DEFINE_TEST_EXISTS(wallpaper, WALLPAPER, 1)
@@ -474,6 +475,7 @@ main (int argc, char **argv)
   g_test_add_func ("/portal/proxyresolver/exists", test_proxy_resolver_exists);
   g_test_add_func ("/portal/screenshot/exists", test_screenshot_exists);
   g_test_add_func ("/portal/settings/exists", test_settings_exists);
+  g_test_add_func ("/portal/sessionfactory/exists", test_session_factory_exists);
   g_test_add_func ("/portal/trash/exists", test_trash_exists);
   g_test_add_func ("/portal/wallpaper/exists", test_wallpaper_exists);
   g_test_add_func ("/portal/realtime/exists", test_realtime_exists);

--- a/tests/test_session_factory.py
+++ b/tests/test_session_factory.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+from tests import Request, PortalTest
+from gi.repository import GLib
+
+class TestSessionFactory(PortalTest):
+    def test_version(self):
+        self.check_version(1)
+
+    def test_create_session(self):
+        self.start_xdp()
+
+        session_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, session_intf)
+        options = {
+            "session_handle_token": "token0",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+        assert response.response == 0
+        results = response.results
+        assert "session_handle" in results
+        assert results["session_handle"].endswith("token0")


### PR DESCRIPTION
Motivated by the discussion in https://github.com/flatpak/libportal/pull/102

This disentangles session creation from any specific portal. Previously,
a `Session` was created by a portal's call to `CreateSession` but sessions
are more complicated than that. The `RemoteDesktop`/`ScreenCast` sessions
are of largely overlapping functionality but the `Location` session is
slightly different (or at least not as commonly combined, I guess).

This patch introduces a new portal: the `SessionFactory` with a single
call `CreateSession`. Once a session has been created, it can be used with
the various portals that require session, effectively adding that portal
to the existing session so all interactions can be terminated with a
single `Close()`/`Closed` signal.

*Note that implementation is missing, it's a fair bit of work so I'd rather work on this once we agree it's the way to go.*

cc @jadahl 