### PR TITLE
Added support for 'mapping' Snaps

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2151,7 +2151,22 @@ app_info_map_pids (XdpAppInfo  *app_info,
   g_return_val_if_fail (app_info != NULL, FALSE);
   g_return_val_if_fail (pids != NULL, FALSE);
 
-  if (app_info->kind != XDP_APP_INFO_KIND_FLATPAK)
+  if (app_info->kind == XDP_APP_INFO_KIND_SNAP)
+    {
+      for (int i = 0; i < n_pids; i++)
+        {
+          XdpAppInfo *info = xdp_get_app_info_from_pid(pids[i], error);
+          if (strcmp(info->id, app_info->id) != 0 || info->kind != app_info->kind)
+            {
+              g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
+                                   "App info of pids do not match.");
+              return FALSE;
+            }
+        }
+
+      return TRUE;
+    }
+  else if (app_info->kind != XDP_APP_INFO_KIND_FLATPAK)
     {
       g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
                            "Mapping pids is not supported.");


### PR DESCRIPTION
Allows Snaps to have their pids "mapped" if each pid app info matches, namely for use cases such as [this](https://github.com/FeralInteractive/gamemode/pull/385).