### PR TITLE
document-portal: Use correct signature for xdp_fuse_forget

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -2065,7 +2065,7 @@ forget_one (fuse_ino_t ino,
 static void
 xdp_fuse_forget (fuse_req_t req,
                  fuse_ino_t ino,
-                 unsigned long nlookup)
+                 uint64_t nlookup)
 {
   forget_one (ino, nlookup);
   fuse_reply_none (req);


### PR DESCRIPTION
The recent Clang compiler (LLVM 16) became stricter so compiling this code on 32 bit arch results in a error.

Relevant log: https://pkg-status.freebsd.org/beefy17/data/main-i386-default/p4785b313b958_se8efee297c/logs/xdg-desktop-portal-1.16.0_1.log