### PR TITLE
notification: Pass the desktop-id to the notification impl

### DIFF
--- a/data/org.freedesktop.impl.portal.Notification.xml
+++ b/data/org.freedesktop.impl.portal.Notification.xml
@@ -40,7 +40,19 @@
         the notification is replaced by the new one.
 
         The format of the @notification is the same as for
-        org.freedesktop.portal.Notification.AddNotification().
+        org.freedesktop.portal.Notification.AddNotification() plus
+        these private meta-data keys (all optional):
+        <variablelist>
+          <varlistentry>
+            <term>desktop-id s</term>
+            <listitem>
+              <para>
+              The desktop ID of the application sending the notification.
+              This may me omitted in case the provided @app_id is matching it.
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="AddNotification">
       <arg type="s" name="app_id" direction="in"/>

--- a/src/device.c
+++ b/src/device.c
@@ -100,12 +100,7 @@ device_query_permission_sync (const char *app_id,
       g_autoptr(GAppInfo) info = NULL;
       g_autoptr(XdpDbusImplRequest) impl_request = NULL;
 
-      if (app_id[0] != 0)
-        {
-          g_autofree char *desktop_id;
-          desktop_id = g_strconcat (app_id, ".desktop", NULL);
-          info = (GAppInfo*)g_desktop_app_info_new (desktop_id);
-        }
+      info = xdp_app_info_load_app_info (request->app_info);
 
       g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
 

--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -680,7 +680,7 @@ handle_request_install_token (XdpDbusDynamicLauncher *object,
    * app was launched from the CLI:
    * https://github.com/flatpak/xdg-desktop-portal/pull/719#issuecomment-1057412221
    */
-  if (xdp_app_info_is_host (call->app_info) && g_str_equal (app_id, ""))
+  if (xdp_app_info_get_kind (call->app_info) == XDP_APP_INFO_KIND_TEST)
     {
       response = 0;
     }

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -516,6 +516,7 @@ find_recommended_choices (const char *scheme,
   if (info != NULL)
     {
       *default_app = get_app_id (info);
+      g_clear_object (&info);
       g_debug ("Default handler %s for %s, %s", *default_app, scheme, content_type);
     }
   else

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -219,6 +219,7 @@ handle_screenshot_in_thread_func (GTask *task,
   if (!interactive && permission != PERMISSION_YES)
     {
       g_autoptr(GVariant) access_results = NULL;
+      g_autoptr(GAppInfo) info = NULL;
       GVariantBuilder access_opt_builder;
       g_autofree gchar *subtitle = NULL;
       g_autofree gchar *title = NULL;
@@ -239,16 +240,12 @@ handle_screenshot_in_thread_func (GTask *task,
       g_variant_builder_add (&access_opt_builder, "{sv}",
                              "icon", g_variant_new_string ("applets-screenshooter-symbolic"));
 
-      if (g_strcmp0 (app_id, "") != 0)
+      info = xdp_app_info_load_app_info (request->app_info);
+      if (info)
         {
-          g_autoptr(GDesktopAppInfo) info = NULL;
-          g_autofree gchar *id = NULL;
           const gchar *name;
 
-          id = g_strconcat (app_id, ".desktop", NULL);
-          info = g_desktop_app_info_new (id);
           name = g_app_info_get_display_name (G_APP_INFO (info));
-
           title = g_strdup_printf (_("Allow %s to Take Screenshots?"), name);
           subtitle = g_strdup_printf (_("%s wants to be able to take screenshots at any time."), name);
         }

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -170,6 +170,7 @@ handle_set_wallpaper_in_thread_func (GTask *task,
     {
       guint access_response = 2;
       g_autoptr(GVariant) access_results = NULL;
+      g_autoptr(GAppInfo) info = NULL;
       GVariantBuilder access_opt_builder;
       g_autofree gchar *title = NULL;
       g_autofree gchar *subtitle = NULL;
@@ -183,7 +184,8 @@ handle_set_wallpaper_in_thread_func (GTask *task,
       g_variant_builder_add (&access_opt_builder, "{sv}",
                              "icon", g_variant_new_string ("preferences-desktop-wallpaper-symbolic"));
 
-      if (g_str_equal (app_id, ""))
+      info = xdp_app_info_load_app_info (request->app_info);
+      if (!info)
         {
           /* Note: this will set the wallpaper permission for all unsandboxed
            * apps for which an app ID can't be determined.
@@ -194,14 +196,9 @@ handle_set_wallpaper_in_thread_func (GTask *task,
         }
       else
         {
-          g_autoptr(GDesktopAppInfo) info = NULL;
-          g_autofree gchar *id = NULL;
           const gchar *name;
 
-          id = g_strconcat (app_id, ".desktop", NULL);
-          info = g_desktop_app_info_new (id);
           name = g_app_info_get_display_name (G_APP_INFO (info));
-
           title = g_strdup_printf (_("Allow %s to Set Backgrounds?"), name);
           subtitle = g_strdup_printf (_("%s is requesting to be able to change the background image."), name);
         }

--- a/src/xdp-test-utils.h
+++ b/src/xdp-test-utils.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2022, Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Marco Trevisan <marco.trevisan@canonical.com>
+ */
+
+#define TEST_METADATA_FILE_NAME ".xdg_app_info"
+
+#define TEST_METADATA_GROUP_INFO "XdpAppInfo"
+#define TEST_METADATA_KEY_APP_ID "AppId"
+#define TEST_METADATA_KEY_DESKTOP_ID "DesktopId"
+
+#define TEST_METADATA_GROUP_STATE "State"
+#define TEST_METADATA_KEY_HAS_NETWORK "HasNetwork"

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -280,6 +280,25 @@ xdp_app_info_get_id (XdpAppInfo *app_info)
   return app_info->id;
 }
 
+const char *
+xdp_app_info_get_desktop_id (XdpAppInfo *app_info)
+{
+  g_return_val_if_fail (app_info != NULL, NULL);
+
+  switch (app_info->kind)
+    {
+    case XDP_APP_INFO_KIND_FLATPAK:
+      return app_info->id;
+
+    case XDP_APP_INFO_KIND_SNAP:
+      return app_info->u.snap.desktop_id;
+
+    case XDP_APP_INFO_KIND_HOST:
+    default:
+      return NULL;
+    }
+}
+
 XdpAppInfoKind
 xdp_app_info_get_kind (XdpAppInfo  *app_info)
 {
@@ -295,24 +314,8 @@ xdp_app_info_load_app_info (XdpAppInfo *app_info)
 
   g_return_val_if_fail (app_info != NULL, NULL);
 
-  switch (app_info->kind)
-    {
-    case XDP_APP_INFO_KIND_FLATPAK:
-      desktop_id = g_strconcat (app_info->id, ".desktop", NULL);
-      break;
-
-    case XDP_APP_INFO_KIND_SNAP:
-      desktop_id = g_key_file_get_string (app_info->u.snap.keyfile,
-                                          SNAP_METADATA_GROUP_INFO,
-                                          SNAP_METADATA_KEY_DESKTOP_FILE,
-                                          NULL);
-      break;
-
-    case XDP_APP_INFO_KIND_HOST:
-    default:
-      desktop_id = NULL;
-      break;
-    }
+  if (xdp_app_info_get_desktop_id (app_info))
+    desktop_id = g_strconcat (xdp_app_info_get_desktop_id (app_info), ".desktop", NULL);
 
   if (desktop_id == NULL)
     return NULL;

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -1243,11 +1243,11 @@ xdp_set_documents_mountpoint (const char *path)
 
 /* alternate_document_path converts a file path  */
 char *
-xdp_get_alternate_document_path (const char *path, const char *app_id)
+xdp_get_alternate_document_path (const char *path, const char *app_id, XdpAppInfoKind kind)
 {
   int len;
 
-  if (g_str_equal (app_id, ""))
+  if (g_str_equal (app_id, "") || kind == XDP_APP_INFO_KIND_TEST)
     return NULL;
 
   /* If we don't know where the document portal is mounted, then there
@@ -1452,7 +1452,7 @@ xdp_app_info_get_path_for_fd (XdpAppInfo *app_info,
          as a failure.
       */
       g_autofree char *alt_path = NULL;
-      alt_path = xdp_get_alternate_document_path (path, xdp_app_info_get_id (app_info));
+      alt_path = xdp_get_alternate_document_path (path, app_info->id, app_info->kind);
 
       if (alt_path == NULL)
         return NULL;

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -75,6 +75,7 @@ G_DEFINE_AUTO_CLEANUP_FREE_FUNC(XdpFd, close, -1)
 XdpAppInfo *xdp_app_info_ref             (XdpAppInfo  *app_info);
 void        xdp_app_info_unref           (XdpAppInfo  *app_info);
 const char *xdp_app_info_get_id          (XdpAppInfo  *app_info);
+const char *xdp_app_info_get_desktop_id  (XdpAppInfo  *app_info);
 char *      xdp_app_info_get_instance    (XdpAppInfo  *app_info);
 gboolean    xdp_app_info_is_host         (XdpAppInfo  *app_info);
 XdpAppInfoKind xdp_app_info_get_kind     (XdpAppInfo  *app_info);

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -51,6 +51,7 @@ typedef enum
   XDP_APP_INFO_KIND_HOST = 0,
   XDP_APP_INFO_KIND_FLATPAK = 1,
   XDP_APP_INFO_KIND_SNAP    = 2,
+  XDP_APP_INFO_KIND_TEST    = 3,
 } XdpAppInfoKind;
 
 gint xdp_mkstempat (int    dir_fd,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -115,7 +115,7 @@ char       *xdp_app_info_get_tryexec_path (XdpAppInfo  *app_info);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdpAppInfo, xdp_app_info_unref)
 
 void  xdp_set_documents_mountpoint    (const char *path);
-char *xdp_get_alternate_document_path (const char *path, const char *app_id);
+char *xdp_get_alternate_document_path (const char *path, const char *app_id, XdpAppInfoKind kind);
 
 XdpAppInfo *xdp_invocation_lookup_app_info_sync (GDBusMethodInvocation *invocation,
                                                  GCancellable          *cancellable,

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -2,7 +2,7 @@ test_programs =
 
 TESTS_ENVIRONMENT = \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
-	XDG_DATA_DIRS=$(top_srcdir)/tests/share/:$${XDG_DATA_DIRS} \
+	XDG_DATA_DIRS=$(abs_top_srcdir)/tests/share/:$${XDG_DATA_DIRS} \
 	XDP_UNINSTALLED=1 \
 	$(NULL)
 

--- a/tests/backend/notification.c
+++ b/tests/backend/notification.c
@@ -49,6 +49,7 @@ handle_add_notification (XdpDbusImplNotification *object,
   g_autofree char *path = NULL;
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autofree char *notification_s = NULL;
+  g_autofree char *app_id = NULL;
   g_autoptr(GVariant) notification = NULL;
   g_autoptr(GError) error = NULL;
   int delay;
@@ -59,10 +60,12 @@ handle_add_notification (XdpDbusImplNotification *object,
   g_key_file_load_from_file (keyfile, path, 0, &error);
   g_assert_no_error (error);
 
+  app_id = g_key_file_get_string (keyfile, "notification", "app-id", NULL);
   notification_s = g_key_file_get_string (keyfile, "notification", "data", NULL);
   notification = g_variant_parse (G_VARIANT_TYPE_VARDICT, notification_s, NULL, NULL, &error);
   g_assert_no_error (error);
   g_assert_true (g_variant_equal (notification, arg_notification));
+  g_assert_cmpstr (app_id, ==, arg_app_id);
 
   if (g_key_file_get_boolean (keyfile, "backend", "expect-no-call", NULL))
     g_assert_not_reached ();

--- a/tests/camera.c
+++ b/tests/camera.c
@@ -26,7 +26,7 @@ set_camera_permissions (const char *permission)
                                                            "devices",
                                                            TRUE,
                                                            "camera",
-                                                           "",
+                                                           tests_get_expected_app_id (),
                                                            permissions,
                                                            NULL,
                                                            &error);

--- a/tests/inhibit.c
+++ b/tests/inhibit.c
@@ -1,6 +1,7 @@
 #include <config.h>
 
 #include "inhibit.h"
+#include "utils.h"
 
 #include <libportal/portal.h>
 #include "xdp-impl-dbus.h"
@@ -18,7 +19,7 @@ set_inhibit_permissions (const char **permissions)
                                                            "inhibit",
                                                            TRUE,
                                                            "inhibit",
-                                                           "",
+                                                           tests_get_expected_app_id (),
                                                            permissions,
                                                            NULL,
                                                            &error);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -51,6 +51,7 @@ test(
   'test-doc-portal',
   test_doc_portal,
   env: env_tests,
+  depends: xdg_desktop_portal,
   is_parallel: false,
   protocol: test_protocol,
 )
@@ -149,7 +150,7 @@ foreach p : portal_tests
       'test-portals-@0@'.format(p),
       test_portals,
       args: ['--keep-going', '--tap', '-p', '/portal/@0@'.format(p)],
-      depends: [test_backends, test_portals],
+      depends: [xdg_desktop_portal, test_backends, test_portals],
       env: env_tests,
       is_parallel: false,
       protocol: test_protocol,

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -2,9 +2,11 @@
 #include <config.h>
 
 #include "account.h"
+#include "utils.h"
 
 #include <libportal/portal.h>
 #include "xdp-utils.h"
+#include "xdp-test-utils.h"
 
 extern char outdir[];
 
@@ -52,6 +54,7 @@ test_notification_basic (void)
 
   keyfile = g_key_file_new ();
 
+  g_key_file_set_string (keyfile, "notification", "app-id", tests_get_expected_app_id ());
   g_key_file_set_string (keyfile, "notification", "data", notification_s);
   g_key_file_set_string (keyfile, "notification", "id", "test");
   g_key_file_set_string (keyfile, "notification", "action", "test-action");
@@ -100,6 +103,7 @@ test_notification_buttons (void)
 
   keyfile = g_key_file_new ();
 
+  g_key_file_set_string (keyfile, "notification", "app-id", tests_get_expected_app_id ());
   g_key_file_set_string (keyfile, "notification", "data", notification_s);
   g_key_file_set_string (keyfile, "notification", "id", "test2");
   g_key_file_set_string (keyfile, "notification", "action", "action1");
@@ -160,6 +164,7 @@ test_notification_bad_arg (void)
 
   keyfile = g_key_file_new ();
 
+  g_key_file_set_string (keyfile, "notification", "app-id", tests_get_expected_app_id ());
   g_key_file_set_string (keyfile, "notification", "data", notification_s);
   g_key_file_set_string (keyfile, "notification", "id", "test2");
   g_key_file_set_string (keyfile, "notification", "action", "action1");
@@ -198,6 +203,7 @@ test_notification_bad_priority (void)
 
   keyfile = g_key_file_new ();
 
+  g_key_file_set_string (keyfile, "notification", "app-id", tests_get_expected_app_id ());
   g_key_file_set_string (keyfile, "notification", "data", notification_s);
   g_key_file_set_string (keyfile, "notification", "id", "test2");
   g_key_file_set_string (keyfile, "notification", "action", "action1");
@@ -237,6 +243,7 @@ test_notification_bad_button (void)
 
   keyfile = g_key_file_new ();
 
+  g_key_file_set_string (keyfile, "notification", "app-id", tests_get_expected_app_id ());
   g_key_file_set_string (keyfile, "notification", "data", notification_s);
   g_key_file_set_string (keyfile, "notification", "id", "test2");
   g_key_file_set_string (keyfile, "notification", "action", "action1");

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -80,6 +80,110 @@ test_notification_basic (void)
 }
 
 void
+test_notification_basic_with_desktop_id (void)
+{
+  g_autoptr(XdpPortal) portal = NULL;
+  g_autoptr(GKeyFile) keyfile = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autofree char *path = NULL;
+  g_autoptr(GVariant) notification = NULL;
+  const char *notification_s;
+  gulong id;
+
+  notification_s = "{ 'title': <'title'>, "
+                   "  'body': <'test notification body'>, "
+                   "  'priority': <'normal'>, "
+                   "  'default-action': <'test-action'> }";
+
+  notification = g_variant_parse (G_VARIANT_TYPE_VARDICT, notification_s, NULL, NULL, NULL);
+
+  keyfile = g_key_file_new ();
+  tests_set_app_desktop_id ("some-desktop-id", &error);
+  g_assert_no_error (error);
+
+  g_key_file_set_string (keyfile, "notification", "app-id", tests_get_expected_app_id ());
+  g_key_file_set_string (keyfile, "notification", "desktop-id", tests_get_expected_desktop_id ());
+  g_key_file_set_string (keyfile, "notification", "data", notification_s);
+  g_key_file_set_string (keyfile, "notification", "id", "test");
+  g_key_file_set_string (keyfile, "notification", "action", "test-action");
+  g_key_file_set_integer (keyfile, "backend", "delay", 200);
+
+  path = g_build_filename (outdir, "notification", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+
+  portal = xdp_portal_new ();
+
+  id = g_signal_connect (portal, "notification-action-invoked", G_CALLBACK (notification_action_invoked), keyfile);
+
+  got_info = 0;
+  xdp_portal_add_notification (portal, "test", notification, 0, NULL, NULL, NULL);
+
+  while (!got_info)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_signal_handler_disconnect (portal, id);
+
+  xdp_portal_remove_notification (portal, "test");
+
+  tests_set_app_desktop_id (NULL, &error);
+  g_assert_no_error (error);
+}
+
+void
+test_notification_basic_with_ignored_desktop_id (void)
+{
+  g_autoptr(XdpPortal) portal = NULL;
+  g_autoptr(GKeyFile) keyfile = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autofree char *path = NULL;
+  g_autoptr(GVariant) notification = NULL;
+  const char *notification_s;
+  gulong id;
+
+  notification_s = "{ 'title': <'title'>, "
+                   "  'body': <'test notification body'>, "
+                   "  'priority': <'normal'>, "
+                   "  'default-action': <'test-action'> }";
+
+  notification = g_variant_parse (G_VARIANT_TYPE_VARDICT, notification_s, NULL, NULL, NULL);
+
+  keyfile = g_key_file_new ();
+  tests_set_app_id ("an-app-id-equal-to-desktop-id", &error);
+  g_assert_no_error (error);
+  tests_set_app_desktop_id (tests_get_expected_app_id (), &error);
+  g_assert_no_error (error);
+
+  g_key_file_set_string (keyfile, "notification", "app-id", tests_get_expected_app_id ());
+  g_key_file_set_string (keyfile, "notification", "data", notification_s);
+  g_key_file_set_string (keyfile, "notification", "id", "test");
+  g_key_file_set_string (keyfile, "notification", "action", "test-action");
+  g_key_file_set_integer (keyfile, "backend", "delay", 200);
+
+  path = g_build_filename (outdir, "notification", NULL);
+  g_key_file_save_to_file (keyfile, path, &error);
+  g_assert_no_error (error);
+
+  portal = xdp_portal_new ();
+
+  id = g_signal_connect (portal, "notification-action-invoked", G_CALLBACK (notification_action_invoked), keyfile);
+
+  got_info = 0;
+  xdp_portal_add_notification (portal, "test", notification, 0, NULL, NULL, NULL);
+
+  while (!got_info)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_signal_handler_disconnect (portal, id);
+
+  xdp_portal_remove_notification (portal, "test");
+
+  tests_set_app_id (NULL, &error);
+  tests_set_app_desktop_id (NULL, &error);
+  g_assert_no_error (error);
+}
+
+void
 test_notification_buttons (void)
 {
   g_autoptr(XdpPortal) portal = NULL;

--- a/tests/notification.h
+++ b/tests/notification.h
@@ -2,6 +2,8 @@
 #pragma once
 
 void test_notification_basic (void);
+void test_notification_basic_with_desktop_id (void);
+void test_notification_basic_with_ignored_desktop_id (void);
 void test_notification_buttons (void);
 void test_notification_bad_arg (void);
 void test_notification_bad_priority (void);

--- a/tests/openuri.c
+++ b/tests/openuri.c
@@ -41,7 +41,7 @@ set_openuri_permissions (const char *type,
                                                            "desktop-used-apps",
                                                            TRUE,
                                                            type,
-                                                           "",
+                                                           tests_get_expected_app_id (),
                                                            permissions,
                                                            NULL,
                                                            &error);

--- a/tests/screenshot.c
+++ b/tests/screenshot.c
@@ -1,6 +1,7 @@
 #include <config.h>
 
 #include "screenshot.h"
+#include "utils.h"
 
 #include <libportal/portal.h>
 #include "xdp-impl-dbus.h"
@@ -17,12 +18,15 @@ set_screenshot_permissions (const char *permission)
   const char *permissions[2] = { NULL, NULL };
   g_autoptr(GError) error = NULL;
 
+  tests_set_app_id ("furrfix", &error);
+  g_assert_no_error (error);
+
   permissions[0] = permission;
   xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
                                                            "screenshot",
                                                            TRUE,
                                                            "screenshot",
-                                                           "",
+                                                           tests_get_expected_app_id (),
                                                            permissions,
                                                            NULL,
                                                            &error);
@@ -32,7 +36,11 @@ set_screenshot_permissions (const char *permission)
 static void
 reset_screenshot_permissions (void)
 {
+  GError *error = NULL;
+
   set_screenshot_permissions (NULL);
+  tests_set_app_id (NULL, &error);
+  g_assert_no_error (error);
 }
 
 static void

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -694,6 +694,8 @@ main (int argc, char **argv)
   g_test_add_func ("/portal/background/reason", test_background_reason);
 
   g_test_add_func ("/portal/notification/basic", test_notification_basic);
+  g_test_add_func ("/portal/notification/basic-with-desktop-id", test_notification_basic_with_desktop_id);
+  g_test_add_func ("/portal/notification/basic-with-ignored-desktop-id", test_notification_basic_with_ignored_desktop_id);
   g_test_add_func ("/portal/notification/buttons", test_notification_buttons);
   g_test_add_func ("/portal/notification/bad-arg", test_notification_bad_arg);
   g_test_add_func ("/portal/notification/bad-priority", test_notification_bad_priority);

--- a/tests/test-xdp-utils.c
+++ b/tests/test-xdp-utils.c
@@ -103,25 +103,25 @@ test_alternate_doc_path (void)
   xdp_set_documents_mountpoint (NULL);
 
   /* If no documents mount point is set, there is no alternate path */
-  path = xdp_get_alternate_document_path ("/whatever", "app-id");
+  path = xdp_get_alternate_document_path ("/whatever", "app-id", XDP_APP_INFO_KIND_HOST);
   g_assert_cmpstr (path, ==, NULL);
 
   xdp_set_documents_mountpoint ("/doc/portal");
 
   /* Paths outside of the document portal do not have an alternate path */
-  path = xdp_get_alternate_document_path ("/whatever", "app-id");
+  path = xdp_get_alternate_document_path ("/whatever", "app-id", XDP_APP_INFO_KIND_HOST);
   g_assert_cmpstr (path, ==, NULL);
 
   /* The doc portal mount point itself does not have an alternate path */
-  path = xdp_get_alternate_document_path ("/doc/portal", "app-id");
+  path = xdp_get_alternate_document_path ("/doc/portal", "app-id", XDP_APP_INFO_KIND_HOST);
   g_assert_cmpstr (path, ==, NULL);
 
   /* Paths under the doc portal mount point have an alternate path */
-  path = xdp_get_alternate_document_path ("/doc/portal/foo/bar", "app-id");
+  path = xdp_get_alternate_document_path ("/doc/portal/foo/bar", "app-id", XDP_APP_INFO_KIND_HOST);
   g_assert_cmpstr (path, ==, "/doc/portal/by-app/app-id/foo/bar");
 
   g_clear_pointer (&path, g_free);
-  path = xdp_get_alternate_document_path ("/doc/portal/foo/bar", "second-app");
+  path = xdp_get_alternate_document_path ("/doc/portal/foo/bar", "second-app", XDP_APP_INFO_KIND_HOST);
   g_assert_cmpstr (path, ==, "/doc/portal/by-app/second-app/foo/bar");
 
   xdp_set_documents_mountpoint (NULL);

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -9,3 +9,9 @@ gboolean tests_set_property_sync (GDBusProxy *proxy,
                                   GError **error);
 
 void setup_dbus_daemon_wrapper (const char *outdir);
+
+gboolean tests_set_app_id (const char *app_id, GError **error);
+gboolean tests_set_app_desktop_id (const char *desktop_id, GError **error);
+
+const char *tests_get_expected_app_id (void);
+const char *tests_get_expected_desktop_id (void);

--- a/tests/wallpaper.c
+++ b/tests/wallpaper.c
@@ -1,6 +1,7 @@
 #include <config.h>
 
 #include "account.h"
+#include "utils.h"
 
 #include <libportal/portal.h>
 #include "xdp-impl-dbus.h"
@@ -22,7 +23,7 @@ set_wallpaper_permissions (const char *permission)
                                                            "wallpaper",
                                                            TRUE,
                                                            "wallpaper",
-                                                           "",
+                                                           tests_get_expected_app_id (),
                                                            permissions,
                                                            NULL,
                                                            &error);


### PR DESCRIPTION
Notification implementers expects that the app-id is always matching the
application desktop-id, but while this is true for flatpaks is not true
for snaps, so include an extra desktop-id value the notification so that
can be used by the portals to properly implement actions and notify the
shell.
