### PR TITLE
Always send response even if permissions dialog cannot be shown

### DIFF
--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -278,6 +278,7 @@ handle_screenshot_in_thread_func (GTask *task,
                                                          &error))
         {
           g_warning ("Failed to show access dialog: %s", error->message);
+          send_response (request, 2, g_variant_builder_end (&opt_builder));
           return;
         }
 

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -222,6 +222,7 @@ handle_set_wallpaper_in_thread_func (GTask *task,
                                                          &error))
         {
           g_warning ("Failed to show access dialog: %s", error->message);
+          send_response (request, 2);
           return;
         }
 


### PR DESCRIPTION
If for some reason, the permissions dialog cannot be shown, there is no response sent to the caller, so it may remain waiting forever.
This PR ensures that there is always a response sent, even when the dialog has not been shown.
The response is similar to the "No permissions" response (value = 2), as  the caller will not have permission to continue.

The same issue happens in both, Screenshot and Wallpaper.