### PR TITLE
Persistent remote desktop sessions

### DIFF
--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -81,6 +81,47 @@
               Default is all.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>restore_data (suv)</term>
+            <listitem><para>
+              The data to restore from a previous session.
+            </para>
+            <para>
+              If the stored session cannot be restored, this value is ignored
+              and the user will be prompted normally. This may happen when, for
+              example, the session contains a monitor or a window that is not
+              available anymore, or when the stored permissions are withdrawn.
+            </para>
+            <para>
+              The restore data is composed of the vendor name (e.g. "GNOME" or
+              "KDE"), the version of the implementation-specific private data,
+              and the implementation-specific private data itself.
+            </para>
+            <para>
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>persist_mode u</term>
+            <listitem><para>
+              How this session should persist. Default is 0. Accepted values are:
+            </para>
+            <para>
+              <simplelist>
+                <member>0: Do not persist (default)</member>
+                <member>1: Permissions persist as long as the application is running</member>
+                <member>2: Permissions persist until explicitly revoked</member>
+              </simplelist>
+            </para>
+            <para>
+              If the permission for the session to persist is granted, "restore_data"
+              will be returned via the #org.freedesktop.portal.Request::Response
+              signal of the #org.freedesktop.impl.portal.RemoteDesktop.Start method.
+            </para>
+            <para>
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         For available device types, see the AvailableDeviceTypes property.

--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -105,6 +105,9 @@
         @response: Numeric response
         @results: Vardict with the results of the call
 
+        Start the remote desktop session. This will typically result the portal
+        presenting a dialog.
+
         Supported keys in the @options vardict include:
         <variablelist>
           <varlistentry>
@@ -134,9 +137,21 @@
               Since version 2.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>streams a(ua{sv})</term>
+            <listitem><para>
+              Equivalent to the streams entry documented in
+              #org.freedesktop.impl.portal.ScreenCast.Start.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>devices u</term>
+            <listitem><para>
+              The device types that can be used for remote control. See the
+              AvailableDeviceTypes property.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
-
-        Start the remote desktop session.
     -->
     <method name="Start">
       <arg type="o" name="handle" direction="in"/>

--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -61,6 +61,30 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+    <!--
+        SelectDevices:
+        @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
+        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @app_id: App id of the application
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Configure what the devices remote desktop session should expose.
+
+        Supported keys in the @options vardict include:
+        <variablelist>
+          <varlistentry>
+            <term>types u</term>
+            <listitem><para>
+              Bitmask of what device types to request remote controlling of.
+              Default is all.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        For available device types, see the AvailableDeviceTypes property.
+    -->
     <method name="SelectDevices">
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -62,7 +62,6 @@
         @handle: Object path for the #org.freedesktop.impl.portal.Request object representing this call
         @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
         @app_id: App id of the application
-        @session_id: Session identifier
         @options: Vardict with optional further information
         @response: Numeric response
         @results: Vardict with the results of the call
@@ -144,7 +143,6 @@
         @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
         @app_id: App id of the application
         @parent_window: Identifier for the application window, see <link linkend="parent_window">Common Conventions</link>
-        @session_id: Identifier for the screen cast session
         @options: Vardict with optional further information
         @response: Numeric response
         @results: Vardict with the results of the call

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -115,9 +115,10 @@
               </simplelist>
             </para>
             <para>
-              If the permission for the session to persist is granted, a restore token will
-              be returned via the #org.freedesktop.portal.Request::Response signal of the
-              #org.freedesktop.portal.ScreenCast.SelectSources method.
+              If the permission for the session to persist is granted,
+              "persist_mode" will be returned via the
+              #org.freedesktop.portal.Request::Response signal of the
+              #org.freedesktop.impl.portal.ScreenCast.Start method.
             </para>
             <para>
               This option was added in version 4 of this interface.

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -111,7 +111,7 @@
           </varlistentry>
         </variablelist>
 
-        For available source types, see the AvailableDeviceTypes property.
+        For available device types, see the AvailableDeviceTypes property.
     -->
     <method name="SelectDevices">
       <arg type="o" name="session_handle" direction="in"/>

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -109,6 +109,41 @@
               Default is all.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>restore_token s</term>
+            <listitem><para>
+              The token to restore a previous session.
+
+              If the stored session cannot be restored, this value is ignored
+              and the user will be prompted normally. This may happen when, for
+              example, the session contains a monitor or a window that is not
+              available anymore, or when the stored permissions are withdrawn.
+
+              The restore token is invalidated after using it once. To restore
+              the same session again, use the new restore token sent in response
+              to starting this session.
+
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>persist_mode u</term>
+            <listitem><para>
+              How this session should persist. Default is 0. Accepted values are:
+
+              <simplelist>
+                <member>0: Do not persist (default)</member>
+                <member>1: Permissions persist as long as the application is running</member>
+                <member>2: Permissions persist until explicitly revoked</member>
+              </simplelist>
+
+              If the permission for the session to persist is granted, a restore token will
+              be returned via the #org.freedesktop.portal.Request::Response signal of the
+              start method used to start the session.
+
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         For available device types, see the AvailableDeviceTypes property.
@@ -157,6 +192,16 @@
               A boolean for whether the clipboard was enabled ('true') or not ('false'). 
               See the #org.freedesktop.portal.Clipboard documentation for more information.
               Since version 2.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>restore_token s</term>
+            <listitem><para>
+              The restore token. This token is a single use token that can later
+              be used to restore a session. See
+              org.freedesktop.portal.RemoteDesktop.SelectDevices() for details.
+
+              This response option was added in version 2 of this interface.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -133,6 +133,10 @@
               the same session again, use the new restore token sent in response
               to starting this session.
 
+              Setting a restore_token is only allowed for screen cast sessions.
+              Persistent remote desktop screen cast sessions can only be handled
+              via the #org.freedesktop.portal.RemoteDesktop interface.
+
               This option was added in version 4 of this interface.
             </para></listitem>
           </varlistentry>
@@ -147,8 +151,9 @@
                 <member>2: Permissions persist until explicitly revoked</member>
               </simplelist>
 
-              Remote desktop screen cast sessions cannot persist. The only allowed
-              persist_mode for remote desktop sessions is 0.
+              Setting persist_mode is only allowed for screen cast sessions. Persistent
+              remote desktop screen cast sessions can only be handled via the
+              #org.freedesktop.portal.RemoteDesktop interface.
 
               If the permission for the session to persist is granted, a restore token will
               be returned via the #org.freedesktop.portal.Request::Response signal of the

--- a/src/meson.build
+++ b/src/meson.build
@@ -93,6 +93,7 @@ if have_pipewire
   xdg_desktop_portal_sources += files(
       'screen-cast.c',
       'remote-desktop.c',
+      'restore-token.c',
       'pipewire.c',
       'camera.c',
       'clipboard.c',

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -491,10 +491,10 @@ replace_remote_desktop_restore_token_with_data (Session *session,
     persist_mode = PERSIST_MODE_NONE;
 
   remote_desktop_session->persist_mode = persist_mode;
-  replace_restore_token_with_data (session,
-                                   REMOTE_DESKTOP_TABLE,
-                                   in_out_options,
-                                   &remote_desktop_session->restore_token);
+  xdp_session_persistence_replace_restore_token_with_data (session,
+                                                           REMOTE_DESKTOP_TABLE,
+                                                           in_out_options,
+                                                           &remote_desktop_session->restore_token);
 
   return TRUE;
 }
@@ -598,12 +598,12 @@ static void
 replace_restore_remote_desktop_data_with_token (RemoteDesktopSession *remote_desktop_session,
                                                 GVariant **in_out_results)
 {
-  replace_restore_data_with_token ((Session *) remote_desktop_session,
-                                   REMOTE_DESKTOP_TABLE,
-                                   in_out_results,
-                                   &remote_desktop_session->persist_mode,
-                                   &remote_desktop_session->restore_token,
-                                   &remote_desktop_session->restore_data);
+  xdp_session_persistence_replace_restore_data_with_token ((Session *) remote_desktop_session,
+                                                           REMOTE_DESKTOP_TABLE,
+                                                           in_out_results,
+                                                           &remote_desktop_session->persist_mode,
+                                                           &remote_desktop_session->restore_token,
+                                                           &remote_desktop_session->restore_data);
 }
 
 static gboolean

--- a/src/restore-token.c
+++ b/src/restore-token.c
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2021-2022 Endless OS Foundation, LLC
+ * Copyright 2023 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include "permissions.h"
+#include "restore-token.h"
+
+static GMutex transient_permissions_lock;
+static GHashTable *transient_permissions;
+
+#define RESTORE_DATA_TYPE "(suv)"
+
+void
+set_transient_permissions (const char *sender,
+                           const char *restore_token,
+                           GVariant *restore_data)
+{
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&transient_permissions_lock);
+
+  if (!transient_permissions)
+    {
+      transient_permissions =
+        g_hash_table_new_full (g_str_hash, g_str_equal,
+                               g_free, (GDestroyNotify) g_variant_unref);
+    }
+
+  g_hash_table_insert (transient_permissions,
+                       g_strdup_printf ("%s/%s", sender, restore_token),
+                       g_variant_ref (restore_data));
+}
+
+void
+delete_transient_permissions (const char *sender,
+                              const char *restore_token)
+{
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&transient_permissions_lock);
+  g_autofree char *id = NULL;
+
+  if (!transient_permissions)
+    return;
+
+  id = g_strdup_printf ("%s/%s", sender, restore_token);
+  g_hash_table_remove (transient_permissions, id);
+}
+
+GVariant *
+get_transient_permissions (const char *sender,
+                           const char *restore_token)
+{
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&transient_permissions_lock);
+  g_autofree char *id = NULL;
+  GVariant *permissions;
+
+  if (!transient_permissions)
+    return NULL;
+
+  id = g_strdup_printf ("%s/%s", sender, restore_token);
+  permissions = g_hash_table_lookup (transient_permissions, id);
+  return permissions ? g_variant_ref (permissions) : NULL;
+}
+
+void
+set_persistent_permissions (const char *table,
+                            const char *app_id,
+                            const char *restore_token,
+                            GVariant *restore_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  set_permission_sync (app_id, table, restore_token, PERMISSION_YES);
+
+  if (!xdp_dbus_impl_permission_store_call_set_value_sync (get_permission_store (),
+                                                           table,
+                                                           TRUE,
+                                                           restore_token,
+                                                           g_variant_new_variant (restore_data),
+                                                           NULL,
+                                                           &error))
+    {
+      g_dbus_error_strip_remote_error (error);
+      g_warning ("Error setting permission store value: %s", error->message);
+    }
+}
+
+void
+delete_persistent_permissions (const char *table,
+                               const char *app_id,
+                               const char *restore_token)
+{
+
+  g_autoptr(GError) error = NULL;
+
+  if (!xdp_dbus_impl_permission_store_call_delete_sync (get_permission_store (),
+                                                        table,
+                                                        restore_token,
+                                                        NULL,
+                                                        &error))
+    {
+      g_dbus_error_strip_remote_error (error);
+      g_warning ("Error deleting permission: %s", error->message);
+    }
+}
+
+GVariant *
+get_persistent_permissions (const char *table,
+                            const char *app_id,
+                            const char *restore_token)
+{
+  g_autoptr(GVariant) perms = NULL;
+  g_autoptr(GVariant) data = NULL;
+  g_autoptr(GError) error = NULL;
+  const char **permissions;
+
+  if (!xdp_dbus_impl_permission_store_call_lookup_sync (get_permission_store (),
+                                                        table,
+                                                        restore_token,
+                                                        &perms,
+                                                        &data,
+                                                        NULL,
+                                                        &error))
+    {
+      return NULL;
+    }
+
+  if (!perms || !g_variant_lookup (perms, app_id, "^a&s", &permissions))
+    return NULL;
+
+  if (!data)
+    return NULL;
+
+  return g_variant_get_child_value (data, 0);
+}
+
+void
+remove_transient_permissions_for_sender (const char *sender)
+{
+  g_autoptr(GMutexLocker) locker = NULL;
+  GHashTableIter iter;
+  const char *key;
+
+  locker = g_mutex_locker_new (&transient_permissions_lock);
+
+  if (!transient_permissions)
+    return;
+
+  g_hash_table_iter_init (&iter, transient_permissions);
+  while (g_hash_table_iter_next (&iter, (gpointer *) &key, NULL))
+    {
+      g_auto(GStrv) split = g_strsplit (key, "/", 2);
+
+      if (split && split[0] && g_strcmp0 (split[0], sender) == 0)
+        g_hash_table_iter_remove (&iter);
+    }
+}
+
+void
+replace_restore_token_with_data (Session *session,
+                                 const char *table,
+                                 GVariant **in_out_options,
+                                 char **out_restore_token)
+{
+  GVariantIter options_iter;
+  GVariantBuilder options_builder;
+  char *key;
+  GVariant *value;
+
+  g_variant_iter_init (&options_iter, *in_out_options);
+
+  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+
+  while (g_variant_iter_next (&options_iter, "{sv}", &key, &value))
+    {
+      if (g_strcmp0 (key, "restore_token") == 0)
+        {
+          g_autofree char *restore_token = NULL;
+          g_autoptr(GVariant) restore_data = NULL;
+
+          restore_token = g_variant_dup_string (value, NULL);
+
+          /* Lookup permissions in memory first, and fallback to the permission
+           * store if not found. Immediately delete them now as a safety measure,
+           * since they'll be stored again when the session is closed.
+           *
+           * Notice that transient mode uses the sender name, whereas persistent
+           * mode uses the app id.
+           */
+          restore_data = get_transient_permissions (session->sender, restore_token);
+          if (restore_data)
+            {
+              delete_transient_permissions (session->sender, restore_token);
+            }
+          else
+            {
+              restore_data = get_persistent_permissions (table,
+                                                         session->app_id,
+                                                         restore_token);
+              if (restore_data)
+                {
+                  delete_persistent_permissions (table,
+                                                 session->app_id,
+                                                 restore_token);
+                }
+            }
+
+          if (restore_data &&
+              g_variant_check_format_string (restore_data, RESTORE_DATA_TYPE, FALSE))
+            {
+              g_debug ("Replacing 'restore_token' with portal-specific data");
+              g_variant_builder_add (&options_builder, "{sv}",
+                                     "restore_data", restore_data);
+              *out_restore_token = g_steal_pointer (&restore_token);
+            }
+        }
+      else
+        {
+          g_variant_builder_add (&options_builder, "{sv}",
+                                 key, g_variant_ref (value));
+        }
+
+      g_free (key);
+      g_variant_unref (value);
+    }
+
+  *in_out_options = g_variant_builder_end (&options_builder);
+}
+
+void
+generate_and_save_restore_token (Session *session,
+                                 const char *table,
+                                 PersistMode persist_mode,
+                                 char **in_out_restore_token,
+                                 GVariant **in_out_restore_data)
+{
+  if (!*in_out_restore_data)
+    {
+      if (*in_out_restore_token)
+        {
+          delete_persistent_permissions (table,
+                                         session->app_id,
+                                         *in_out_restore_token);
+          delete_transient_permissions (session->sender,
+                                        *in_out_restore_token);
+        }
+
+      g_clear_pointer (in_out_restore_token, g_free);
+      return;
+    }
+
+  switch (persist_mode)
+    {
+    case PERSIST_MODE_NONE:
+      if (*in_out_restore_token)
+        {
+          delete_persistent_permissions (table,
+                                         session->app_id,
+                                         *in_out_restore_token);
+          delete_transient_permissions (session->sender,
+                                        *in_out_restore_token);
+        }
+
+      g_clear_pointer (in_out_restore_token, g_free);
+      g_clear_pointer (in_out_restore_data, g_variant_unref);
+      break;
+
+    case PERSIST_MODE_TRANSIENT:
+      if (!*in_out_restore_token)
+        *in_out_restore_token = g_uuid_string_random ();
+
+      set_transient_permissions (session->sender,
+                                 *in_out_restore_token,
+                                 *in_out_restore_data);
+      break;
+
+    case PERSIST_MODE_PERSISTENT:
+      if (!*in_out_restore_token)
+        *in_out_restore_token = g_uuid_string_random ();
+
+      set_persistent_permissions (table,
+                                  session->app_id,
+                                  *in_out_restore_token,
+                                  *in_out_restore_data);
+
+      break;
+    }
+}
+
+void
+replace_restore_data_with_token (Session *session,
+                                 const char *table,
+                                 GVariant **in_out_results,
+                                 PersistMode *in_out_persist_mode,
+                                 char **in_out_restore_token,
+                                 GVariant **in_out_restore_data)
+{
+  g_autoptr(GVariant) results = *in_out_results;
+  GVariantBuilder results_builder;
+  GVariantIter iter;
+  const char *key;
+  GVariant *value;
+  gboolean found_restore_data = FALSE;
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+
+  g_variant_iter_init (&iter, results);
+  while (g_variant_iter_next (&iter, "{&sv}", &key, &value))
+    {
+      if (g_strcmp0 (key, "restore_data") == 0)
+        {
+          if (g_variant_check_format_string (value, RESTORE_DATA_TYPE, FALSE))
+            {
+              *in_out_restore_data = g_variant_ref_sink (value);
+              found_restore_data = TRUE;
+            }
+          else
+            {
+              g_warning ("Received restore data in invalid variant format ('%s'; expected '%s')",
+                         g_variant_get_type_string (value),
+                         RESTORE_DATA_TYPE);
+            }
+        }
+      else if (g_strcmp0 (key, "persist_mode") == 0)
+        {
+          *in_out_persist_mode = MIN (*in_out_persist_mode,
+                                      g_variant_get_uint32 (value));
+        }
+      else
+        {
+          g_variant_builder_add (&results_builder, "{sv}", key, value);
+        }
+    }
+
+  if (found_restore_data)
+    {
+      g_debug ("Replacing restore data received from portal impl with a token");
+
+      generate_and_save_restore_token (session,
+                                       table,
+                                       *in_out_persist_mode,
+                                       in_out_restore_token,
+                                       in_out_restore_data);
+      g_variant_builder_add (&results_builder, "{sv}", "restore_token",
+                             g_variant_new_string (*in_out_restore_token));
+    }
+  else
+    {
+      *in_out_persist_mode = PERSIST_MODE_NONE;
+    }
+
+  *in_out_results = g_variant_builder_end (&results_builder);
+}

--- a/src/restore-token.h
+++ b/src/restore-token.h
@@ -27,45 +27,43 @@ typedef enum _PersistMode
   PERSIST_MODE_PERSISTENT = 2,
 } PersistMode;
 
-void set_transient_permissions (const char *sender,
-                                const char *restore_token,
-                                GVariant *restore_data);
+void xdp_session_persistence_set_transient_permissions (Session *session,
+                                                        const char *restore_token,
+                                                        GVariant *restore_data);
 
-void delete_transient_permissions (const char *sender,
-                                   const char *restore_token);
+void xdp_session_persistence_delete_transient_permissions (Session *session,
+                                                           const char *restore_token);
 
-GVariant * get_transient_permissions (const char *sender,
-                                      const char *restore_token);
+GVariant * xdp_session_persistence_get_transient_permissions (Session *session,
+                                                              const char *restore_token);
 
-void set_persistent_permissions (const char *table,
-                                 const char *app_id,
-                                 const char *restore_token,
-                                 GVariant *restore_data);
+void xdp_session_persistence_set_persistent_permissions (Session *session,
+                                                         const char *table,
+                                                         const char *restore_token,
+                                                         GVariant *restore_data);
 
-void delete_persistent_permissions (const char *table,
-                                    const char *app_id,
-                                    const char *restore_token);
+void xdp_session_persistence_delete_persistent_permissions (Session *session,
+                                                            const char *table,
+                                                            const char *restore_token);
 
-GVariant * get_persistent_permissions (const char *table,
-                                       const char *app_id,
-                                       const char *restore_token);
+GVariant * xdp_session_persistence_get_persistent_permissions (Session *session,
+                                                               const char *table,
+                                                               const char *restore_token);
 
-void remove_transient_permissions_for_sender (const char *sender);
+void xdp_session_persistence_replace_restore_token_with_data (Session *session,
+                                                              const char *table,
+                                                              GVariant **in_out_options,
+                                                              char **out_restore_token);
 
-void replace_restore_token_with_data (Session *session,
-                                      const char *table,
-                                      GVariant **in_out_options,
-                                      char **out_restore_token);
+void xdp_session_persistence_replace_restore_data_with_token (Session *session,
+                                                              const char *table,
+                                                              GVariant **in_out_results,
+                                                              PersistMode *in_out_persist_mode,
+                                                              char **in_out_restore_token,
+                                                              GVariant **in_out_restore_data);
 
-void replace_restore_data_with_token (Session *session,
-                                      const char *table,
-                                      GVariant **in_out_results,
-                                      PersistMode *in_out_persist_mode,
-                                      char **in_out_restore_token,
-                                      GVariant **in_out_restore_data);
-
-void generate_and_save_restore_token (Session *session,
-                                      const char *table,
-                                      PersistMode persist_mode,
-                                      char **in_out_restore_token,
-                                      GVariant **in_out_restore_data);
+void xdp_session_persistence_generate_and_save_restore_token (Session *session,
+                                                              const char *table,
+                                                              PersistMode persist_mode,
+                                                              char **in_out_restore_token,
+                                                              GVariant **in_out_restore_data);

--- a/src/restore-token.h
+++ b/src/restore-token.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2023 Red Hat
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "session.h"
+
+typedef enum _PersistMode
+{
+  PERSIST_MODE_NONE = 0,
+  PERSIST_MODE_TRANSIENT = 1,
+  PERSIST_MODE_PERSISTENT = 2,
+} PersistMode;
+
+void set_transient_permissions (const char *sender,
+                                const char *restore_token,
+                                GVariant *restore_data);
+
+void delete_transient_permissions (const char *sender,
+                                   const char *restore_token);
+
+GVariant * get_transient_permissions (const char *sender,
+                                      const char *restore_token);
+
+void set_persistent_permissions (const char *table,
+                                 const char *app_id,
+                                 const char *restore_token,
+                                 GVariant *restore_data);
+
+void delete_persistent_permissions (const char *table,
+                                    const char *app_id,
+                                    const char *restore_token);
+
+GVariant * get_persistent_permissions (const char *table,
+                                       const char *app_id,
+                                       const char *restore_token);
+
+void remove_transient_permissions_for_sender (const char *sender);
+
+void replace_restore_token_with_data (Session *session,
+                                      const char *table,
+                                      GVariant **in_out_options,
+                                      char **out_restore_token);
+
+void replace_restore_data_with_token (Session *session,
+                                      const char *table,
+                                      GVariant **in_out_results,
+                                      PersistMode *in_out_persist_mode,
+                                      char **in_out_restore_token,
+                                      GVariant **in_out_restore_data);
+
+void generate_and_save_restore_token (Session *session,
+                                      const char *table,
+                                      PersistMode persist_mode,
+                                      char **in_out_restore_token,
+                                      GVariant **in_out_restore_data);

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -349,7 +349,7 @@ select_sources_done (GObject *source_object,
 }
 
 static gboolean
-validate_device_types (const char *key,
+validate_source_types (const char *key,
                        GVariant *value,
                        GVariant *options,
                        GError **error)
@@ -428,7 +428,7 @@ validate_persist_mode (const char *key,
 }
 
 static XdpOptionKey screen_cast_select_sources_options[] = {
-  { "types", G_VARIANT_TYPE_UINT32, validate_device_types },
+  { "types", G_VARIANT_TYPE_UINT32, validate_source_types },
   { "multiple", G_VARIANT_TYPE_BOOLEAN, NULL },
   { "cursor_mode", G_VARIANT_TYPE_UINT32, validate_cursor_mode },
   { "restore_token", G_VARIANT_TYPE_STRING, validate_restore_token },

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -26,18 +26,19 @@
 #include "screen-cast.h"
 #include "remote-desktop.h"
 #include "request.h"
+#include "restore-token.h"
 #include "permissions.h"
 #include "pipewire.h"
 #include "xdp-dbus.h"
 #include "xdp-impl-dbus.h"
 #include "xdp-utils.h"
 
-#define RESTORE_DATA_TYPE "(suv)"
 #define PERMISSION_ITEM(item_id, item_permissions) \
   ((struct pw_permission) { \
     .id = item_id, \
     .permissions = item_permissions \
   })
+#define SCREEN_CAST_TABLE "screencast"
 
 typedef struct _ScreenCast ScreenCast;
 typedef struct _ScreenCastClass ScreenCastClass;
@@ -55,9 +56,6 @@ struct _ScreenCastClass
 static XdpDbusImplScreenCast *impl;
 static int impl_version;
 static ScreenCast *screen_cast;
-
-static GMutex transient_permissions_lock;
-static GHashTable *transient_permissions;
 
 static unsigned int available_cursor_modes = 0;
 
@@ -77,13 +75,6 @@ G_DEFINE_TYPE_WITH_CODE (ScreenCast, screen_cast,
                          XDP_DBUS_TYPE_SCREEN_CAST_SKELETON,
                          G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_SCREEN_CAST,
                                                 screen_cast_iface_init))
-
-typedef enum _PersistMode
-{
-  PERSIST_MODE_NONE = 0,
-  PERSIST_MODE_TRANSIENT = 1,
-  PERSIST_MODE_PERSISTENT = 2,
-} PersistMode;
 
 typedef enum _ScreenCastSessionState
 {
@@ -116,143 +107,11 @@ GType screen_cast_session_get_type (void);
 
 G_DEFINE_TYPE (ScreenCastSession, screen_cast_session, session_get_type ())
 
-static void
-set_persistent_permissions (const char *app_id,
-                            const char *restore_token,
-                            GVariant *restore_data)
-{
-  g_autoptr(GError) error = NULL;
-
-  set_permission_sync (app_id, "screencast", restore_token, PERMISSION_YES);
-
-  if (!xdp_dbus_impl_permission_store_call_set_value_sync (get_permission_store (),
-                                                           "screencast",
-                                                           TRUE,
-                                                           restore_token,
-                                                           g_variant_new_variant (restore_data),
-                                                           NULL,
-                                                           &error))
-    {
-      g_dbus_error_strip_remote_error (error);
-      g_warning ("Error setting permission store value: %s", error->message);
-    }
-}
-
-static GVariant *
-get_persistent_permissions (const char *app_id,
-                            const char *restore_token)
-{
-  g_autoptr(GVariant) perms = NULL;
-  g_autoptr(GVariant) data = NULL;
-  g_autoptr(GError) error = NULL;
-  const char **permissions;
-
-  if (!xdp_dbus_impl_permission_store_call_lookup_sync (get_permission_store (),
-                                                        "screencast",
-                                                        restore_token,
-                                                        &perms,
-                                                        &data,
-                                                        NULL,
-                                                        &error))
-    {
-      return NULL;
-    }
-
-  if (!perms || !g_variant_lookup (perms, app_id, "^a&s", &permissions))
-    return NULL;
-
-  if (!data)
-    return NULL;
-
-  return g_variant_get_child_value (data, 0);
-}
-
-void
-delete_persistent_permissions (const char *app_id,
-                               const char *restore_token)
-{
-
-  g_autoptr(GError) error = NULL;
-
-  if (!xdp_dbus_impl_permission_store_call_delete_sync (get_permission_store (),
-                                                        "screencast",
-                                                        restore_token,
-                                                        NULL,
-                                                        &error))
-    {
-      g_dbus_error_strip_remote_error (error);
-      g_warning ("Error deleting permission: %s", error->message);
-    }
-}
-
-static void
-set_transient_permissions (const char *sender,
-                           const char *restore_token,
-                           GVariant *restore_data)
-{
-  g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&transient_permissions_lock);
-
-  if (!transient_permissions)
-    {
-      transient_permissions = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                     g_free, (GDestroyNotify)g_variant_unref);
-    }
-
-  g_hash_table_insert (transient_permissions,
-                       g_strdup_printf ("%s/%s", sender, restore_token),
-                       g_variant_ref (restore_data));
-}
-
-static GVariant *
-get_transient_permissions (const char *sender,
-                           const char *restore_token)
-{
-  g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&transient_permissions_lock);
-  g_autofree char *id = NULL;
-  GVariant *permissions;
-
-  if (!transient_permissions)
-    return NULL;
-
-  id = g_strdup_printf ("%s/%s", sender, restore_token);
-  permissions = g_hash_table_lookup (transient_permissions, id);
-  return permissions ? g_variant_ref (permissions) : NULL;
-}
-
-static void
-delete_transient_permissions (const char *sender,
-                              const char *restore_token)
-{
-  g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&transient_permissions_lock);
-  g_autofree char *id = NULL;
-
-  if (!transient_permissions)
-    return;
-
-  id = g_strdup_printf ("%s/%s", sender, restore_token);
-  g_hash_table_remove (transient_permissions, id);
-}
 
 void
 screen_cast_remove_transient_permissions_for_sender (const char *sender)
 {
-  g_autoptr(GMutexLocker) locker = NULL;
-  GHashTableIter iter;
-  const char *key;
-
-  locker = g_mutex_locker_new (&transient_permissions_lock);
-
-  if (!transient_permissions)
-    return;
-
-  g_hash_table_iter_init (&iter, transient_permissions);
-  while (g_hash_table_iter_next (&iter, (gpointer *) &key, NULL))
-    {
-      g_auto(GStrv) split = g_strsplit (key, "/", 2);
-
-      if (split && split[0] && g_strcmp0 (split[0], sender) == 0)
-        g_hash_table_iter_remove (&iter);
-    }
+  remove_transient_permissions_for_sender (sender);
 }
 
 static gboolean
@@ -577,108 +436,69 @@ static XdpOptionKey screen_cast_select_sources_options[] = {
 };
 
 static gboolean
-replace_restore_token_with_data (Session *session,
-                                 GVariant **in_out_options,
-                                 GError **error)
+variant_contains_key (GVariant *dictionary,
+                      const char *key)
 {
-  GVariantBuilder options_builder;
+  GVariantIter iter;
+
+  g_variant_iter_init (&iter, dictionary);
+  while (TRUE)
+    {
+      g_autoptr(GVariant) entry = NULL;
+      g_autoptr(GVariant) entry_key = NULL;
+
+      entry = g_variant_iter_next_value (&iter);
+      if (!entry)
+        break;
+
+      entry_key = g_variant_get_child_value (entry, 0);
+      if (g_strcmp0 (g_variant_get_string (entry_key, NULL), key) == 0)
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+static gboolean
+replace_screen_cast_restore_token_with_data (Session *session,
+                                             GVariant **in_out_options,
+                                             GError **error)
+{
   g_autoptr(GVariant) options = NULL;
   PersistMode persist_mode;
-  gsize i;
 
   options = *in_out_options;
 
   if (!g_variant_lookup (options, "persist_mode", "u", &persist_mode))
     persist_mode = PERSIST_MODE_NONE;
 
-  if (is_remote_desktop_session (session) && persist_mode != PERSIST_MODE_NONE)
+  if (is_remote_desktop_session (session))
     {
-      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Remote desktop sessions cannot persist");
-      return FALSE;
+      if (persist_mode != PERSIST_MODE_NONE ||
+          variant_contains_key (options, "restore_token"))
+        {
+          g_set_error (error,
+                       XDG_DESKTOP_PORTAL_ERROR,
+                       XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                       "Remote desktop sessions cannot persist");
+          return FALSE;
+        }
     }
 
   if (is_screen_cast_session (session))
     {
       ScreenCastSession *screen_cast_session = (ScreenCastSession *)session;
+
       screen_cast_session->persist_mode = persist_mode;
+      replace_restore_token_with_data (session,
+                                       SCREEN_CAST_TABLE,
+                                       in_out_options,
+                                       &screen_cast_session->restore_token);
     }
-
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
-  for (i = 0; i < G_N_ELEMENTS (screen_cast_select_sources_options); i++)
+  else
     {
-      g_autoptr(GVariant) value = NULL;
-
-      value = g_variant_lookup_value (options,
-                                      screen_cast_select_sources_options[i].key,
-                                      screen_cast_select_sources_options[i].type);
-
-      if (!value)
-        continue;
-
-      if (g_strcmp0 (screen_cast_select_sources_options[i].key, "restore_token") == 0)
-        {
-          ScreenCastSession *screen_cast_session;
-          g_autoptr(GVariant) restore_data = NULL;
-          g_autofree char *restore_token = NULL;
-
-          if (is_remote_desktop_session (session))
-            {
-              g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                           "Remote desktop sessions cannot be restored");
-              return FALSE;
-            }
-
-          restore_token = g_variant_dup_string (value, NULL);
-
-          /* Lookup permissions in memory first, and fallback to the permission
-           * store if not found. Immediately delete them now as a safety measure,
-           * since they'll be stored again when the session is closed.
-           *
-           * Notice that transient mode uses the sender name, whereas persistent
-           * mode uses the app id.
-           */
-          restore_data = get_transient_permissions (session->sender, restore_token);
-          if (restore_data)
-            {
-              delete_transient_permissions (session->sender, restore_token);
-            }
-          else
-            {
-              restore_data = get_persistent_permissions (session->app_id, restore_token);
-              if (restore_data)
-                delete_persistent_permissions (session->app_id, restore_token);
-            }
-
-          if (!restore_data)
-            continue;
-
-          if (!g_variant_check_format_string (restore_data, RESTORE_DATA_TYPE, FALSE))
-            {
-              g_warning ("Restore data was stored with the wrong format, ignoring");
-              continue;
-            }
-
-          /* Only store the restore token after checking if it exists, otherwise
-           * apps can pass random UUIDs and yet predict what the next token will
-           * be.
-           */
-          g_assert (is_screen_cast_session (session));
-          screen_cast_session = (ScreenCastSession *)session;
-          screen_cast_session->restore_token = g_steal_pointer (&restore_token);
-
-          g_debug ("Replacing 'restore_token' with portal-specific data");
-          g_variant_builder_add (&options_builder, "{sv}", "restore_data", restore_data);
-        }
-      else
-        {
-          g_variant_builder_add (&options_builder, "{sv}",
-                                 screen_cast_select_sources_options[i].key,
-                                 g_steal_pointer (&value));
-        }
+      *in_out_options = g_steal_pointer (&options);
     }
-
-  *in_out_options = g_variant_builder_end (&options_builder);
 
   return TRUE;
 }
@@ -794,7 +614,7 @@ handle_select_sources (XdpDbusScreenCast *object,
    * permission store and / or the GHashTable with transient permissions.
    * Portal implementations do not have access to the restore token.
    */
-  if (!replace_restore_token_with_data (session, &options, &error))
+  if (!replace_screen_cast_restore_token_with_data (session, &options, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
@@ -938,111 +758,15 @@ collect_screen_cast_stream_data (GVariantIter *streams_iter)
 }
 
 static void
-generate_and_save_restore_token (ScreenCastSession *screen_cast_session)
+replace_restore_screen_cast_data_with_token (ScreenCastSession *screen_cast_session,
+                                             GVariant **in_out_results)
 {
-  Session *session = (Session *)screen_cast_session;
-
-  if (!screen_cast_session->restore_data)
-    {
-      if (screen_cast_session->restore_token)
-        {
-          delete_persistent_permissions (session->app_id, screen_cast_session->restore_token);
-          delete_transient_permissions (session->sender, screen_cast_session->restore_token);
-        }
-
-      g_clear_pointer (&screen_cast_session->restore_token, g_free);
-      return;
-    }
-
-  switch (screen_cast_session->persist_mode)
-    {
-    case PERSIST_MODE_NONE:
-      if (screen_cast_session->restore_token)
-        {
-          delete_persistent_permissions (session->app_id, screen_cast_session->restore_token);
-          delete_transient_permissions (session->sender, screen_cast_session->restore_token);
-        }
-
-      g_clear_pointer (&screen_cast_session->restore_token, g_free);
-      g_clear_pointer (&screen_cast_session->restore_data, g_variant_unref);
-      break;
-
-    case PERSIST_MODE_TRANSIENT:
-      if (screen_cast_session->restore_token == NULL)
-        screen_cast_session->restore_token = g_uuid_string_random ();
-
-      set_transient_permissions (session->sender,
-                                 screen_cast_session->restore_token,
-                                 screen_cast_session->restore_data);
-      break;
-
-    case PERSIST_MODE_PERSISTENT:
-      if (screen_cast_session->restore_token == NULL)
-        screen_cast_session->restore_token = g_uuid_string_random ();
-
-      set_persistent_permissions (session->app_id,
-                                  screen_cast_session->restore_token,
-                                  screen_cast_session->restore_data);
-
-      break;
-    }
-}
-
-static void
-replace_restore_data_by_token (ScreenCastSession *screen_cast_session,
-                               GVariant **in_out_results)
-{
-  g_autoptr(GVariant) results = *in_out_results;
-  GVariantBuilder results_builder;
-  GVariantIter iter;
-  const char *key;
-  GVariant *value;
-  gboolean found_restore_data = FALSE;
-
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
-
-  g_variant_iter_init (&iter, results);
-  while (g_variant_iter_next (&iter, "{&sv}", &key, &value))
-    {
-      if (g_strcmp0 (key, "restore_data") == 0)
-        {
-          if (g_variant_check_format_string (value, RESTORE_DATA_TYPE, FALSE))
-            {
-              screen_cast_session->restore_data = g_variant_ref_sink (value);
-              found_restore_data = TRUE;
-            }
-          else
-            {
-              g_warning ("Received restore data in invalid variant format ('%s'; expected '%s')",
-                         g_variant_get_type_string (value),
-                         RESTORE_DATA_TYPE);
-            }
-        }
-      else if (g_strcmp0 (key, "persist_mode") == 0)
-        {
-          screen_cast_session->persist_mode = MIN (screen_cast_session->persist_mode,
-                                                   g_variant_get_uint32 (value));
-        }
-      else
-        {
-          g_variant_builder_add (&results_builder, "{sv}", key, value);
-        }
-    }
-
-  if (found_restore_data)
-    {
-      g_debug ("Replacing restore data received from portal impl with a token");
-
-      generate_and_save_restore_token (screen_cast_session);
-      g_variant_builder_add (&results_builder, "{sv}", "restore_token",
-                             g_variant_new_string (screen_cast_session->restore_token));
-    }
-  else
-    {
-      screen_cast_session->persist_mode = PERSIST_MODE_NONE;
-    }
-
-  *in_out_results = g_variant_builder_end (&results_builder);
+  replace_restore_data_with_token ((Session *) screen_cast_session,
+                                   SCREEN_CAST_TABLE,
+                                   in_out_results,
+                                   &screen_cast_session->persist_mode,
+                                   &screen_cast_session->restore_token,
+                                   &screen_cast_session->restore_data);
 }
 
 static gboolean
@@ -1060,7 +784,8 @@ process_results (ScreenCastSession *screen_cast_session,
     }
 
   screen_cast_session->streams = collect_screen_cast_stream_data (streams_iter);
-  replace_restore_data_by_token (screen_cast_session, in_out_results);
+  replace_restore_screen_cast_data_with_token (screen_cast_session,
+                                               in_out_results);
   return TRUE;
 }
 
@@ -1428,7 +1153,11 @@ screen_cast_session_close (Session *session)
 
   screen_cast_session->state = SCREEN_CAST_SESSION_STATE_CLOSED;
 
-  generate_and_save_restore_token (screen_cast_session);
+  generate_and_save_restore_token (session,
+                                   SCREEN_CAST_TABLE,
+                                   screen_cast_session->persist_mode,
+                                   &screen_cast_session->restore_token,
+                                   &screen_cast_session->restore_data);
 
   g_debug ("screen cast session owned by '%s' closed", session->sender);
 }

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -108,12 +108,6 @@ GType screen_cast_session_get_type (void);
 G_DEFINE_TYPE (ScreenCastSession, screen_cast_session, session_get_type ())
 
 
-void
-screen_cast_remove_transient_permissions_for_sender (const char *sender)
-{
-  remove_transient_permissions_for_sender (sender);
-}
-
 static gboolean
 is_screen_cast_session (Session *session)
 {
@@ -466,10 +460,10 @@ replace_screen_cast_restore_token_with_data (Session *session,
       ScreenCastSession *screen_cast_session = (ScreenCastSession *)session;
 
       screen_cast_session->persist_mode = persist_mode;
-      replace_restore_token_with_data (session,
-                                       SCREEN_CAST_TABLE,
-                                       in_out_options,
-                                       &screen_cast_session->restore_token);
+      xdp_session_persistence_replace_restore_token_with_data (session,
+                                                               SCREEN_CAST_TABLE,
+                                                               in_out_options,
+                                                               &screen_cast_session->restore_token);
     }
   else
     {
@@ -737,12 +731,12 @@ static void
 replace_restore_screen_cast_data_with_token (ScreenCastSession *screen_cast_session,
                                              GVariant **in_out_results)
 {
-  replace_restore_data_with_token ((Session *) screen_cast_session,
-                                   SCREEN_CAST_TABLE,
-                                   in_out_results,
-                                   &screen_cast_session->persist_mode,
-                                   &screen_cast_session->restore_token,
-                                   &screen_cast_session->restore_data);
+  xdp_session_persistence_replace_restore_data_with_token ((Session *) screen_cast_session,
+                                                           SCREEN_CAST_TABLE,
+                                                           in_out_results,
+                                                           &screen_cast_session->persist_mode,
+                                                           &screen_cast_session->restore_token,
+                                                           &screen_cast_session->restore_data);
 }
 
 static gboolean
@@ -1129,11 +1123,11 @@ screen_cast_session_close (Session *session)
 
   screen_cast_session->state = SCREEN_CAST_SESSION_STATE_CLOSED;
 
-  generate_and_save_restore_token (session,
-                                   SCREEN_CAST_TABLE,
-                                   screen_cast_session->persist_mode,
-                                   &screen_cast_session->restore_token,
-                                   &screen_cast_session->restore_data);
+  xdp_session_persistence_generate_and_save_restore_token (session,
+                                                           SCREEN_CAST_TABLE,
+                                                           screen_cast_session->persist_mode,
+                                                           &screen_cast_session->restore_token,
+                                                           &screen_cast_session->restore_data);
 
   g_debug ("screen cast session owned by '%s' closed", session->sender);
 }

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -436,30 +436,6 @@ static XdpOptionKey screen_cast_select_sources_options[] = {
 };
 
 static gboolean
-variant_contains_key (GVariant *dictionary,
-                      const char *key)
-{
-  GVariantIter iter;
-
-  g_variant_iter_init (&iter, dictionary);
-  while (TRUE)
-    {
-      g_autoptr(GVariant) entry = NULL;
-      g_autoptr(GVariant) entry_key = NULL;
-
-      entry = g_variant_iter_next_value (&iter);
-      if (!entry)
-        break;
-
-      entry_key = g_variant_get_child_value (entry, 0);
-      if (g_strcmp0 (g_variant_get_string (entry_key, NULL), key) == 0)
-        return TRUE;
-    }
-
-  return FALSE;
-}
-
-static gboolean
 replace_screen_cast_restore_token_with_data (Session *session,
                                              GVariant **in_out_options,
                                              GError **error)
@@ -475,7 +451,7 @@ replace_screen_cast_restore_token_with_data (Session *session,
   if (is_remote_desktop_session (session))
     {
       if (persist_mode != PERSIST_MODE_NONE ||
-          variant_contains_key (options, "restore_token"))
+          xdp_variant_contains_key (options, "restore_token"))
         {
           g_set_error (error,
                        XDG_DESKTOP_PORTAL_ERROR,

--- a/src/session.c
+++ b/src/session.c
@@ -24,6 +24,15 @@
 
 enum
 {
+  INTERNAL_CLOSED,
+
+  N_SIGNALS
+};
+
+static guint signals[N_SIGNALS];
+
+enum
+{
   PROP_0,
 
   PROP_SENDER,
@@ -173,6 +182,8 @@ session_close (Session *session,
     return;
 
   SESSION_GET_CLASS (session)->close (session);
+
+  g_signal_emit (session, signals[INTERNAL_CLOSED], 0);
 
   if (notify_closed)
     {
@@ -528,4 +539,11 @@ session_class_init (SessionClass *klass)
                          G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
+
+  signals[INTERNAL_CLOSED] = g_signal_new ("internal-closed",
+                                           G_TYPE_FROM_CLASS (klass),
+                                           G_SIGNAL_RUN_LAST,
+                                           0,
+                                           NULL, NULL, NULL,
+                                           G_TYPE_NONE, 0);
 }

--- a/src/session.h
+++ b/src/session.h
@@ -45,6 +45,10 @@ struct _Session
   char *impl_dbus_name;
   GDBusConnection *impl_connection;
   XdpDbusImplSession *impl_session;
+
+  struct {
+    gboolean has_transient_permissions;
+  } persistence;
 };
 
 struct _SessionClass

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -218,9 +218,6 @@ peer_died_cb (const char *name)
 {
   close_requests_for_sender (name);
   close_sessions_for_sender (name);
-#ifdef HAVE_PIPEWIRE
-  screen_cast_remove_transient_permissions_for_sender (name);
-#endif
 }
 
 static void

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2384,3 +2384,27 @@ xdp_validate_serialized_icon (GVariant  *v,
 
   return TRUE;
 }
+
+gboolean
+xdp_variant_contains_key (GVariant *dictionary,
+                          const char *key)
+{
+  GVariantIter iter;
+
+  g_variant_iter_init (&iter, dictionary);
+  while (TRUE)
+    {
+      g_autoptr(GVariant) entry = NULL;
+      g_autoptr(GVariant) entry_key = NULL;
+
+      entry = g_variant_iter_next_value (&iter);
+      if (!entry)
+        break;
+
+      entry_key = g_variant_get_child_value (entry, 0);
+      if (g_strcmp0 (g_variant_get_string (entry_key, NULL), key) == 0)
+        return TRUE;
+    }
+
+  return FALSE;
+}

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -121,6 +121,8 @@ XdpAppInfo *xdp_invocation_lookup_app_info_sync (GDBusMethodInvocation *invocati
 void   xdp_connection_track_name_owners  (GDBusConnection       *connection,
                                           XdpPeerDiedCallback    peer_died_cb);
 
+gboolean xdp_variant_contains_key (GVariant *dictionary,
+                                   const char *key);
 
 typedef struct {
   const char *key;


### PR DESCRIPTION
This adds persistent remote desktop sessions similar to persistent
screen cast sessions. What it means is that applications can ask for
sessions to be "saved" either temporarily in the portal, or in the
permission store, and later be restored at will, without any interactive
dialog showing up.
    
It works the same way, by the Start() method returning a restore token,
and similarly to the screen cast variant, passing the same restore token
to the SelectDevices() method the next time.
    
Closes: https://github.com/flatpak/xdg-desktop-portal/issues/850


-----


Also contains a bunch of cleanups to the screen cast and remote desktop portal specification.