### PR TITLE
tests: Add missing dependency on permission-store GDBus header

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -116,6 +116,7 @@ endif
 test_portals = executable(
   'test-portals',
   impl_built_sources,
+  permission_store_built_sources,
   portal_built_sources,
   sd_escape_sources,
   test_portals_sources,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -115,7 +115,11 @@ endif
 
 test_portals = executable(
   'test-portals',
-  test_portals_sources + portal_built_sources + impl_built_sources + xdp_utils_sources + sd_escape_sources,
+  impl_built_sources,
+  portal_built_sources,
+  sd_escape_sources,
+  test_portals_sources,
+  xdp_utils_sources,
   dependencies: [common_deps, libportal_dep, libsystemd_dep],
   include_directories: [common_includes, xdp_utils_includes],
   c_args: ['-DXDG_DP_BUILDDIR="src"',  '-DXDG_PS_BUILDDIR="document-portal"'],


### PR DESCRIPTION
* tests: List lists of sources one per line in alphabetical order
    
    This will make it easier to add more without merge conflicts or a very
    long line.

* tests: Add missing dependency on permission-store GDBus header
    
    When doing a clean build of x-d-p, we need generated headers to have
    been generated before we try to compile code that includes them.
    
    Resolves: https://github.com/flatpak/xdg-desktop-portal/issues/942