### PR TITLE
print: Add an accept_label option

### DIFF
--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -98,6 +98,12 @@
               Whether to make the dialog modal. Defaults to yes.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>accept_label s</term>
+            <listitem><para>
+              Label for the accept button. Mnemonic underlines are allowed.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned via the @results vardict:

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -116,6 +116,12 @@
               Whether to make the dialog modal. Defaults to yes.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>accept_label s</term>
+            <listitem><para>
+             Label for the accept button. Mnemonic underlines are allowed.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned via the #org.freedesktop.portal.Request::Response signal:

--- a/src/print.c
+++ b/src/print.c
@@ -100,7 +100,7 @@ print_done (GObject *source,
 
 static XdpOptionKey print_options[] = {
   { "token", G_VARIANT_TYPE_UINT32, NULL },
-  { "modal", G_VARIANT_TYPE_BOOLEAN, NULL }
+  { "modal", G_VARIANT_TYPE_BOOLEAN, NULL },
 };
 
 static gboolean
@@ -213,7 +213,8 @@ prepare_print_done (GObject *source,
 }
 
 static XdpOptionKey prepare_print_options[] = {
-  { "modal", G_VARIANT_TYPE_BOOLEAN }
+  { "modal", G_VARIANT_TYPE_BOOLEAN },
+  { "accept_label", G_VARIANT_TYPE_STRING }
 };
 
 static gboolean


### PR DESCRIPTION
It makes sense to allow changing the button label, in particular for the PreparePrint call. We allow
the same for file chooser dialogs.