### PR TITLE
CI: make the autotools vs meson decision a matrix field

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -153,7 +153,6 @@ jobs:
 
     - name: Upload test logs
       uses: actions/upload-artifact@v3
-      if: failure() || cancelled()
       with:
         name: test logs
         path: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,11 +8,12 @@ env:
 
 jobs:
   # identical to the meson job but for the autotools commands
-  check-autotools:
-    name: Ubuntu 22.04 autotools build
+  check:
+    name: Ubuntu 22.04 build
     runs-on: ubuntu-22.04
     strategy:
       matrix:
+        buildsystem: ['autotools', 'meson']
         compiler: ['gcc', 'clang']
         sanitizer: ['address']
 
@@ -23,6 +24,7 @@ jobs:
       BUILD_CONTAINER: ${{ matrix.compiler }}-build-container
       RUN_CMD: docker exec -t -w /src -e TEST_IN_CI -e ASAN_OPTIONS -e G_MESSAGES_DEBUG -e XDG_DATA_DIRS ${{ matrix.compiler }}-build-container
       AS_USER: runuser -u tester --
+      BUILDDIR: builddir
 
     steps:
     - name: Prepare environment
@@ -54,9 +56,6 @@ jobs:
         $RUN_CMD apt-get upgrade -y
         $RUN_CMD apt-get install -y --no-install-recommends \
           ${{ matrix.compiler }} \
-          autoconf \
-          automake \
-          autopoint \
           desktop-file-utils \
           fuse3 \
           gettext \
@@ -75,9 +74,23 @@ jobs:
           libsystemd-dev \
           libtool \
           llvm \
-          make \
           python3-gi \
           shared-mime-info
+
+    - name: Install dependencies for autotools
+      run: |
+        $RUN_CMD apt-get install -y --no-install-recommends \
+          autoconf \
+          automake \
+          autopoint \
+          make
+      if: ${{ matrix.buildsystem == 'autotools' }}
+
+    - name: Install dependencies for meson
+      run: |
+        $RUN_CMD apt-get install -y --no-install-recommends \
+          meson
+      if: ${{ matrix.buildsystem == 'meson' }}
 
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v3
@@ -87,21 +100,43 @@ jobs:
         $RUN_CMD adduser --disabled-password --gecos "" tester
         $RUN_CMD chown tester:tester . -R
 
-    - name: Configure xdg-desktop-portal
-      run: $RUN_CMD $AS_USER ./autogen.sh --disable-dependency-tracking --enable-installed-tests
+    - name: Build xdg-desktop-portal with autotools
+      run: |
+        $RUN_CMD $AS_USER ./autogen.sh --disable-dependency-tracking --enable-installed-tests
+        $RUN_CMD $AS_USER make
+      if: ${{ matrix.buildsystem == 'autotools' }}
 
-    - name: Build xdg-desktop-portal
-      run: $RUN_CMD $AS_USER make
-
-    - name: Run xdg-desktop-portal tests
+    - name: Run xdg-desktop-portal tests with autotools
       run: $RUN_CMD $AS_USER timeout --signal=KILL -v ${TESTS_TIMEOUT}m make check
       env:
         TEST_IN_CI: 1
         G_MESSAGES_DEBUG: all
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
+      if: ${{ matrix.buildsystem == 'autotools' }}
 
-    - name: Install xdg-desktop-portal
+    - name: Build xdg-desktop-portal with meson
+      run: |
+        $RUN_CMD $AS_USER meson setup ${BUILDDIR} $MESON_OPTIONS
+        $RUN_CMD $AS_USER meson compile -C ${BUILDDIR}
+      env:
+        MESON_OPTIONS: -Dinstalled-tests=true -Db_sanitize=${{ matrix.sanitizer }}
+      if: ${{ matrix.buildsystem == 'meson' }}
+
+    - name: Run xdg-desktop-portal tests with meson
+      run: $RUN_CMD $AS_USER timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR}
+      env:
+        TEST_IN_CI: 1
+        G_MESSAGES_DEBUG: all
+        ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
+      if: ${{ matrix.buildsystem == 'meson' }}
+
+    - name: Install xdg-desktop-portal with autotools
       run: $RUN_CMD make install
+      if: ${{ matrix.buildsystem == 'autotools' }}
+
+    - name: Install xdg-desktop-portal with meson
+      run: $RUN_CMD meson install -C ${BUILDDIR}
+      if: ${{ matrix.buildsystem == 'meson' }}
 
     - name: Run xdg-desktop-portal installed-tests
       run: |
@@ -125,114 +160,7 @@ jobs:
           tests/*.log
           test-*.log
           installed-test-logs/
-
-  # identical to the autotools job but for the meson commands
-  check-meson:
-    name: Ubuntu 22.04 meson build
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        compiler: ['gcc', 'clang']
-        sanitizer: ['address']
-
-    env:
-      UBUNTU_VERSION: '22.04'
-      CC: ${{ matrix.compiler }}
-      BASE_CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
-      BUILD_CONTAINER: ${{ matrix.compiler }}-build-container
-      RUN_CMD: docker exec -t -w /src -e TEST_IN_CI -e ASAN_OPTIONS -e G_MESSAGES_DEBUG -e XDG_DATA_DIRS ${{ matrix.compiler }}-build-container
-      AS_USER: runuser -u tester --
-      BUILDDIR: builddir
-
-    steps:
-    - name: Prepare container
-      run: |
-        docker run --name $BUILD_CONTAINER \
-          --tty --device /dev/fuse --cap-add SYS_ADMIN \
-          --security-opt apparmor:unconfined \
-          -v $(pwd):/src \
-          -e DEBIAN_FRONTEND \
-          -e DEBCONF_NONINTERACTIVE_SEEN=true \
-          -e TERM=dumb \
-          -e MAKEFLAGS="-j $(getconf _NPROCESSORS_ONLN)" \
-          -e CC -e CFLAGS="${{ steps.env-setup.outputs.cflags }}" \
-          -d ubuntu:$UBUNTU_VERSION sleep infinity
-
-    - name: Install dependencies
-      run: |
-        $RUN_CMD apt-get update
-        $RUN_CMD apt-get upgrade -y
-        $RUN_CMD apt-get install -y --no-install-recommends \
-          ${{ matrix.compiler }} \
-          desktop-file-utils \
-          fuse3 \
-          gettext \
-          gnome-desktop-testing \
-          gtk-doc-tools \
-          libcap2-bin \
-          libflatpak-dev \
-          libfontconfig1-dev \
-          libfuse3-dev \
-          libgdk-pixbuf-2.0-dev \
-          libgeoclue-2-dev \
-          libglib2.0-dev \
-          libjson-glib-dev \
-          libpipewire-0.3-dev \
-          libportal-dev \
-          libsystemd-dev \
-          llvm \
-          meson \
-          python3-gi \
-          shared-mime-info
-
-    - name: Check out xdg-desktop-portal
-      uses: actions/checkout@v3
-
-    - name: Setup test user
-      run: |
-        $RUN_CMD adduser --disabled-password --gecos "" tester
-        $RUN_CMD chown tester:tester . -R
-
-    - name: Configure xdg-desktop-portal with meson
-      run: |
-        $RUN_CMD $AS_USER meson setup ${BUILDDIR} $MESON_OPTIONS
-      env:
-        MESON_OPTIONS: -Dinstalled-tests=true -Db_sanitize=${{ matrix.sanitizer }}
-
-    - name: Build xdg-desktop-portal with meson
-      run: $RUN_CMD $AS_USER meson compile -C ${BUILDDIR}
-
-    - name: Run xdg-desktop-portal tests with meson
-      run: $RUN_CMD $AS_USER timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR}
-      env:
-        TEST_IN_CI: 1
-        G_MESSAGES_DEBUG: all
-        ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
-
-    - name: Install xdg-desktop-portal with meson
-      run: $RUN_CMD meson install -C {$BUILDDIR}
-
-    - name: Run xdg-desktop-portal installed-tests
-      run: |
-        test -n "$($RUN_CMD $AS_USER gnome-desktop-testing-runner -l xdg-desktop-portal)"
-        $RUN_CMD $AS_USER \
-          env TEST_INSTALLED_IN_CI=1 XDG_DATA_DIRS=/src/tests/share/:$XDG_DATA_DIRS \
-          gnome-desktop-testing-runner --report-directory installed-test-logs/ \
-            -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
-      env:
-        G_MESSAGES_DEBUG: all
-        TEST_IN_CI: 1
-        XDG_DATA_DIRS: /usr/local/share:/usr/share
-        ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
-
-    - name: Upload test logs
-      uses: actions/upload-artifact@v3
-      if: failure() || cancelled()
-      with:
-        name: test logs
-        path: |
           builddir/meson-logs/testlog.txt
-          installed-test-logs/
 
   xenial:
     name: Ubuntu 16.04 build (old glib)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,9 +52,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        $RUN_CMD apt-get update
-        $RUN_CMD apt-get upgrade -y
-        $RUN_CMD apt-get install -y --no-install-recommends \
+        $RUN_CMD apt-get update --quiet
+        $RUN_CMD apt-get upgrade --quiet -y
+        $RUN_CMD apt-get install --quiet -y --no-install-recommends \
           ${{ matrix.compiler }} \
           desktop-file-utils \
           fuse3 \
@@ -79,7 +79,7 @@ jobs:
 
     - name: Install dependencies for autotools
       run: |
-        $RUN_CMD apt-get install -y --no-install-recommends \
+        $RUN_CMD apt-get install --quiet -y --no-install-recommends \
           autoconf \
           automake \
           autopoint \
@@ -88,7 +88,7 @@ jobs:
 
     - name: Install dependencies for meson
       run: |
-        $RUN_CMD apt-get install -y --no-install-recommends \
+        $RUN_CMD apt-get install --quiet -y --no-install-recommends \
           meson
       if: ${{ matrix.buildsystem == 'meson' }}
 
@@ -168,10 +168,10 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        apt-get update -y
-        apt-get install -y software-properties-common
+        apt-get update --quiet -y
+        apt-get install --quiet -y software-properties-common
         add-apt-repository ppa:alexlarsson/flatpak
-        apt-get install -y \
+        apt-get install --quiet -y \
           autoconf \
           automake \
           autopoint \
@@ -190,7 +190,7 @@ jobs:
     - name: Install libfuse3
       run: |
         # Install libfuse3 dependencies
-        apt-get install -y git python3-pip udev
+        apt-get install --quiet -y git python3-pip udev
         pip3 install meson==0.56.2 ninja
         git clone https://github.com/libfuse/libfuse.git
         cd libfuse

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Prepare environment
       id: env-setup
       run: |
-        if [ "${{ matrix.sanitizer }}" == "address" ]; then
+        if [ "${{ matrix.sanitizer }}" == "address" && "${{ matrix.buildsystem }}" == "autotools" ]; then
           echo "cflags=$BASE_CFLAGS" \
             "-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address" >> $GITHUB_OUTPUT;
         else

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -210,7 +210,7 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
 
     - name: Install xdg-desktop-portal with meson
-      run: $RUN_CMD meson install -C builddir
+      run: $RUN_CMD meson install -C {$BUILDDIR}
 
     - name: Run xdg-desktop-portal installed-tests
       run: |


### PR DESCRIPTION
This sits on top of #925 

Instead of two near-identical workflow jobs, push the buildsystem into the matrix and make the various `run:` commands dependent on that matrix value. This removes *some* duplication, albeit not that much. But it's probably better than having this separately.

In particular, I'm interested in the `CI: only pass the sanitize CFLAGS through for autotools` commit because that is what makes building libei from git harder in #714.