### PR TITLE
global-shortcuts: Signal arguments are outputs

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -130,11 +130,11 @@
         Emitted when a shortcut is activated.
     -->
     <signal name="Activated">
-      <arg type="o" name="session_handle" direction="in"/>
-      <arg type="s" name="shortcut_id" direction="in"/>
-      <arg type="t" name="timestamp" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
+      <arg type="o" name="session_handle" direction="out"/>
+      <arg type="s" name="shortcut_id" direction="out"/>
+      <arg type="t" name="timestamp" direction="out"/>
+      <arg type="a{sv}" name="options" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
     </signal>
 
     <!--
@@ -147,11 +147,11 @@
         Emitted when a shortcut is deactivated.
     -->
     <signal name="Deactivated">
-      <arg type="o" name="session_handle" direction="in"/>
-      <arg type="s" name="shortcut_id" direction="in"/>
-      <arg type="t" name="timestamp" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
+      <arg type="o" name="session_handle" direction="out"/>
+      <arg type="s" name="shortcut_id" direction="out"/>
+      <arg type="t" name="timestamp" direction="out"/>
+      <arg type="a{sv}" name="options" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out3" value="QVariantMap"/>
     </signal>
 
     <!--

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -222,11 +222,11 @@
         Notifies about a shortcut becoming active.
     -->
     <signal name="Activated">
-      <arg type="o" name="session_handle" direction="in"/>
-      <arg type="s" name="shortcut_id" direction="in"/>
-      <arg type="t" name="timestamp" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg type="o" name="session_handle" direction="out"/>
+      <arg type="s" name="shortcut_id" direction="out"/>
+      <arg type="t" name="timestamp" direction="out"/>
+      <arg type="a{sv}" name="options" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out3" value="QVariantMap"/>
     </signal>
 
     <!--
@@ -239,11 +239,11 @@
         Notifies that a shortcut is not active anymore.
     -->
     <signal name="Deactivated">
-      <arg type="o" name="session_handle" direction="in"/>
-      <arg type="s" name="shortcut_id" direction="in"/>
-      <arg type="t" name="timestamp" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
+      <arg type="o" name="session_handle" direction="out"/>
+      <arg type="s" name="shortcut_id" direction="out"/>
+      <arg type="t" name="timestamp" direction="out"/>
+      <arg type="a{sv}" name="options" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out3" value="QVariantMap"/>
     </signal>
 
     <!--


### PR DESCRIPTION
I'm a bit surprised that the different tooling didn't complain about this, is this something that should be supported?