### PR TITLE
CI: build the docs with meson

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -164,9 +164,6 @@ jobs:
         $RUN_CMD apt-get upgrade -y
         $RUN_CMD apt-get install -y --no-install-recommends \
           ${{ matrix.compiler }} \
-          autoconf \
-          automake \
-          autopoint \
           desktop-file-utils \
           fuse3 \
           gettext \
@@ -183,9 +180,7 @@ jobs:
           libpipewire-0.3-dev \
           libportal-dev \
           libsystemd-dev \
-          libtool \
           llvm \
-          make \
           meson \
           python3-gi \
           shared-mime-info

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,28 +15,27 @@ jobs:
           apt-get update
           apt-get upgrade -y
           apt-get install -y --no-install-recommends \
-            autoconf \
-            automake \
-            autopoint \
             desktop-file-utils \
             fuse3 \
             gcc \
             gettext \
             gnome-desktop-testing \
             gtk-doc-tools \
+            libcap2-bin \
             libflatpak-dev \
             libfontconfig1-dev \
             libfuse3-dev \
-            libgdk-pixbuf2.0-dev \
+            libgdk-pixbuf-2.0-dev \
             libgeoclue-2-dev \
             libglib2.0-dev \
             libjson-glib-dev \
             libpipewire-0.3-dev \
             libportal-dev \
             libsystemd-dev \
-            libtool \
-            make \
-            shared-mime-info \
+            llvm \
+            meson \
+            python3-gi \
+            shared-mime-info
 
       - name: Install dependencies for doc builds
         env:
@@ -52,11 +51,11 @@ jobs:
 
       - name: Build docs
         run: |
-          ./autogen.sh --enable-docbook-docs
-          make
+          meson setup builddir -Ddocbook-docs=enabled
+          meson compile -C builddir
 
       - name: Prepare docs
-        working-directory: doc
+        working-directory: builddir/doc
         run: |
           mkdir published-docs
           mv portal-docs.html ./published-docs/index.html
@@ -68,5 +67,5 @@ jobs:
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc/published-docs/
+          publish_dir: ./builddir/doc/published-docs/
           destination_dir: ./

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,10 @@ jobs:
             autoconf \
             automake \
             autopoint \
-            ca-certificates \
             desktop-file-utils \
             fuse3 \
             gcc \
             gettext \
-            git \
             gnome-desktop-testing \
             gtk-doc-tools \
             libflatpak-dev \
@@ -39,6 +37,14 @@ jobs:
             libtool \
             make \
             shared-mime-info \
+
+      - name: Install dependencies for doc builds
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            git \
             xmlto
 
       - name: Check out xdg-desktop-portal

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,11 +15,31 @@ jobs:
           apt-get update
           apt-get upgrade -y
           apt-get install -y --no-install-recommends \
-          make automake autoconf libtool gettext autopoint gcc git ca-certificates \
-          gtk-doc-tools shared-mime-info desktop-file-utils gnome-desktop-testing \
-          xmlto fuse3 libflatpak-dev libglib2.0-dev libgeoclue-2-dev libjson-glib-dev \
-          libfontconfig1-dev libfuse3-dev libportal-dev libpipewire-0.3-dev \
-          libgdk-pixbuf2.0-dev libsystemd-dev
+            autoconf \
+            automake \
+            autopoint \
+            ca-certificates \
+            desktop-file-utils \
+            fuse3 \
+            gcc \
+            gettext \
+            git \
+            gnome-desktop-testing \
+            gtk-doc-tools \
+            libflatpak-dev \
+            libfontconfig1-dev \
+            libfuse3-dev \
+            libgdk-pixbuf2.0-dev \
+            libgeoclue-2-dev \
+            libglib2.0-dev \
+            libjson-glib-dev \
+            libpipewire-0.3-dev \
+            libportal-dev \
+            libsystemd-dev \
+            libtool \
+            make \
+            shared-mime-info \
+            xmlto
 
       - name: Check out xdg-desktop-portal
         uses: actions/checkout@v2

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -23,5 +23,17 @@ if build_docbook
     install: true,
     install_dir: docs_dir,
   )
-  install_data('docbook.css', install_dir: docs_dir)
+  doc_extra = files(
+      'docbook.css',
+      'redirect.html'
+  )
+  foreach f : doc_extra
+      configure_file(
+        input: f,
+        output: '@PLAINNAME@',
+        copy: true,
+        install: true,
+        install_dir: docs_dir,
+      )
+  endforeach
 endif


### PR DESCRIPTION
It's the fuuuuture! Also, meson has better autodetection of features, so we don't need to install *all* dependencies just to build the docs.