### PR TITLE
portal-impl: Only return found implementation if it launched

### DIFF
--- a/src/portal-impl.h
+++ b/src/portal-impl.h
@@ -23,6 +23,7 @@
 #define __PORTAL_IMPL_H__
 
 #include <glib.h>
+#include <gio/gio.h>
 
 typedef struct {
   char *source;
@@ -30,10 +31,12 @@ typedef struct {
   char **interfaces;
   char **use_in;
   int priority;
+  GHashTable *dummy_proxies;
 } PortalImplementation;
 
 void                  load_installed_portals          (gboolean opt_verbose);
-PortalImplementation *find_portal_implementation      (const char *interface);
+PortalImplementation *find_portal_implementation      (GDBusConnection *connection,
+                                                       const char *interface);
 GPtrArray            *find_all_portal_implementations (const char *interface);
 
 #endif  /* __PORTAL_IMPL_H__ */

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -237,7 +237,8 @@ on_bus_acquired (GDBusConnection *connection,
   init_document_proxy (connection);
   init_permission_store (connection);
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Lockdown");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Lockdown");
   if (implementation != NULL)
     lockdown = xdp_dbus_impl_lockdown_proxy_new_sync (connection,
                                                       G_DBUS_PROXY_FLAGS_NONE,
@@ -259,40 +260,48 @@ on_bus_acquired (GDBusConnection *connection,
   export_portal_implementation (connection, settings_create (connection, impls));
   g_ptr_array_free (impls, TRUE);
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.FileChooser");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.FileChooser");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   file_chooser_create (connection, implementation->dbus_name, lockdown));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.AppChooser");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.AppChooser");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   open_uri_create (connection, implementation->dbus_name, lockdown));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Print");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Print");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   print_create (connection, implementation->dbus_name, lockdown));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Notification");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Notification");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   notification_create (connection, implementation->dbus_name));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Inhibit");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Inhibit");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   inhibit_create (connection, implementation->dbus_name));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Access");
-  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Screenshot");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Access");
+  implementation2 = find_portal_implementation (connection,
+                                                "org.freedesktop.impl.portal.Screenshot");
   if (implementation != NULL && implementation2 != NULL)
     export_portal_implementation (connection,
                                   screenshot_create (connection,
                                                      implementation->dbus_name,
                                                      implementation2->dbus_name));
 
-  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Background");
+  implementation2 = find_portal_implementation (connection,
+                                                "org.freedesktop.impl.portal.Background");
   if (implementation != NULL)
     {
       export_portal_implementation (connection,
@@ -313,47 +322,55 @@ on_bus_acquired (GDBusConnection *connection,
                                                      implementation->dbus_name,
                                                      implementation2->dbus_name));
 
-  implementation2 = find_portal_implementation ("org.freedesktop.impl.portal.Wallpaper");
+  implementation2 = find_portal_implementation (connection,
+                                                "org.freedesktop.impl.portal.Wallpaper");
   if (implementation != NULL && implementation2 != NULL)
     export_portal_implementation (connection,
                                   wallpaper_create (connection,
                                                     implementation->dbus_name,
                                                     implementation2->dbus_name));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Account");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Account");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   account_create (connection, implementation->dbus_name));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Email");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Email");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   email_create (connection, implementation->dbus_name));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.Secret");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.Secret");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   secret_create (connection, implementation->dbus_name));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.GlobalShortcuts");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.GlobalShortcuts");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   global_shortcuts_create (connection, implementation->dbus_name));
 
 #ifdef HAVE_GLIB_2_66
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.DynamicLauncher");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.DynamicLauncher");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   dynamic_launcher_create (connection, implementation->dbus_name));
 #endif
 
 #ifdef HAVE_PIPEWIRE
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.ScreenCast");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.ScreenCast");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   screen_cast_create (connection, implementation->dbus_name));
 
-  implementation = find_portal_implementation ("org.freedesktop.impl.portal.RemoteDesktop");
+  implementation = find_portal_implementation (connection,
+                                               "org.freedesktop.impl.portal.RemoteDesktop");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   remote_desktop_create (connection, implementation->dbus_name));


### PR DESCRIPTION
If no portal backend for a given interface is found, a fallback is always tried anyway, despite that fallback not being listed as compatible with the current desktop environment.

Sometimes it's good that a fallback is returned; e.g. the xdg-desktop-portal-gtk file chooser backend is technically usable anywhere, however, some backends might be specifically designed to only work in a specific desktop environment, e.g. xdg-desktop-portal-gnome.

In order to avoid creating portals with non-functional backends, make sure it's possible to create a proxy object for the interface and D-Bus name, and that it launched successfully (i.e. has no name owner after creating the proxy).


----

Opening this against xdg-desktop-portals-1.16 because hopefully https://github.com/flatpak/xdg-desktop-portal/pull/955 will make this obsolete.

Not sure how this will work on non-systemd systems; it relies on using `g_dbus_proxy_get_name_owner()` being set after D-Bus activation did its thing, which is true for the portals I have managed to test (xdg-desktop-portal-{gnome,gtk,kde})