### PR TITLE
RemoteDesktop: Pass the creator's pid when creating a session

### DIFF
--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -39,6 +39,16 @@
         org.freedesktop.portal.ScreenCast), but may only be started and stopped
         with this interface.
 
+        The following results get passed via the options argument:
+        <variablelist>
+          <varlistentry>
+            <term>pid t</term>
+            <listitem><para>
+              The process id of the process that is creating the session.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
         The following results get returned via the #org.freedesktop.portal.Request::Response signal:
         <variablelist>
           <varlistentry>

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -279,6 +279,8 @@ handle_create_session (XdpDbusRemoteDesktop *object,
     }
 
   g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&options_builder, "{sv}",
+                         "pid", g_variant_new ("t", xdp_app_info_get_pid (request->app_info)));
   options = g_variant_builder_end (&options_builder);
 
   g_object_set_qdata_full (G_OBJECT (request),

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -75,6 +75,7 @@ G_DEFINE_AUTO_CLEANUP_FREE_FUNC(XdpFd, close, -1)
 XdpAppInfo *xdp_app_info_ref             (XdpAppInfo  *app_info);
 void        xdp_app_info_unref           (XdpAppInfo  *app_info);
 const char *xdp_app_info_get_id          (XdpAppInfo  *app_info);
+pid_t       xdp_app_info_get_pid         (XdpAppInfo  *app_info);
 char *      xdp_app_info_get_instance    (XdpAppInfo  *app_info);
 gboolean    xdp_app_info_is_host         (XdpAppInfo  *app_info);
 XdpAppInfoKind xdp_app_info_get_kind     (XdpAppInfo  *app_info);


### PR DESCRIPTION
The portal implementation can use the extra information to decide to which extent the request should be trusted. This can be done by checking the process namespace or its origin in the filesystem.