### PR TITLE
file-chooser: Set writable flag correctly

### DIFF
--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -79,6 +79,7 @@ send_response_in_thread_func (GTask        *task,
   const char **uris;
   GVariant *choices;
   GVariant *current_filter;
+  GVariant *writable;
 
   g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_init (&ruris, G_VARIANT_TYPE_STRING_ARRAY);
@@ -95,7 +96,8 @@ send_response_in_thread_func (GTask        *task,
   if (response != 0)
     goto out;
 
-  if (!g_variant_lookup_value (options, "writable", G_VARIANT_TYPE("b")))
+  writable = g_variant_lookup_value (options, "writable", G_VARIANT_TYPE("b"));
+  if (writable && !g_variant_get_boolean (writable))
     flags &= ~DOCUMENT_FLAG_WRITABLE;
 
   choices = g_variant_lookup_value (options, "choices", G_VARIANT_TYPE ("a(ss)"));


### PR DESCRIPTION
Previously this was evaluating as if (gvariant != NULL) which is always true if the option is present, this caused all files to be passed down as read-write regardless of what the impl, app and user requested.

I tested this change locally using Bustle and one can see that the permission store gets 

```
([handle 0], uint32 7, 'com.belmoussaoui.ashpd.demo', ['read', 'grant-permissions'])
```

rather than 

```
([handle 0], uint32 7, 'com.belmoussaoui.ashpd.demo', ['read', 'write', 'grant-permissions'])
```

when the user ticks the "read-only" choice in the file picker.