### PR TITLE
Avoid compiler warning with recent GLib versions

### DIFF
--- a/document-portal/gvdb/gvdb-builder.c
+++ b/document-portal/gvdb/gvdb-builder.c
@@ -508,13 +508,14 @@ gvdb_table_get_content (GHashTable     *table,
   FileBuilder *fb;
   GString *str;
   GBytes *res;
+  gsize len;
 
   fb = file_builder_new (byteswap);
   file_builder_add_hash (fb, table, &root);
   str = file_builder_serialise (fb, root);
 
-  res = g_bytes_new_take (str->str, str->len);
-  g_string_free (str, FALSE);
+  len = str->len;
+  res = g_bytes_new_take (g_string_free (str, FALSE), len);
 
   return res;
 }


### PR DESCRIPTION
GLib 2.76 added a compiler annotation to ensure that the value returned by g_string_free() is used, as it catches potential leaks.

There is a false positive in the GVDB code, but since the C compiler cannot distinguish it from an actual positive case, let's re-arrange the code a bit to avoid a compiler warning.

Since the order of evaluation of arguments is undefined in C, we also need to extract the string length before freeing GString, to avoid possible side effects of g_string_free().