### PR TITLE
Respect portal configuration for find_all_portal

### DIFF
--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -503,24 +503,21 @@ find_portal_implementation (const char *interface)
   GList *l;
   int i;
 
-  desktops = get_current_lowercase_desktops ();
-
-  for (i = 0; desktops[i] != NULL; i++)
+  for (l = implementations; l != NULL; l = l->next)
     {
-     for (l = implementations; l != NULL; l = l->next)
+      PortalImplementation *impl = l->data;
+
+      if (!g_strv_contains ((const char **)impl->interfaces, interface))
+        continue;
+
+      if (portal_impl_matches_config (impl, interface))
         {
-          PortalImplementation *impl = l->data;
-
-          if (!g_strv_contains ((const char **)impl->interfaces, interface))
-            continue;
-
-          if (portal_impl_matches_config (impl, interface))
-            {
-              g_debug ("Using %s.portal for %s in %s (config)", impl->source, interface, desktops[i]);
-              return impl;
-            }
+          g_debug ("Using %s.portal for %s (config)", impl->source, interface);
+          return impl;
         }
     }
+
+  desktops = get_current_lowercase_desktops ();
 
   /* Fallback to the old UseIn key */
   for (i = 0; desktops[i] != NULL; i++)

--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -569,9 +569,12 @@ find_all_portal_implementations (const char *interface)
     {
       PortalImplementation *impl = l->data;
 
-      if (g_strv_contains ((const char **)impl->interfaces, interface))
+      if (!g_strv_contains ((const char **)impl->interfaces, interface))
+        continue;
+
+      if (portal_impl_matches_config (impl, interface))
         {
-          g_debug ("Using %s.portal for %s", impl->source, interface);
+          g_debug ("Using %s.portal for %s (config)", impl->source, interface);
           g_ptr_array_add (impls, impl);
         }
     }


### PR DESCRIPTION
The settings portal is discovered using find_all_portal_implementations, which looked for any portal that provided the implementation, regardless of configuration or UseIn=.

The new portal configuration allows us to specify which portals should be considered for each interface. Update find_all_portal_implementations to respect the configuration.

Fixes: https://github.com/flatpak/xdg-desktop-portal/issues/1017