### PR TITLE
Drop pre-2.66 GLib compatibility layer

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,7 +97,7 @@ foreach h : check_headers
   config_h.set(h.get(1), cc.has_header(h.get(0)))
 endforeach
 
-glib_dep = dependency('glib-2.0')
+glib_dep = dependency('glib-2.0', version: '>= 2.66')
 gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0')
 json_glib_dep = dependency('json-glib-1.0')
@@ -115,18 +115,6 @@ libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))
 
 bwrap_required = host_machine.system() in ['linux']
 bwrap = find_program('bwrap', required: bwrap_required)
-
-if glib_dep.version().version_compare('>= 2.60')
-  config_h.set(
-    'GLIB_VERSION_MIN_REQUIRED',
-    'GLIB_VERSION_2_60',
-    description: 'Ignore massive GTimeVal deprecation warnings in 2.62',
-  )
-endif
-
-if glib_dep.version().version_compare('>= 2.66')
-  config_h.set('HAVE_GLIB_2_66', 1)
-endif
 
 have_libportal = libportal_dep.found()
 if have_libportal
@@ -147,6 +135,8 @@ have_libsystemd = libsystemd_dep.found()
 if have_libsystemd
   config_h.set('HAVE_LIBSYSTEMD', 1)
 endif
+
+add_project_arguments(['-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_66'], language: 'c')
 
 build_docbook = false
 xmlto = find_program('xmlto', required: get_option('docbook-docs'))

--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -20,8 +20,6 @@
 
 #include "config.h"
 
-#ifdef HAVE_GLIB_2_66
-
 #include <locale.h>
 #include <stdio.h>
 #include <string.h>
@@ -1051,5 +1049,3 @@ dynamic_launcher_create (GDBusConnection *connection,
 
   return G_DBUS_INTERFACE_SKELETON (dynamic_launcher);
 }
-
-#endif /* HAVE_GLIB_2_66 */

--- a/src/dynamic-launcher.h
+++ b/src/dynamic-launcher.h
@@ -22,8 +22,6 @@
 
 #include "config.h"
 
-#ifdef HAVE_GLIB_2_66
-
 #include <gio/gio.h>
 
 #define XDG_PORTAL_APPLICATIONS_DIR "xdg-desktop-portal" G_DIR_SEPARATOR_S "applications"
@@ -31,5 +29,3 @@
 
 GDBusInterfaceSkeleton * dynamic_launcher_create (GDBusConnection *connection,
                                                   const char      *dbus_name);
-
-#endif

--- a/src/glib-backports.c
+++ b/src/glib-backports.c
@@ -5,6 +5,7 @@
  * Copyright © 2021 Nelson Ben
  * Copyright © 2021 Peter Bloomfield
  * Copyright © 2021 Collabora Ltd.
+ * Copyright 2023 Igalia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/glib-backports.h
+++ b/src/glib-backports.h
@@ -23,28 +23,6 @@
 
 #include <gio/gio.h>
 
-#ifndef G_DBUS_METHOD_INVOCATION_HANDLED
-#define G_DBUS_METHOD_INVOCATION_HANDLED TRUE
-#define G_DBUS_METHOD_INVOCATION_UNHANDLED FALSE
-#endif
-
-#if !GLIB_CHECK_VERSION (2, 58, 0)
-static inline gboolean
-g_hash_table_steal_extended (GHashTable    *hash_table,
-                             gconstpointer  lookup_key,
-                             gpointer      *stolen_key,
-                             gpointer      *stolen_value)
-{
-  if (g_hash_table_lookup_extended (hash_table, lookup_key, stolen_key, stolen_value))
-    {
-      g_hash_table_steal (hash_table, lookup_key);
-      return TRUE;
-    }
-  else
-      return FALSE;
-}
-#endif
-
 #if !GLIB_CHECK_VERSION (2, 68, 0)
 guint g_string_replace (GString     *string,
                         const gchar *find,

--- a/src/rewrite-launchers.c
+++ b/src/rewrite-launchers.c
@@ -20,8 +20,6 @@
 
 #include "config.h"
 
-#ifdef HAVE_GLIB_2_66
-
 #include <glib.h>
 #include <gio/gdesktopappinfo.h>
 
@@ -272,15 +270,12 @@ migrate_renamed_app_launchers (void)
 
   return success;
 }
-#endif /* HAVE_GLIB_2_66 */
 
 int
 main (int argc, char *argv[])
 {
-/* The dynamic launcher portal is only compiled against GLib >= 2.66 */
-#ifdef HAVE_GLIB_2_66
   if (!migrate_renamed_app_launchers ())
     return 1;
-#endif
+
   return 0;
 }

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -340,12 +340,10 @@ on_bus_acquired (GDBusConnection *connection,
     export_portal_implementation (connection,
                                   global_shortcuts_create (connection, implementation->dbus_name));
 
-#ifdef HAVE_GLIB_2_66
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.DynamicLauncher");
   if (implementation != NULL)
     export_portal_implementation (connection,
                                   dynamic_launcher_create (connection, implementation->dbus_name));
-#endif
 
 #ifdef HAVE_PIPEWIRE
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.ScreenCast");

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -67,8 +67,8 @@ xdp_mkstempat (int    dir_fd,
   static const char letters[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   static const int NLETTERS = sizeof (letters) - 1;
-  glong value;
-  GTimeVal tv;
+  gint64 value;
+  gint64 current_time;
   static int counter = 0;
 
   g_return_val_if_fail (tmpl != NULL, -1);
@@ -83,12 +83,12 @@ xdp_mkstempat (int    dir_fd,
     }
 
   /* Get some more or less random data.  */
-  g_get_current_time (&tv);
-  value = (tv.tv_usec ^ tv.tv_sec) + counter++;
+  current_time = g_get_real_time ();
+  value = ((current_time % G_USEC_PER_SEC) ^ (current_time / G_USEC_PER_SEC)) + counter++;
 
   for (count = 0; count < 100; value += 7777, ++count)
     {
-      glong v = value;
+      gint64 v = value;
 
       /* Fill in the random bits.  */
       XXXXXX[0] = letters[v % NLETTERS];


### PR DESCRIPTION
GLib 2.66 was released in September 2020.

Note: this pull request depends on #977.