### PR TITLE
meson: expose the pytest suite as meson feature and require it in the CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -93,7 +93,7 @@ jobs:
         $RUN_CMD $AS_USER meson setup ${BUILDDIR} $MESON_OPTIONS
         $RUN_CMD $AS_USER meson compile -C ${BUILDDIR}
       env:
-        MESON_OPTIONS: -Dinstalled-tests=true -Db_sanitize=${{ matrix.sanitizer }}
+        MESON_OPTIONS: -Dinstalled-tests=true -Dpytest=enabled -Db_sanitize=${{ matrix.sanitizer }}
 
     - name: Run xdg-desktop-portal tests
       run: $RUN_CMD $AS_USER timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR}

--- a/meson.build
+++ b/meson.build
@@ -154,18 +154,6 @@ endif
 
 enable_installed_tests = get_option('installed-tests')
 
-summary({
-    'Enable docbook documentation': build_docbook,
-    'Enable pipewire support': have_pipewire,
-    'Enable libsystemd support': have_libsystemd,
-    'Enable geoclue support': have_geoclue,
-    'Enable libportal support': have_libportal,
-    'Enable installed tests:': enable_installed_tests,
-  },
-  section: 'Optional builds',
-  bool_yn: true,
-)
-
 ###### systemd units, dbus service files, pkgconfig
 
 base_config = configuration_data()
@@ -198,3 +186,16 @@ subdir('doc')
 
 ###### generate config.h
 configure_file(output: 'config.h', configuration: config_h)
+
+summary({
+    'Enable docbook documentation': build_docbook,
+    'Enable pipewire support': have_pipewire,
+    'Enable libsystemd support': have_libsystemd,
+    'Enable geoclue support': have_geoclue,
+    'Enable libportal support': have_libportal,
+    'Enable installed tests:': enable_installed_tests,
+    'Enable python test suite': enable_pytest,
+  },
+  section: 'Optional builds',
+  bool_yn: true,
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -42,3 +42,7 @@ option('installed-tests',
         type: 'boolean',
         value: false,
         description: 'Enable installation of some test cases')
+option('pytest',
+        type: 'feature',
+        value: 'auto',
+        description: 'Enable the pytest-based test suite')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -265,15 +265,17 @@ test(
   protocol: test_protocol,
 )
 
-pytest = find_program('pytest-3', 'pytest', required: false)
+pytest = find_program('pytest-3', 'pytest', required: get_option('pytest'))
 pymod = import('python')
 python = pymod.find_installation(
   'python3',
   modules: ['dbus', 'dbusmock', 'gi'],
-  required: false,
+  required: get_option('pytest'),
 )
 
-if pytest.found() and python.found()
+enable_pytest = pytest.found() and python.found()
+
+if enable_pytest
   subdir('templates')
   pytest_files = [
     '__init__.py',


### PR DESCRIPTION
Previously the pytests were enabled if pytest and the required python modules were available. Make this more explicit by having a meson feature for that.


Suggested by @smcv in https://github.com/flatpak/xdg-desktop-portal/pull/1016#issuecomment-1542305566