### PR TITLE
Switch from ninja to meson compile in the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ run:
 
 ```
 $ meson setup . _build
-$ ninja -C _build
+$ meson compile -C _build
 ```
 
 ### Running

--- a/RELEASE_HOWTO.md
+++ b/RELEASE_HOWTO.md
@@ -1,14 +1,14 @@
 # Steps for doing a xdg-desktop-portal release
 
  - git clean -fxd
- - meson setup . _build && ninja -C _build/ xdg-desktop-portal-update-po
+ - meson setup . _build && meson compile -C _build/ xdg-desktop-portal-update-po
  - git add po/*po &&  git commit -m "Update po files"
  - git clean -fxd
  - add content to NEWS
  - git commit -m <version>
  - git push origin main
  - meson setup . _build -Ddocbook-docs=enabled 
- - ninja -C _build dist
+ - meson compile -C _build dist
  - git tag <version>
  - git push origin refs/tags/<version>
  - upload tarball to github as release


### PR DESCRIPTION
As of meson 0.55 this is the backend-agnostic compiler command so let's use it to standardize across projects. We require 0.56 anyway.