### PR TITLE
Add tests for Session.Close() and Session.Closed

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -323,7 +323,7 @@ class PortalTest(dbusmock.DBusTestCase):
 
         xdp = subprocess.Popen(argv, env=env)
 
-        for _ in range(500):
+        for _ in range(50):
             if self.dbus_con.name_has_owner("org.freedesktop.portal.Desktop"):
                 break
             time.sleep(0.1)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,9 +9,9 @@
 # your portal's name (e.g. TestEmail). This will auto-fill your portal
 # name into some of the functions.
 #
-# Make sure you have a dbusmock template for the impl.portal of your portal in
-# tests/templates. See the dbusmock documentation for details on those
-# templates.
+# Make sure the portal is listed in tests/portals/test.portal  and you have a
+# dbusmock template for the impl.portal of your portal in tests/templates. See
+# the dbusmock documentation for details on those templates.
 #
 # Environment variables:
 #   XDP_UNINSTALLED: run from $PWD (with an emulation of the glib test behavior)

--- a/tests/portals/test.portal
+++ b/tests/portals/test.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.Test
-Interfaces=org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Settings;
+Interfaces=org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.RemoteDesktop;
 UseIn=test

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -7,7 +7,25 @@ import dbus
 import dbusmock
 import logging
 
-logger: Optional[logging.Logger] = None
+
+def init_template_logger(name: str):
+    """
+    Common logging setup for the impl.portal templates. Use as:
+
+        >>> from tests.templates import init_template_logger
+        >>> logger = init_template_logger(__name__)
+        >>> logger.debug("foo")
+
+    """
+    logging.basicConfig(
+        format="%(levelname).1s|%(name)s: %(message)s", level=logging.DEBUG
+    )
+    logger = logging.getLogger(f"templates.{name}")
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+logger = init_template_logger("request")
 
 
 class Response(NamedTuple):
@@ -92,23 +110,3 @@ class ImplRequest:
 
     def __str__(self):
         return f"ImplRequest {self.handle}"
-
-
-def init_template_logger(name: str):
-    """
-    Common logging setup for the impl.portal templates. Use as:
-
-        >>> from tests.templates import init_template_logger
-        >>> logger = init_template_logger(__name__)
-        >>> logger.debug("foo")
-
-    """
-    logging.basicConfig(
-        format="%(levelname).1s|%(name)s: %(message)s", level=logging.DEBUG
-    )
-    logger = logging.getLogger(f"templates.{name}")
-    logger.setLevel(logging.DEBUG)
-    return logger
-
-
-logger = init_template_logger("request")

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -109,3 +109,119 @@ class ImplRequest:
 
     def __str__(self):
         return f"ImplRequest {self.handle}"
+
+
+class ImplSession:
+    """
+    Implementation of a org.freedesktop.impl.portal.Session object. Do not
+    instantiate this directly, instead use ``ImplSession.export()``. Typically
+    like this:
+
+        >>> s = ImplSession.export(mock, "org.freedesktop.impl.portal.Test", "/path/foo")
+
+    Where the test or the backend implementation relies on the Closed() method
+    of the ImplSession, provide a callback to be invoked.
+
+        >>> r.export(close_callback=my_callback)
+
+    Note that the latter only works if the test invokes methods
+    asynchronously.
+
+    .. attribute:: closed
+
+        Set to True if the Close() method on the Session was invoked
+
+    .. attribute:: handle
+
+        The session's object path
+
+    """
+
+    def __init__(
+        self,
+        mock: dbusmock.DBusMockObject,
+        busname: str,
+        handle: str,
+    ):
+        self.mock = mock  # the main mock object
+        self.handle = handle
+        self.closed = False
+        self._close_callback: Optional[Callable] = None
+
+        self.mock_object: Optional[dbusmock.DBusMockObject] = None
+
+        bus = mock.connection
+        proxy = bus.get_object(busname, handle)
+        mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
+
+        # Register for the Close() call on the impl.Session. If it gets
+        # called, use the side-channel SessionClosed signal so we can notify
+        # the test that the impl.Session was actually closed by the
+        # xdg-desktop-portal
+        def cb_methodcall(name, args):
+            if name == "Close":
+                self.closed = True
+                logger.debug(f"Session.Close() on {self.handle}")
+                if self._close_callback:
+                    self._close_callback()
+                self.mock.EmitSignal(
+                    "org.freedesktop.impl.portal.Test",
+                    "SessionClosed",
+                    "s",
+                    (self.handle,),
+                )
+                self._unexport()
+
+        mock_interface.connect_to_signal("MethodCalled", cb_methodcall)
+
+    def export(
+        self,
+        close_callback: Optional[Callable] = None,
+    ) -> "ImplSession":
+        """
+        Create the session on the bus. If ``close_callback`` is not None, that
+        callback will be invoked in response to the Close() method called on
+        this object.
+        """
+        self.mock.AddObject(
+            path=self.handle,
+            interface="org.freedesktop.impl.portal.Session",
+            properties={},
+            methods=[
+                (
+                    "Close",
+                    "",
+                    "",
+                    "",
+                )
+            ],
+        )
+        # This is a bit awkward. We need our session's DBusMockObject for
+        # EmitSignal of impl.portal.Session.Close. This is available in
+        # dbusmock.get_object() since our template runs as part of the server.
+        #
+        # In theory, EmitSignal should work on self.mock_interface but
+        # it doesn't and I can't figure out why.
+        self.mock_object = dbusmock.get_object(self.handle)
+        return self
+
+    def _unexport(self):
+        self.mock.RemoveObject(path=self.handle)
+
+    def close(self):
+        """
+        Send out Closed signal and remove this session from the bus.
+        """
+        assert self.mock_object is not None, "Session was never exported"
+        logger.debug(f"Signal Session.Closed on {self.handle}")
+        self.mock_object.EmitSignal(
+            interface="org.freedesktop.impl.portal.Session",
+            name="Closed",
+            signature="",
+            sigargs=(),
+        )
+        self.closed = True
+        self._unexport()
+
+    def __str__(self):
+        return f"ImplSession {self.handle}"

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -63,8 +63,6 @@ class ImplRequest:
 
         bus = mock.connection
         proxy = bus.get_object(busname, handle)
-        intf = dbus.Interface(proxy, "org.freedesktop.impl.portal.Request")
-        self.proxy = proxy
         mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
 
         # Register for the Close() call on the impl.Request. If it gets
@@ -87,7 +85,7 @@ class ImplRequest:
 
         mock_interface.connect_to_signal("MethodCalled", cb_methodcall)
 
-    def export(self, close_callback: Callable = None):
+    def export(self, close_callback: Optional[Callable] = None):
         """
         Create the object on the bus. If close_callback is not None, that
         callback will be invoked in response to the Close() method called on
@@ -107,6 +105,7 @@ class ImplRequest:
             ],
         )
         self._close_callback = close_callback
+        return self
 
     def __str__(self):
         return f"ImplRequest {self.handle}"

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+from tests.templates import Response, init_template_logger, ImplRequest, ImplSession
+import dbus
+import dbus.service
+
+from gi.repository import GLib
+
+
+BUS_NAME = "org.freedesktop.impl.portal.Test"
+MAIN_OBJ = "/org/freedesktop/portal/desktop"
+SYSTEM_BUS = False
+MAIN_IFACE = "org.freedesktop.impl.portal.RemoteDesktop"
+VERSION = 1
+
+
+logger = init_template_logger(__name__)
+
+
+def load(mock, parameters):
+    logger.debug(f"Loading parameters: {parameters}")
+
+    mock.delay: int = parameters.get("delay", 200)
+    mock.response: int = parameters.get("response", 0)
+    mock.expect_close: bool = parameters.get("expect-close", False)
+    mock.force_close: int = parameters.get("force-close", 0)
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary(
+            {
+                "version": dbus.UInt32(parameters.get("version", VERSION)),
+            }
+        ),
+    )
+
+
+@dbus.service.method(
+    MAIN_IFACE,
+    in_signature="oosa{sv}",
+    out_signature="ua{sv}",
+    async_callbacks=("cb_success", "cb_error"),
+)
+def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_error):
+    try:
+        logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
+
+        session = ImplSession(self, BUS_NAME, session_handle).export()
+
+        response = Response(self.response, {"session_handle": session.handle})
+
+        request = ImplRequest(self, BUS_NAME, handle)
+
+        if self.expect_close:
+
+            def closed_callback():
+                response = Response(2, {})
+                logger.debug(f"CreateSession Close() response {response}")
+                cb_success(response.response, response.results)
+
+            request.export(closed_callback)
+        else:
+            request.export()
+
+            def reply():
+                logger.debug(f"CreateSession with response {response}")
+                cb_success(response.response, response.results)
+
+            logger.debug(f"scheduling delay of {self.delay}")
+            GLib.timeout_add(self.delay, reply)
+
+            if self.force_close > 0:
+
+                def force_close():
+                    session.close()
+
+                GLib.timeout_add(self.force_close, force_close)
+
+    except Exception as e:
+        logger.critical(e)
+        cb_error(e)

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -3,8 +3,10 @@
 import os, sys, stat, random, errno, argparse
 from gi.repository import Gio, GLib
 
+
 def filename_to_ay(filename):
     return list(filename.encode("utf-8")) + [0]
+
 
 running_count = {}
 
@@ -13,7 +15,7 @@ dir_prefix = "dir"
 ensure_no_remaining = True
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--verbose', '-v', action='count')
+parser.add_argument("--verbose", "-v", action="count")
 parser.add_argument("--iterations", type=int, default=3)
 parser.add_argument("--prefix")
 args = parser.parse_args(sys.argv[1:])
@@ -23,15 +25,18 @@ if args.prefix:
     dir_prefix = dir_prefix + "-" + args.prefix + "-"
     ensure_no_remaining = False
 
+
 def log(str):
     if args.prefix:
         print("%s: %s" % (args.prefix, str))
     else:
         print(str)
 
+
 def logv(str):
     if args.verbose:
         log(str)
+
 
 def get_a_count(counter):
     global running_count
@@ -43,32 +48,39 @@ def get_a_count(counter):
     running_count[counter] = 1
     return 1
 
+
 def setFileContent(path, content):
     with open(path, "w") as f:
         f.write(content)
+
 
 def appendFileContent(path, content):
     with open(path, "a") as f:
         f.write(content)
 
+
 def readFdContent(fd):
     os.lseek(fd, 0, os.SEEK_SET)
-    return str(os.read(fd, 64*1024), "utf-8")
+    return str(os.read(fd, 64 * 1024), "utf-8")
+
 
 def replaceFdContent(fd, content):
     os.lseek(fd, 0, os.SEEK_SET)
     os.ftruncate(fd, 0)
     os.write(fd, bytes(content, "utf-8"))
 
+
 def appendFdContent(fd, content):
     os.lseek(fd, 0, os.SEEK_END)
     os.write(fd, bytes(content, "utf-8"))
 
-TEST_DATA_DIR=os.environ['TEST_DATA_DIR']
-DOCUMENT_ADD_FLAGS_REUSE_EXISTING             = (1 << 0)
-DOCUMENT_ADD_FLAGS_PERSISTENT                 = (1 << 1)
-DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP           = (1 << 2)
-DOCUMENT_ADD_FLAGS_DIRECTORY                  = (1 << 3)
+
+TEST_DATA_DIR = os.environ["TEST_DATA_DIR"]
+DOCUMENT_ADD_FLAGS_REUSE_EXISTING = 1 << 0
+DOCUMENT_ADD_FLAGS_PERSISTENT = 1 << 1
+DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP = 1 << 2
+DOCUMENT_ADD_FLAGS_DIRECTORY = 1 << 3
+
 
 def assertRaises(exc_type, func, *args, **kwargs):
     raised_exc = None
@@ -80,7 +92,12 @@ def assertRaises(exc_type, func, *args, **kwargs):
     if not raised_exc:
         raise AssertionError("{0} was not raised".format(exc_type.__name__))
     if raised_exc != exc_type:
-        raise AssertionError("Wrong assertion type {0} was raised instead of {1}".format(raised_exc.__name__, exc_type.__name__))
+        raise AssertionError(
+            "Wrong assertion type {0} was raised instead of {1}".format(
+                raised_exc.__name__, exc_type.__name__
+            )
+        )
+
 
 def assertRaisesErrno(error_nr, func, *args, **kwargs):
     raised_exc = None
@@ -96,39 +113,54 @@ def assertRaisesErrno(error_nr, func, *args, **kwargs):
     if raised_exc != OSError:
         raise AssertionError("OSError was not raised")
     if raised_exc_value.errno != error_nr:
-        raise AssertionError("Wrong errno {0} was raised instead of {1}".format(raised_exc_value.errno, error_nr))
+        raise AssertionError(
+            "Wrong errno {0} was raised instead of {1}".format(
+                raised_exc_value.errno, error_nr
+            )
+        )
+
 
 def assertEmpty(a_set):
     if len(a_set) != 0:
         raise AssertionError("Set was not empty as expected (was: {0})".format(a_set))
 
+
 def assertEqual(a, b):
     if a != b:
         raise AssertionError("{} was not the expected {}".format(a, b))
 
+
 def assertIn(element, container):
     if not element in container:
-        raise AssertionError("{} was not in the container {}".format(element, container))
+        raise AssertionError(
+            "{} was not in the container {}".format(element, container)
+        )
+
 
 def assertFileHasContent(path, expected_content):
     with open(path) as f:
         file_content = f.read()
         assertEqual(file_content, expected_content)
 
+
 def assertFdHasContent(fd, expected_content):
     content = readFdContent(fd)
     assertEqual(content, expected_content)
 
+
 def assertSameStat(a, b, b_mode_mask):
-    if not (a.st_mode == (b.st_mode & b_mode_mask) and
-            a.st_nlink == b.st_nlink and
-            a.st_size == b.st_size and
-            a.st_uid == b.st_uid and
-            a.st_gid == b.st_gid and
-            a.st_atime == b.st_atime and
-            a.st_mtime == b.st_mtime and
-            a.st_ctime == b.st_ctime):
+    if not (
+        a.st_mode == (b.st_mode & b_mode_mask)
+        and a.st_nlink == b.st_nlink
+        and a.st_size == b.st_size
+        and a.st_uid == b.st_uid
+        and a.st_gid == b.st_gid
+        and a.st_atime == b.st_atime
+        and a.st_mtime == b.st_mtime
+        and a.st_ctime == b.st_ctime
+    ):
         raise AssertionError("Stat value {} was not the expected {})".format(a, b))
+
 
 def assertFileExist(path):
     try:
@@ -138,6 +170,7 @@ def assertFileExist(path):
     except:
         raise AssertionError("File {} doesn't exist".format(path))
 
+
 def assertDirExist(path):
     try:
         info = os.lstat(path)
@@ -146,6 +179,7 @@ def assertDirExist(path):
     except:
         raise AssertionError("File {} doesn't exist".format(path))
 
+
 def assertSymlink(path, expected_target):
     try:
         info = os.lstat(path)
@@ -153,9 +187,14 @@ def assertSymlink(path, expected_target):
             raise AssertionError("File {} is not a symlink".format(path))
         target = os.readlink(path)
         if target != expected_target:
-            raise AssertionError("File {} has wrong target {}, expected {}".format(path, target, expected_target))
+            raise AssertionError(
+                "File {} has wrong target {}, expected {}".format(
+                    path, target, expected_target
+                )
+            )
     except:
         raise AssertionError("Symlink {} doesn't exist".format(path))
+
 
 def assertFileNotExist(path):
     try:
@@ -163,23 +202,37 @@ def assertFileNotExist(path):
     except FileNotFoundError:
         return
     except:
-        raise AssertionError("Got wrong execption {} for {}, expected FileNotFoundError".format(sys.exc_info()[0], path))
+        raise AssertionError(
+            "Got wrong execption {} for {}, expected FileNotFoundError".format(
+                sys.exc_info()[0], path
+            )
+        )
     raise AssertionError("Path {} unexpectedly exists".format(path))
 
-def assertDirFiles(path, expected_files, exhaustive = True, volatile_files = None):
-    found_files = os.listdir (path)
+
+def assertDirFiles(path, expected_files, exhaustive=True, volatile_files=None):
+    found_files = os.listdir(path)
     remaining = set(found_files)
     for file in expected_files:
         if file in remaining:
             remaining.remove(file)
         elif not file in volatile_files:
-            raise AssertionError("Expected file {} not found in dir {} (all: {})".format(file, path, found_files))
+            raise AssertionError(
+                "Expected file {} not found in dir {} (all: {})".format(
+                    file, path, found_files
+                )
+            )
     if exhaustive:
         if len(remaining) != 0:
-            raise AssertionError("Unexpected files {} in dir {} (all: {})".format(remaining, path, found_files))
+            raise AssertionError(
+                "Unexpected files {} in dir {} (all: {})".format(
+                    remaining, path, found_files
+                )
+            )
+
 
 class Doc:
-    def __init__(self, portal, id, path, content, is_dir = False):
+    def __init__(self, portal, id, path, content, is_dir=False):
         self.portal = portal
         self.id = id
         self.content = content
@@ -228,48 +281,60 @@ class Doc:
         else:
             return "%s" % (name)
 
+
 class DocPortal:
     def __init__(self):
         self.apps = []
         self.volatile_apps = set()
         self.docs = {}
         self.bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
-        self.proxy = Gio.DBusProxy.new_sync( self.bus, Gio.DBusProxyFlags.NONE, None,
-                                             "org.freedesktop.portal.Documents", "/org/freedesktop/portal/documents", "org.freedesktop.portal.Documents", None)
+        self.proxy = Gio.DBusProxy.new_sync(
+            self.bus,
+            Gio.DBusProxyFlags.NONE,
+            None,
+            "org.freedesktop.portal.Documents",
+            "/org/freedesktop/portal/documents",
+            "org.freedesktop.portal.Documents",
+            None,
+        )
         self.mountpoint = self.get_mount_path()
 
     def get_mount_path(self):
-        res = self.proxy.call_sync ("GetMountPoint",
-                                    GLib.Variant('()', ()),
-                                    0, -1, None)
+        res = self.proxy.call_sync("GetMountPoint", GLib.Variant("()", ()), 0, -1, None)
         return bytearray(res[0][:-1]).decode("utf-8")
 
     def grant_permissions(self, doc_id, app_id, permissions):
-        self.proxy.call_sync ("GrantPermissions",
-                              GLib.Variant('(ssas)', (doc_id, app_id, permissions)),
-                              0, -1, None)
+        self.proxy.call_sync(
+            "GrantPermissions",
+            GLib.Variant("(ssas)", (doc_id, app_id, permissions)),
+            0,
+            -1,
+            None,
+        )
 
     def lookup(self, path):
-        res = self.proxy.call_sync ("Lookup",
-                                    GLib.Variant('(ay)', (filename_to_ay(path), )),
-                                    0, -1, None)
+        res = self.proxy.call_sync(
+            "Lookup", GLib.Variant("(ay)", (filename_to_ay(path),)), 0, -1, None
+        )
         return res[0]
 
     def delete(self, doc_id):
-        self.proxy.call_sync ("Delete",
-                              GLib.Variant('(s)', (doc_id, )),
-                              0, -1, None)
+        self.proxy.call_sync("Delete", GLib.Variant("(s)", (doc_id,)), 0, -1, None)
         del self.docs[doc_id]
 
     def add(self, path, reuse_existing=True):
         fdlist = Gio.UnixFDList.new()
-        fd = os.open (path, os.O_PATH)
-        handle = fdlist.append(fd);
+        fd = os.open(path, os.O_PATH)
+        handle = fdlist.append(fd)
         os.close(fd)
-        res = self.proxy.call_with_unix_fd_list_sync ("Add",
-                                                      GLib.Variant('(hbb)',
-                                                                   (handle, reuse_existing, False)),
-                                                      0, -1, fdlist, None)
+        res = self.proxy.call_with_unix_fd_list_sync(
+            "Add",
+            GLib.Variant("(hbb)", (handle, reuse_existing, False)),
+            0,
+            -1,
+            fdlist,
+            None,
+        )
         doc_id = res[0][0]
         if doc_id in self.docs:
             return self.docs[doc_id]
@@ -283,13 +348,19 @@ class DocPortal:
     def add_named(self, path, reuse_existing=True):
         (dirname, filename) = os.path.split(path)
         fdlist = Gio.UnixFDList.new()
-        fd = os.open (dirname, os.O_PATH)
-        handle = fdlist.append(fd);
+        fd = os.open(dirname, os.O_PATH)
+        handle = fdlist.append(fd)
         os.close(fd)
-        res = self.proxy.call_with_unix_fd_list_sync ("AddNamed",
-                                                      GLib.Variant('(haybb)',
-                                                                   (handle, filename_to_ay(filename), reuse_existing, False)),
-                                                      0, -1, fdlist, None)
+        res = self.proxy.call_with_unix_fd_list_sync(
+            "AddNamed",
+            GLib.Variant(
+                "(haybb)", (handle, filename_to_ay(filename), reuse_existing, False)
+            ),
+            0,
+            -1,
+            fdlist,
+            None,
+        )
         doc_id = res[0][0]
         if doc_id in self.docs:
             return self.docs[doc_id]
@@ -305,13 +376,17 @@ class DocPortal:
 
     def add_full(self, path, flags):
         fdlist = Gio.UnixFDList.new()
-        fd = os.open (path, os.O_PATH)
-        handle = fdlist.append(fd);
+        fd = os.open(path, os.O_PATH)
+        handle = fdlist.append(fd)
         os.close(fd)
-        res = self.proxy.call_with_unix_fd_list_sync ("AddFull",
-                                                      GLib.Variant('(ahusas)',
-                                                                   ([handle], flags, '', [])),
-                                                      0, -1, fdlist, None)
+        res = self.proxy.call_with_unix_fd_list_sync(
+            "AddFull",
+            GLib.Variant("(ahusas)", ([handle], flags, "", [])),
+            0,
+            -1,
+            fdlist,
+            None,
+        )
         doc_id = res[0][0][0]
         if doc_id in self.docs:
             return self.docs[doc_id]
@@ -320,7 +395,9 @@ class DocPortal:
         return doc
 
     def add_dir(self, path):
-        return self.add_full (path, DOCUMENT_ADD_FLAGS_REUSE_EXISTING|DOCUMENT_ADD_FLAGS_DIRECTORY)
+        return self.add_full(
+            path, DOCUMENT_ADD_FLAGS_REUSE_EXISTING | DOCUMENT_ADD_FLAGS_DIRECTORY
+        )
 
     def get_docs_for_app(self, app_id):
         docs = []
@@ -363,7 +440,8 @@ class DocPortal:
     def app_path(self, app_id):
         return portal.mountpoint + "/by-app/" + app_id
 
-def check_virtual_stat (info, writable = False):
+
+def check_virtual_stat(info, writable=False):
     assertEqual(info.st_uid, os.getuid())
     assertEqual(info.st_gid, os.getgid())
     if writable:
@@ -371,9 +449,10 @@ def check_virtual_stat (info, writable = False):
     else:
         assertEqual(info.st_mode, stat.S_IFDIR | 0o500)
 
-def verify_virtual_dir (path, files, volatile_files=None):
+
+def verify_virtual_dir(path, files, volatile_files=None):
     info = os.lstat(path)
-    check_virtual_stat (info)
+    check_virtual_stat(info)
     assert os.access(path, os.R_OK)
     assert not os.access(path, os.W_OK)
 
@@ -382,17 +461,18 @@ def verify_virtual_dir (path, files, volatile_files=None):
     if files != None:
         assertDirFiles(path, files, ensure_no_remaining, volatile_files)
 
+
 def verify_doc(doc, app_id=None):
     dir = doc.get_doc_path(app_id)
 
     if doc.is_dir:
         vdir = os.path.dirname(dir)
         info = os.lstat(vdir)
-        check_virtual_stat (info)
+        check_virtual_stat(info)
         pass
     else:
         info = os.lstat(dir)
-        check_virtual_stat (info, doc.is_writable_by(app_id))
+        check_virtual_stat(info, doc.is_writable_by(app_id))
         assert os.access(dir, os.R_OK)
         if doc.is_writable_by(app_id):
             assert os.access(dir, os.W_OK)
@@ -426,9 +506,9 @@ def verify_doc(doc, app_id=None):
 
             info = os.lstat(main_path)
             real_info = os.lstat(real_path)
-            mode_mask = ~(stat.S_ISUID|stat.S_ISGID|stat.S_ISVTX);
+            mode_mask = ~(stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)
             if not doc.is_writable_by(app_id):
-                mode_mask = mode_mask & ~(stat.S_IWUSR|stat.S_IWGRP|stat.S_IWOTH);
+                mode_mask = mode_mask & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
             assertSameStat(info, real_info, mode_mask)
 
         else:
@@ -438,12 +518,15 @@ def verify_doc(doc, app_id=None):
             assertRaises(FileNotFoundError, os.open, doc.real_path, os.O_RDONLY)
 
     # Ensure no leftover temp files
-    for real_file in os.listdir (os.path.dirname(doc.real_path)):
+    for real_file in os.listdir(os.path.dirname(doc.real_path)):
         assert not real_file.startswith(".xdp")
 
+
 def verify_fs_layout():
-    verify_virtual_dir (portal.mountpoint, ["by-app"] + list(portal.docs.keys()))
-    verify_virtual_dir (portal.by_app_path(), portal.get_app_ids(), portal.get_volatile_app_ids())
+    verify_virtual_dir(portal.mountpoint, ["by-app"] + list(portal.docs.keys()))
+    verify_virtual_dir(
+        portal.by_app_path(), portal.get_app_ids(), portal.get_volatile_app_ids()
+    )
 
     for doc in portal.get_docs():
         verify_doc(doc)
@@ -451,23 +534,27 @@ def verify_fs_layout():
     # Verify the by-app subdirs (just the directory for now)
     for app_id in portal.get_app_ids():
         docs_for_app = portal.get_docs_for_app(app_id)
-        verify_virtual_dir (portal.app_path(app_id), docs_for_app)
+        verify_virtual_dir(portal.app_path(app_id), docs_for_app)
         for doc_id in docs_for_app:
             doc = portal.get_doc(doc_id)
             verify_doc(doc, app_id)
 
+
 def check_virtdir_perms(path):
     assertRaises(PermissionError, os.mkdir, path + "/a_dir")
-    assertRaises(PermissionError, os.open, path + "/a-file", os.O_RDWR|os.O_CREAT)
+    assertRaises(PermissionError, os.open, path + "/a-file", os.O_RDWR | os.O_CREAT)
+
 
 def check_root_perms(path):
     check_virtdir_perms(path)
     assertRaises(PermissionError, os.rename, path + "/by-app", path + "/by-app2")
     assertRaises(PermissionError, os.rmdir, path + "/by-app")
 
+
 def check_byapp_perms(path):
     check_virtdir_perms(path)
     assertRaises(PermissionError, os.mkdir, path + "/a_dir")
+
 
 def check_regular_doc_perms(doc, app_id):
     path = doc.get_doc_path(app_id)
@@ -479,7 +566,7 @@ def check_regular_doc_perms(doc, app_id):
     docpath = path + "/" + doc.filename
     tmppath = path + "/a-tmpfile"
     tmppath2 = path + "/another-tmpfile"
-    if doc.content: # Main file exists
+    if doc.content:  # Main file exists
         assertFileExist(docpath)
         assertFileExist(doc.real_path)
         assertRaises(PermissionError, os.link, docpath, path + "/a-hardlink")
@@ -491,7 +578,9 @@ def check_regular_doc_perms(doc, app_id):
         os.close(fd)
 
         if not writable:
-            assertRaises(PermissionError, os.open, docpath, os.O_RDONLY|os.O_TRUNC, 0o600)
+            assertRaises(
+                PermissionError, os.open, docpath, os.O_RDONLY | os.O_TRUNC, 0o600
+            )
             assertRaises(PermissionError, os.open, docpath, os.O_WRONLY, 0o600)
             assertRaises(PermissionError, os.open, docpath, os.O_RDWR, 0o600)
             assertRaises(PermissionError, os.rename, docpath, docpath + "renamed")
@@ -500,11 +589,23 @@ def check_regular_doc_perms(doc, app_id):
             assertRaises(PermissionError, os.utime, docpath)
         else:
             # Can't move file out of docdir or into other version of same docdir
-            assertRaisesErrno(errno.EXDEV, os.rename, docpath, path + "/../" + doc.filename)
+            assertRaisesErrno(
+                errno.EXDEV, os.rename, docpath, path + "/../" + doc.filename
+            )
             if app_id:
-                assertRaisesErrno(errno.EXDEV, os.rename, docpath, doc.get_doc_path(None) + doc.filename)
+                assertRaisesErrno(
+                    errno.EXDEV,
+                    os.rename,
+                    docpath,
+                    doc.get_doc_path(None) + doc.filename,
+                )
             if doc.apps and app_id != doc.apps[0]:
-                assertRaisesErrno(errno.EXDEV, os.rename, docpath, doc.get_doc_path(doc.apps[0]) + doc.filename)
+                assertRaisesErrno(
+                    errno.EXDEV,
+                    os.rename,
+                    docpath,
+                    doc.get_doc_path(doc.apps[0]) + doc.filename,
+                )
 
             # Ensure we can read it (multiple times)
             fd = os.open(docpath, os.O_RDONLY, 0o600)
@@ -570,17 +671,27 @@ def check_regular_doc_perms(doc, app_id):
             assertRaises(PermissionError, os.setxattr, docpath, "user.attr", b"foo")
             assertRaises(PermissionError, os.removexattr, docpath, "user.attr")
 
-    else: # Main file doesn't exist
+    else:  # Main file doesn't exist
         assertFileNotExist(docpath)
         assertFileNotExist(doc.real_path)
-        if writable: # But we can create it
+        if writable:  # But we can create it
             setFileContent(docpath, "some-data")
             assertFileHasContent(docpath, "some-data")
             os.unlink(docpath)
-        else: # And we can't create it
-            assertRaises(PermissionError, os.open, docpath, os.O_CREAT|os.O_RDONLY|os.O_TRUNC, 0o600)
-            assertRaises(PermissionError, os.open, docpath, os.O_CREAT|os.O_WRONLY, 0o600)
-            assertRaises(PermissionError, os.open, docpath, os.O_CREAT|os.O_RDWR, 0o600)
+        else:  # And we can't create it
+            assertRaises(
+                PermissionError,
+                os.open,
+                docpath,
+                os.O_CREAT | os.O_RDONLY | os.O_TRUNC,
+                0o600,
+            )
+            assertRaises(
+                PermissionError, os.open, docpath, os.O_CREAT | os.O_WRONLY, 0o600
+            )
+            assertRaises(
+                PermissionError, os.open, docpath, os.O_CREAT | os.O_RDWR, 0o600
+            )
 
         # Ensure it show up if created outside
         setFileContent(doc.real_path, "from-outside")
@@ -593,7 +704,7 @@ def check_regular_doc_perms(doc, app_id):
             os.unlink(doc.real_path)
         assertFileNotExist(docpath)
 
-    if writable: # We can create tempfiles, do some simple checks
+    if writable:  # We can create tempfiles, do some simple checks
         setFileContent(tmppath, "tempdata")
         assertFileHasContent(tmppath, "tempdata")
         assertRaises(NotADirectoryError, os.rmdir, tmppath)
@@ -606,9 +717,16 @@ def check_regular_doc_perms(doc, app_id):
         os.unlink(tmppath2)
     else:
         # We should be unable to create tempfiles
-        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT|os.O_RDONLY|os.O_TRUNC, 0o600)
-        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT|os.O_WRONLY, 0o600)
-        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT|os.O_RDWR, 0o600)
+        assertRaises(
+            PermissionError,
+            os.open,
+            tmppath,
+            os.O_CREAT | os.O_RDONLY | os.O_TRUNC,
+            0o600,
+        )
+        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT | os.O_WRONLY, 0o600)
+        assertRaises(PermissionError, os.open, tmppath, os.O_CREAT | os.O_RDWR, 0o600)
+
 
 def check_directory_doc_perms(doc, app_id):
     writable = doc.is_writable_by(app_id)
@@ -623,7 +741,9 @@ def check_directory_doc_perms(doc, app_id):
     assertRaises(PermissionError, os.mkdir, vpath + "/a_dir")
     assertRaises(PermissionError, os.rename, docpath, vpath + "/foo")
     assertRaises(PermissionError, os.rmdir, docpath)
-    assertRaises(PermissionError, os.open, vpath + "/a_file", os.O_CREAT|os.O_RDWR, 0o600)
+    assertRaises(
+        PermissionError, os.open, vpath + "/a_file", os.O_CREAT | os.O_RDWR, 0o600
+    )
 
     assertDirExist(docpath)
 
@@ -650,8 +770,9 @@ def check_directory_doc_perms(doc, app_id):
     assertFileHasContent(dir + "/realfile", "real1")
     assertFileHasContent(dir + "/readonly", "readonly")
     assertFileHasContent(dir + "/subdir/hardlink", "real1")
-    assertEqual(os.lstat(dir + "/realfile").st_ino,
-                os.lstat(dir + "/subdir/hardlink").st_ino)
+    assertEqual(
+        os.lstat(dir + "/realfile").st_ino, os.lstat(dir + "/subdir/hardlink").st_ino
+    )
     assertSymlink(dir + "/symlink", "realfile")
     assertSymlink(dir + "/broken-symlink", "the-void")
 
@@ -660,19 +781,19 @@ def check_directory_doc_perms(doc, app_id):
     filepath2 = docpath + "/dir/a-file2"
     real_filepath2 = doc.real_path + "/dir/a-file2"
 
-    if writable: # We can create files
-        if os.environ.get('TEST_IN_ROOTED_CI'):
+    if writable:  # We can create files
+        if os.environ.get("TEST_IN_ROOTED_CI"):
             assertRaises(PermissionError, os.open, dir + "/readonly", os.O_RDWR)
             os.chmod(dir + "/readonly", 0o700)
-            fd = os.open (dir + "/readonly", os.O_RDWR) # Works now
+            fd = os.open(dir + "/readonly", os.O_RDWR)  # Works now
             os.close(fd)
 
         setFileContent(filepath, "filedata")
         assertFileHasContent(filepath, "filedata")
         assertFileHasContent(real_filepath, "filedata")
 
-        fd = os.open (filepath, os.O_RDONLY)
-        fd2 = os.open (filepath, os.O_RDWR)
+        fd = os.open(filepath, os.O_RDONLY)
+        fd2 = os.open(filepath, os.O_RDWR)
         assertFdHasContent(fd, "filedata")
         assertFdHasContent(fd2, "filedata")
         appendFdContent(fd2, "-more")
@@ -680,10 +801,8 @@ def check_directory_doc_perms(doc, app_id):
         assertFdHasContent(fd2, "filedata-more")
 
         os.link(filepath, filepath2)
-        assertEqual(os.lstat(filepath).st_ino,
-                    os.lstat(filepath2).st_ino)
-        assertEqual(os.lstat(filepath).st_ino,
-                    os.fstat(fd).st_ino)
+        assertEqual(os.lstat(filepath).st_ino, os.lstat(filepath2).st_ino)
+        assertEqual(os.lstat(filepath).st_ino, os.fstat(fd).st_ino)
         assertFileHasContent(filepath2, "filedata-more")
         assertFileHasContent(real_filepath2, "filedata-more")
 
@@ -702,7 +821,7 @@ def check_directory_doc_perms(doc, app_id):
         assertFdHasContent(fd2, "replaced")
 
         # Move between dirs
-        os.rename (filepath2, docpath + "/moved")
+        os.rename(filepath2, docpath + "/moved")
         assertFileHasContent(docpath + "/moved", "replaced")
 
         assertRaisesErrno(errno.EXDEV, os.rename, docpath, portal.mountpoint)
@@ -721,9 +840,17 @@ def check_directory_doc_perms(doc, app_id):
 
     else:
         # We should be unable to create files
-        assertRaises(PermissionError, os.open, filepath, os.O_CREAT|os.O_RDONLY|os.O_TRUNC, 0o600)
-        assertRaises(PermissionError, os.open, filepath, os.O_CREAT|os.O_WRONLY, 0o600)
-        assertRaises(PermissionError, os.open, filepath, os.O_CREAT|os.O_RDWR, 0o600)
+        assertRaises(
+            PermissionError,
+            os.open,
+            filepath,
+            os.O_CREAT | os.O_RDONLY | os.O_TRUNC,
+            0o600,
+        )
+        assertRaises(
+            PermissionError, os.open, filepath, os.O_CREAT | os.O_WRONLY, 0o600
+        )
+        assertRaises(PermissionError, os.open, filepath, os.O_CREAT | os.O_RDWR, 0o600)
 
         assertRaises(PermissionError, os.open, dir + "/realfile", os.O_RDWR)
         assertRaises(PermissionError, os.open, dir + "/readonly", os.O_RDWR)
@@ -743,12 +870,13 @@ def check_directory_doc_perms(doc, app_id):
     os.rmdir(real_dir + "/subdir")
     os.rmdir(real_dir)
 
+
 def check_doc_perms(doc, app_id):
     path = doc.get_doc_path(app_id)
     readable = doc.is_readable_by(app_id)
     if not readable:
         assertRaises(FileNotFoundError, os.lstat, path)
-        if doc.is_dir: # Non readable dir means we can't even see the toplevel dir
+        if doc.is_dir:  # Non readable dir means we can't even see the toplevel dir
             assertRaises(FileNotFoundError, os.mkdir, path)
         else:
             assertRaises(PermissionError, os.mkdir, path)
@@ -762,6 +890,7 @@ def check_doc_perms(doc, app_id):
     else:
         check_regular_doc_perms(doc, app_id)
 
+
 def check_perms():
     check_root_perms(portal.mountpoint)
     check_byapp_perms(portal.by_app_path())
@@ -771,15 +900,17 @@ def check_perms():
         for app_id in portal.get_app_ids_randomized():
             check_doc_perms(doc, app_id)
 
+
 # Ensure that a single lookup by app-id creates that app id (we need this for when mounting the subdir for an app)
-def create_app_by_lookup ():
+def create_app_by_lookup():
     # Should only work for valid app ids
     assertRaises(FileNotFoundError, os.lstat, portal.app_path("not-an-app-id"))
 
     app_id = app_prefix + "Lookup"
     info = os.lstat(portal.app_path(app_id))
-    check_virtual_stat (info)
+    check_virtual_stat(info)
     portal.ensure_app_id(app_id, volatile=True)
+
 
 def ensure_real_dir(create_hidden_file=True):
     count = get_a_count("doc")
@@ -789,6 +920,7 @@ def ensure_real_dir(create_hidden_file=True):
         setFileContent(dir + "/cant-see-this-file", "s3krit")
     return (dir, count)
 
+
 def ensure_real_dir_file(create_file):
     (dir, count) = ensure_real_dir()
     path = dir + "/the-file"
@@ -796,7 +928,8 @@ def ensure_real_dir_file(create_file):
         setFileContent(path, "data" + str(count))
     return path
 
-def export_a_doc ():
+
+def export_a_doc():
     path = ensure_real_dir_file(True)
     doc = portal.add(path)
     logv("exported %s as %s" % (path, doc))
@@ -824,7 +957,8 @@ def export_a_doc ():
 
     os.unlink(tmppath)
 
-def export_a_named_doc (create_file):
+
+def export_a_named_doc(create_file):
     path = ensure_real_dir_file(create_file)
     doc = portal.add_named(path)
     logv("exported (named) %s as %s" % (path, doc))
@@ -839,7 +973,8 @@ def export_a_named_doc (create_file):
     not_reused_doc = portal.add_named(path, False)
     assert not doc is not_reused_doc
 
-def export_a_dir_doc ():
+
+def export_a_dir_doc():
     (dir, count) = ensure_real_dir(False)
     doc = portal.add_dir(dir)
     logv("exported (dir) %s as %s" % (dir, doc))
@@ -878,12 +1013,12 @@ def export_a_dir_doc ():
     os.rmdir(subpath)
 
 
-def add_an_app (num_docs):
+def add_an_app(num_docs):
     if num_docs == 0:
         return
     count = get_a_count("app")
-    read_app = app_prefix + "read.App"+ str(count)
-    write_app = app_prefix + "write.App"+ str(count)
+    read_app = app_prefix + "read.App" + str(count)
+    write_app = app_prefix + "write.App" + str(count)
     portal.ensure_app_id(read_app)
     portal.ensure_app_id(write_app)
 
@@ -892,7 +1027,7 @@ def add_an_app (num_docs):
     for i in range(num_docs):
         if len(docs) == 0:
             continue
-        indx = random.randint(0,len(docs)-1)
+        indx = random.randint(0, len(docs) - 1)
         doc = docs[indx]
         del docs[indx]
         ids.append(doc.id)
@@ -902,40 +1037,41 @@ def add_an_app (num_docs):
         doc.apps.append(write_app)
     logv("granted acces to %s and %s for %s" % (read_app, write_app, ids))
 
+
 log("Connecting to portal")
 portal = DocPortal()
 
 log("Running fuse tests...")
-create_app_by_lookup ()
+create_app_by_lookup()
 verify_fs_layout()
 
 log("Creating some docs")
 for i in range(10):
-    export_a_doc ()
+    export_a_doc()
 verify_fs_layout()
 
 log("Creating some named docs (existing)")
 for i in range(10):
-    export_a_named_doc (True)
+    export_a_named_doc(True)
 verify_fs_layout()
 
 log("Creating some named docs (non-existing)")
 for i in range(10):
-    export_a_named_doc (False)
+    export_a_named_doc(False)
 verify_fs_layout()
 
 log("Creating some dir docs")
 for i in range(10):
-    export_a_dir_doc ()
+    export_a_dir_doc()
 verify_fs_layout()
 
 log("Creating some apps")
 for i in range(10):
-    add_an_app (6)
+    add_an_app(6)
 verify_fs_layout()
 
 for i in range(args.iterations):
-    log("Checking permissions, pass %d" % (i+1))
+    log("Checking permissions, pass %d" % (i + 1))
     check_perms()
     verify_fs_layout()
 

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+
+from tests import Request, PortalTest, Session
+from gi.repository import GLib
+
+import dbus
+import time
+
+
+class TestRemoteDesktop(PortalTest):
+    def test_version(self):
+        self.check_version(1)
+
+    def test_remote_desktop_create_close_session(self):
+        self.start_impl_portal()
+        self.start_xdp()
+
+        rd_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "session_handle_token": "session_token0",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+
+        assert response.response == 0
+
+        session = Session.from_response(self.dbus_con, response)
+        # Check the impl portal was called with the right args
+        method_calls = self.mock_interface.GetMethodCalls("CreateSession")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert args[1] == session.handle
+        assert args[2] == ""  # appid
+
+        session.close()
+
+        mainloop = GLib.MainLoop()
+        GLib.timeout_add(2000, mainloop.quit)
+        mainloop.run()
+
+        assert session.closed
+
+    def test_remote_desktop_create_session_signal_closed(self):
+        params = {"force-close": 500}
+        self.start_impl_portal(params=params)
+        self.start_xdp()
+
+        rd_intf = self.get_dbus_interface()
+        request = Request(self.dbus_con, rd_intf)
+        options = {
+            "session_handle_token": "session_token0",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+
+        assert response.response == 0
+
+        session = Session.from_response(self.dbus_con, response)
+        # Check the impl portal was called with the right args
+        method_calls = self.mock_interface.GetMethodCalls("CreateSession")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert args[1] == session.handle
+        assert args[2] == ""  # appid
+
+        # Now expect the backend to close it
+
+        mainloop = GLib.MainLoop()
+        GLib.timeout_add(2000, mainloop.quit)
+        mainloop.run()
+
+        assert session.closed


### PR DESCRIPTION
This sits on top of #863 

Add support for session in the python portal tests and a minimal RemoteDesktop test case that creates a session and verifies that it was closed in the impl as well. And then the same the other way with the `Closed` signal bubbling up.

Motivated by #508, verifies that bug isn't actually x-d-p's fault anymore.