### PR TITLE
filechooser: Support current_folder with OpenFile

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -118,6 +118,12 @@
               Whether the file is opened with write access. Default is no.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>current_folder ay</term>
+            <listitem><para>
+              A suggested folder to open the files from.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
     -->
     <method name="OpenFile">

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -273,6 +273,15 @@
             </para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term>current_folder ay</term>
+          <listitem>
+            <para>
+              Suggested folder to select the files from. The byte array is
+              expected to be null-terminated.
+            </para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     -->
     <method name="SaveFile">

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -455,7 +455,8 @@ static XdpOptionKey open_file_options[] = {
   { "directory", G_VARIANT_TYPE_BOOLEAN, NULL },
   { "filters", (const GVariantType *)"a(sa(us))", validate_filters },
   { "current_filter", (const GVariantType *)"(sa(us))", validate_current_filter },
-  { "choices", (const GVariantType *)"a(ssa(ss)s)", validate_choices }
+  { "choices", (const GVariantType *)"a(ssa(ss)s)", validate_choices },
+  { "current_folder", G_VARIANT_TYPE_BYTESTRING, NULL }
 };
 
 static gboolean


### PR DESCRIPTION
- [x] [xdg-desktop-portal-gnome](https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/54)
- [x] xdg-desktop-portal-gtk: https://github.com/flatpak/xdg-desktop-portal-gtk/pull/396
- [x] GTK 4: Already sends `current_folder` option for OpenFile
- [x] Ashpd: https://github.com/bilelmoussaoui/ashpd/pull/90

Closes #796