### PR TITLE
Fix Meson build of 1.15.x on Debian 11 (GLib 2.66)

### DIFF
--- a/src/glib-backports.h
+++ b/src/glib-backports.h
@@ -53,7 +53,7 @@ guint g_string_replace (GString     *string,
 #endif
 
 #if !GLIB_CHECK_VERSION (2, 68, 0)
-static void
+static inline void
 g_log_writer_default_set_use_stderr (gboolean use_stderr)
 {
   /* Does nothing because outside of the tests we don't really care that it

--- a/tests/backend/test-backends.c
+++ b/tests/backend/test-backends.c
@@ -19,6 +19,8 @@
 #include "settings.h"
 #include "wallpaper.h"
 
+#include "src/glib-backports.h"
+
 #define BACKEND_BUS_NAME "org.freedesktop.impl.portal.Test"
 #define BACKEND_OBJECT_PATH "/org/freedesktop/portal/desktop"
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,6 +5,12 @@ env_tests.set('G_TEST_SRCDIR', meson.current_source_dir())
 env_tests.set('G_TEST_BUILDDIR', meson.current_build_dir())
 env_tests.set('G_DEBUG', 'gc-friendly')  # from glib-tap.mk
 
+if glib_dep.version().version_compare('>= 2.68')
+  test_protocol = 'tap'
+else
+  test_protocol = 'exitcode'
+endif
+
 subdir('dbs')
 subdir('portals')
 subdir('services')
@@ -23,7 +29,7 @@ test(
   test_db,
   env: env_tests,
   is_parallel: false,
-  protocol: 'tap',
+  protocol: test_protocol,
 )
 
 if enable_installed_tests
@@ -46,7 +52,7 @@ test(
   test_doc_portal,
   env: env_tests,
   is_parallel: false,
-  protocol: 'tap'
+  protocol: test_protocol,
 )
 
 test_backends_sources = files(
@@ -146,7 +152,7 @@ foreach p : portal_tests
       depends: [test_backends, test_portals],
       env: env_tests,
       is_parallel: false,
-      protocol: 'tap',
+      protocol: test_protocol,
       suite: 'portals',
     )
 endforeach
@@ -177,7 +183,7 @@ test(
   test_permission_store,
   env: env_tests,
   is_parallel: false,
-  protocol: 'tap',
+  protocol: test_protocol,
 )
 
 test_xdp_utils = executable(
@@ -196,7 +202,7 @@ test(
   test_xdp_utils,
   env: env_tests,
   is_parallel: false,
-  protocol: 'tap',
+  protocol: test_protocol,
 )
 
 pytest = find_program('pytest-3', 'pytest', required: false)

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -16,6 +16,7 @@
 #include "document-portal/document-portal-dbus.h"
 
 #include "can-use-fuse.h"
+#include "src/glib-backports.h"
 #include "utils.h"
 
 char outdir[] = "/tmp/xdp-test-XXXXXX";

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -14,6 +14,7 @@
 
 #include "xdp-utils.h"
 #include "document-portal/permission-store-dbus.h"
+#include "src/glib-backports.h"
 #include "utils.h"
 
 char outdir[] = "/tmp/xdp-test-XXXXXX";

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -4,6 +4,7 @@
 
 #include <gio/gio.h>
 
+#include "src/glib-backports.h"
 #include "xdp-dbus.h"
 #include "xdp-utils.h"
 #include "xdp-impl-dbus.h"


### PR DESCRIPTION
For the benefit of Flatpak apps that need recent portal features, it's useful for newer xdg-desktop-portal releases to be backportable to LTS distributions like Debian stable, Ubuntu LTS and RHEL (in Debian, I maintain an official backport of the versions we aim to have in Debian 12, backported for Debian 11 users).

* tests: Don't apply Meson's strict TAP parsing for older GLib
    
    In older GLib, we don't have a straightforward way to avoid debug
    messages going to stdout, which would be tolerated by Autotools' TAP
    parser but not by Meson's stricter TAP parser.

* tests: Include src/glib-backports.h where needed
    
    The tests call g_log_writer_default_set_use_stderr(), but that function
    isn't available in older GLib.
    
    We have to include this as src/glib-backports.h, because
    tests/glib-backports.h contains different backports.

* glib-backports: Declare stub function as inline
    
    This avoids `-Wunused-function` warnings in translation units that use
    glib-backports.h but do not call this particular function.