### PR TITLE
Remove transient permissions after 24h

### DIFF
--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -143,7 +143,7 @@
 
               <simplelist>
                 <member>0: Do not persist (default)</member>
-                <member>1: Permissions persist as long as the application is running</member>
+                <member>1: Permissions persist as long as the application is running, and for a maximum of 24 hours</member>
                 <member>2: Permissions persist until explicitly revoked</member>
               </simplelist>
 

--- a/meson.build
+++ b/meson.build
@@ -97,7 +97,7 @@ foreach h : check_headers
   config_h.set(h.get(1), cc.has_header(h.get(0)))
 endforeach
 
-glib_dep = dependency('glib-2.0')
+glib_dep = dependency('glib-2.0', version: '>= 2.56')
 gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0')
 json_glib_dep = dependency('json-glib-1.0')

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -268,7 +268,9 @@ delete_transient_permissions (const char *sender,
     return;
 
   id = g_strdup_printf ("%s/%s", sender, restore_token);
-  g_hash_table_remove (transient_permissions, id);
+
+  if (!g_hash_table_remove (transient_permissions, id))
+    g_warning ("Transient permission not found");
 }
 
 void


### PR DESCRIPTION
... and as long as the app is running.

Draft because Chromium seems still be able to restore this token, despite it bring dropped (!) - you can verify that by changing the timeout to, say, 5 seconds.

@grulja do you know why is that?