### PR TITLE
Fix configuration group name in documentation

### DIFF
--- a/doc/portals-conf.rst
+++ b/doc/portals-conf.rst
@@ -16,9 +16,9 @@ should be used to provide the implementation for the requested interface.
 
 The configuration file can be found in the following locations:
 
-- ``/etc/xdg-desktop-portals/portals.conf``, for site-wide configuration
+- ``/etc/xdg-desktop-portal/portals.conf``, for site-wide configuration
 
-- ``$XDG_CONFIG_HOME/xdg-desktop-portals/portals.conf``, for user-specific
+- ``$XDG_CONFIG_HOME/xdg-desktop-portal/portals.conf``, for user-specific
   configuration
 
 Additionally, every desktop environment can provide a portal configuration file

--- a/doc/portals-conf.rst
+++ b/doc/portals-conf.rst
@@ -65,7 +65,7 @@ EXAMPLE
 
 ::
 
-  [portals]
+  [preferred]
   # Use xdg-desktop-portal-gtk for every portal interface...
   default=gtk
   # ... except for the Screencast interface


### PR DESCRIPTION
As described above in the page the group name is [preferred]