### PR TITLE
Fix Meson build when tests are enabled but libportal is disabled

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -85,6 +85,7 @@ test_backends = executable(
 
 test_portals_sources = files(
   'test-portals.c',
+  'utils.c',
 )
 
 if have_libportal
@@ -101,7 +102,6 @@ if have_libportal
     'print.c',
     'screenshot.c',
     'trash.c',
-    'utils.c',
     'wallpaper.c',
     'glib-backports.c',
   )

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -21,9 +21,10 @@
 #include "print.h"
 #include "screenshot.h"
 #include "trash.h"
-#include "utils.h"
 #include "wallpaper.h"
 #endif
+
+#include "utils.h"
 
 /* required while we support meson + autotools. Autotools builds everything in
    the root dir ('.'), meson builds in each subdir nested and overrides these for


### PR DESCRIPTION
We have some very basic test coverage even if libportal isn't used, and that needs setup_dbus_daemon_wrapper().

---

The Debian 11 backport mentioned in #893 needs this: we don't have libportal in Debian 11 (it will be in Debian 12), but I still want to enable whatever test coverage remains.