### PR TITLE
docs: Update supported versions table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ please check
 
 | Version   | Supported          | Status
 | --------  | ------------------ | ------------------------------------------------------------- |
-| 1.15.x    | :white_check_mark: | Development branch, releases may include non-security changes |
-| 1.14.x    | :white_check_mark: | Stable branch, recommended for use in distributions           |
-| 1.12.x    | :white_check_mark: | Old stable branch, still maintained                           |
-| <= 1.10.x | :x:                | Older branches, no longer supported                           |
+| 1.17.x    | :white_check_mark: | Development branch, releases may include non-security changes |
+| 1.16.x    | :white_check_mark: | Stable branch, recommended for use in distributions           |
+| 1.14.x    | :white_check_mark: | Old stable branch, still maintained                           |
+| <= 1.12.x | :x:                | Older branches, no longer supported                           |


### PR DESCRIPTION
Now that 1.16 is out, we can drop 1.12 from the list of supported versions.