### PR TITLE
README: add Cinnamon portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ high-level APIs.
 
 To implement most portals, xdg-desktop-portal relies on a backend
 that provides implementations of the org.freedesktop.impl.portal.\* interfaces.
-Different backends are available see:
+
+Here are some examples of available backends:
 
 - GTK [xdg-desktop-portal-gtk](http://github.com/flatpak/xdg-desktop-portal-gtk)
 - GNOME [xdg-desktop-portal-gnome](https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/)
@@ -38,6 +39,7 @@ Different backends are available see:
 - Pantheon (Elementary) [xdg-desktop-portal-pantheon](https://github.com/elementary/portals)
 - wlroots [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr)
 - Deepin [xdg-desktop-portal-dde](https://github.com/linuxdeepin/xdg-desktop-portal-dde)
+- Xapp (Cinnamon, MATE, Xfce) [xdg-desktop-portal-xapp](https://github.com/linuxmint/xdg-desktop-portal-xapp)
 
 ## Design considerations
 


### PR DESCRIPTION
Cinnamon recently resolved a request [1]  to have a portal backend for their DE by introducing xdg-desktop-portal-xapp. So let's add that to the list of known portal backendss

[1]: https://github.com/linuxmint/cinnamon-desktop/issues/202
[2]: https://github.com/linuxmint/xdg-desktop-portal-xapp