### PR TITLE
Fix a unused variable compiler warning

### DIFF
--- a/src/documents.c
+++ b/src/documents.c
@@ -207,7 +207,6 @@ get_real_path_for_doc_path (const char *path,
 {
   g_autofree char *doc_id = NULL;
   gboolean ret = FALSE;
-  char *real_path = NULL;
   g_autoptr(GError) error = NULL;
 
   if (xdp_app_info_is_host (app_info))


### PR DESCRIPTION
Unused since 60e7984fce78f2bb2baf62ae9d9400976f44a74c