### PR TITLE
CI: bump some actions to newer versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,10 +29,10 @@ jobs:
       id: env-setup
       run: |
         if [ "${{ matrix.sanitizer }}" == "address" ]; then
-          echo "::set-output name=cflags::$BASE_CFLAGS" \
-            "-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address";
+          echo "cflags=$BASE_CFLAGS" \
+            "-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address" >> $GITHUB_OUTPUT;
         else
-          echo "::set-output name=cflags::$BASE_CFLAGS";
+          echo "cflags=$BASE_CFLAGS" >> $GITHUB_OUTPUT;
         fi
 
     - name: Prepare container

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,7 +80,7 @@ jobs:
           shared-mime-info
 
     - name: Check out xdg-desktop-portal
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup test user
       run: |
@@ -117,7 +117,7 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
 
     - name: Upload test logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure() || cancelled()
       with:
         name: test logs
@@ -186,7 +186,7 @@ jobs:
           shared-mime-info
 
     - name: Check out xdg-desktop-portal
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup test user
       run: |
@@ -226,7 +226,7 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
 
     - name: Upload test logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure() || cancelled()
       with:
         name: test logs
@@ -271,7 +271,7 @@ jobs:
         ninja -C _build install
 
     - name: Check out xdg-desktop-portal
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure xdg-desktop-portal
       # TODO: Enable gtk-doc builds

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
             xmlto
 
       - name: Check out xdg-desktop-portal
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build docs
         run: |


### PR DESCRIPTION
Node 12 is deprecated so let's bump the actions to newer versions that use Node 16. See
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/