### PR TITLE
settings: Fix values from read being variants inside variants.

### DIFF
--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -49,7 +49,7 @@
     implementation details that are undocumented. If you are a
     toolkit and want to use this please open an issue.
 
-    This documentation describes version 1 of this interface.
+    This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Settings">
 
@@ -73,8 +73,29 @@
       @value: The value @key is set to.
 
       Reads a single value. Returns an error on any unknown namespace or key.
+
+      Deprecated, use ReadOne instead. The value argument was intended to have
+      the value inside one layer of variant as it is in ReadOne, for example
+      `&lt;string "hello"&gt;` in GVariant text notation; but it is actually
+      returned inside two layers of variant, for example
+      `&lt;&lt;string "hello"&gt;&gt;`.
     -->
     <method name='Read'>
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+      <arg name='namespace' type='s'/>
+      <arg name='key' type='s'/>
+      <arg name='value' direction='out' type='v'/>
+    </method>
+
+    <!--
+      ReadOne:
+      @namespace: Namespace to look up @key in.
+      @key: The key to get.
+      @value: The value @key is set to.
+
+      Reads a single value which may be any valid DBus type. Returns an error on any unknown namespace or key.
+    -->
+    <method name='ReadOne'>
       <arg name='namespace' type='s'/>
       <arg name='key' type='s'/>
       <arg name='value' direction='out' type='v'/>


### PR DESCRIPTION
The backend returns a variant, and this was mistakenly being put inside another
variant when returned to the original caller.

Fixes https://github.com/flatpak/xdg-desktop-portal/issues/789