### PR TITLE
A few fixes for the pytest test suite

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -219,15 +219,26 @@ python = pymod.find_installation(
 )
 
 if pytest.found() and python.found()
-  test_env = environment()
-  test_env.set('XDP_UNINSTALLED', '1')
+  subdir('templates')
+  pytest_files = [
+    '__init__.py',
+    'test_email.py',
+    'test_remotedesktop.py',
+    'test_trash.py',
+  ]
+  foreach pytest_file : pytest_files
+    configure_file(
+      input: pytest_file,
+      output: pytest_file,
+      copy: true,
+      install: false
+    )
+  endforeach
 
   test(
     'pytest',
     pytest,
     args: ['--verbose', '--log-level=DEBUG'],
-    env: test_env,
-    workdir: meson.project_source_root(),
     suite: ['pytest'],
   )
 endif

--- a/tests/templates/meson.build
+++ b/tests/templates/meson.build
@@ -1,0 +1,13 @@
+template_files = [
+  '__init__.py',
+  'email.py',
+  'remotedesktop.py',
+]
+foreach template_file : template_files
+  configure_file(
+    input: template_file,
+    output: template_file,
+    copy: true,
+    install: false
+  )
+endforeach


### PR DESCRIPTION
After successfully paging everything out about this test suite, I struggled to run it - because the defaults only work on autotools but not on meson. This patchset fixes (and documents) this a bit better. Once #977 is merged we can probably drop a few of these.