### PR TITLE
global-shortcuts: Responses should succeed if nothing wrong happened

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -85,7 +85,7 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <arg type="a{sv}" name="results" direction="out"/>
-      <annotation value="QMap&lt;QString,QVariantMap&gt;" name="org.qtproject.QtDBus.QtTypeName.In2"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
     </method>
@@ -168,7 +168,7 @@
     <signal name="ShortcutsChanged">
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QMap&lt;QString,QVariantMap&gt;"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
     </signal>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -83,9 +83,11 @@
       <arg type="a(sa{sv})" name="shortcuts" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
       <arg type="a{sv}" name="results" direction="out"/>
+      <annotation value="QMap&lt;QString,QVariantMap&gt;" name="org.qtproject.QtDBus.QtTypeName.In2"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
     </method>
 
     <!--
@@ -113,8 +115,9 @@
     <method name="ListShortcuts">
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
       <arg type="a{sv}" name="results" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
     </method>
 
     <!--

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -167,7 +167,7 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="request_handle" direction="out"/>
 
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QMap&lt;QString,QVariantMap&gt;"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
     </method>
 
@@ -260,7 +260,7 @@
     <signal name="ShortcutsChanged">
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QMap&lt;QString,QVariantMap&gt;"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
     </signal>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -92,6 +92,7 @@
         @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
         @shortcuts: The list of shortcuts to bind
         @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
+        @options: Vardict with optional further information
         @request_handle: Object path for the #org.freedesktop.portal.Request object representing this call
 
         Bind the shortcuts. This will typically result the portal presenting a
@@ -112,6 +113,19 @@
             <listitem><para>
               The preferred shortcut trigger, defined as described by the "shortcuts"
               XDG specification. Optional.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the
+              @handle. Must be a valid object path element. See the
+              #org.freedesktop.portal.Request documentation for more
+              information about the @handle.
             </para></listitem>
           </varlistentry>
         </variablelist>
@@ -160,9 +174,22 @@
     <!--
         ListShortcuts:
         @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
-        @options: Unused so far
+        @options: Vardict with optional further information
 
         Lists all shortcuts.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>handle_token s</term>
+            <listitem><para>
+              A string that will be used as the last element of the
+              @handle. Must be a valid object path element. See the
+              #org.freedesktop.portal.Request documentation for more
+              information about the @handle.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
 
         The following results get returned via the #org.freedesktop.portal.Request::Response signal:
         <variablelist>
@@ -180,7 +207,9 @@
     -->
     <method name="ListShortcuts">
       <arg type="o" name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="request_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
 
     <!--

--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -278,7 +278,7 @@ shortcuts_bound_cb (GObject *source_object,
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
 
-  if (!xdp_dbus_impl_global_shortcuts_call_bind_shortcuts_finish (impl, &results, res, &error))
+  if (!xdp_dbus_impl_global_shortcuts_call_bind_shortcuts_finish (impl, &response, &results, res, &error))
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("A backend call failed: %s", error->message);
@@ -378,7 +378,7 @@ shortcuts_listed_cb (GObject *source_object,
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
 
-  if (!xdp_dbus_impl_global_shortcuts_call_list_shortcuts_finish (impl, &results, res, &error))
+  if (!xdp_dbus_impl_global_shortcuts_call_list_shortcuts_finish (impl, &response, &results, res, &error))
     {
       g_dbus_error_strip_remote_error (error);
       g_warning ("A backend call failed: %s", error->message);
@@ -402,7 +402,8 @@ shortcuts_listed_cb (GObject *source_object,
 static gboolean
 handle_list_shortcuts (XdpDbusGlobalShortcuts *object,
                        GDBusMethodInvocation *invocation,
-                       const gchar *arg_session_handle)
+                       const gchar *arg_session_handle,
+                       GVariant *arg_options)
 {
   Request *request = request_from_invocation (invocation);
   Session *session;

--- a/src/request.c
+++ b/src/request.c
@@ -353,6 +353,10 @@ get_token (GDBusMethodInvocation *invocation)
         {
           options = g_variant_get_child_value (parameters, 3);
         }
+      else if (strcmp (method, "ListShortcuts") == 0 )
+        {
+          options = g_variant_get_child_value (parameters, 1);
+        }
       else
         {
           g_warning ("Support for %s::%s missing in %s",


### PR DESCRIPTION
We were always returning 2, which is not correct.