### PR TITLE
ScreenCast/RemoteDesktop: add option to pass a description

### DIFF
--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -80,6 +80,22 @@
         @results: Vardict with the results of the call
 
         Start the remote desktop session.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>description s</term>
+            <listitem><para>
+              A localized user facing string meant to provide a description
+              about the context the application intends use the shared
+              resources. Portal backends may incorporate this into potential
+              dialogs allowing users to make more well informed decisions.
+              An example of such description can be a name of a web page
+              making request to use the shared resources.
+              E.g. www.videomeeting.com is requesting access to your screen.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
     -->
     <method name="Start">
       <arg type="o" name="handle" direction="in"/>

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -152,6 +152,22 @@
         Start the screen cast session. This will typically result the portal presenting
         a dialog letting the user do the selection set up by SelectSources.
 
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>description s</term>
+            <listitem><para>
+              A localized user facing string meant to provide a description
+              about the context the application intends use the shared
+              resources. Portal backends may incorporate this into potential
+              dialogs allowing users to make more well informed decisions.
+              An example of such description can be a name of a web page
+              making request to use the shared resources.
+              E.g. www.videomeeting.com is requesting access to your screen.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
         The following results get returned via the #org.freedesktop.portal.Request::Response signal:
         <variablelist>
           <varlistentry>

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -137,6 +137,18 @@
               more information about the @handle.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>description s</term>
+            <listitem><para>
+              A localized user facing string meant to provide a description
+              about the context the application intends use the shared
+              resources. Portal backends may incorporate this into potential
+              dialogs allowing users to make more well informed decisions.
+              An example of such description can be a name of a web page
+              making request to use the shared resources.
+              E.g. www.videomeeting.com is requesting access to your screen.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned via the

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -191,6 +191,18 @@
               more information about the @handle.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>description s</term>
+            <listitem><para>
+              A localized user facing string meant to provide a description
+              about the context the application intends use the shared
+              resources. Portal backends may incorporate this into potential
+              dialogs allowing users to make more well informed decisions.
+              An example of such description can be a name of a web page
+              making request to use the shared resources.
+              E.g. www.videomeeting.com is requesting access to your screen.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned via the

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -575,6 +575,10 @@ start_done (GObject *source_object,
     }
 }
 
+static XdpOptionKey remote_desktop_start_options[] = {
+  { "description", G_VARIANT_TYPE_STRING, NULL }
+};
+
 static gboolean
 handle_start (XdpDbusRemoteDesktop *object,
               GDBusMethodInvocation *invocation,
@@ -657,6 +661,14 @@ handle_start (XdpDbusRemoteDesktop *object,
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
   g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  if (!xdp_filter_options (arg_options, &options_builder,
+                           remote_desktop_start_options,
+                           G_N_ELEMENTS (remote_desktop_start_options),
+                           &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
   options = g_variant_builder_end (&options_builder);
 
   g_object_set_qdata_full (G_OBJECT (request),

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -1140,6 +1140,10 @@ start_done (GObject *source_object,
     }
 }
 
+static XdpOptionKey screen_cast_start_options[] = {
+  { "description", G_VARIANT_TYPE_STRING, NULL }
+};
+
 static gboolean
 handle_start (XdpDbusScreenCast *object,
               GDBusMethodInvocation *invocation,
@@ -1215,6 +1219,14 @@ handle_start (XdpDbusScreenCast *object,
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
   g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  if (!xdp_filter_options (arg_options, &options_builder,
+                           screen_cast_start_options,
+                           G_N_ELEMENTS (screen_cast_start_options),
+                           &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
   options = g_variant_builder_end (&options_builder);
 
   g_object_set_qdata_full (G_OBJECT (request),


### PR DESCRIPTION
Description can be used to further specify details about the request itself. This can be for example used by web browsers to specify the web page that requests the access or hinting a scene/source in case of applications like OBS Studio.

Fixes #758
