### PR TITLE
global-shortcuts: Limit signals broadcast to sender

### DIFF
--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -589,13 +589,22 @@ activated_cb (XdpDbusImplGlobalShortcuts *impl,
               GVariant *options,
               gpointer data)
 {
+  GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   g_autoptr(Session) session = lookup_session (session_id);
   GlobalShortcutsSession *global_shortcuts_session = (GlobalShortcutsSession *)session;
 
   g_debug ("Received activated %s for %s", session_id, shortcut_id);
 
   if (global_shortcuts_session && !global_shortcuts_session->closed)
-    xdp_dbus_global_shortcuts_emit_activated (data, session_id, shortcut_id, timestamp, options);
+    g_dbus_connection_emit_signal (connection,
+                                   session->sender,
+                                   "/org/freedesktop/portal/desktop",
+                                   "org.freedesktop.portal.GlobalShortcuts",
+                                   "Activated",
+                                   g_variant_new ("(ost@a{sv})",
+                                                  session_id, shortcut_id,
+                                                  timestamp, options),
+                                   NULL);
 }
 
 static void
@@ -606,13 +615,22 @@ deactivated_cb (XdpDbusImplGlobalShortcuts *impl,
                 GVariant *options,
                 gpointer data)
 {
+  GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   g_autoptr(Session) session = lookup_session (session_id);
   GlobalShortcutsSession *global_shortcuts_session = (GlobalShortcutsSession *)session;
 
   g_debug ("Received deactivated %s for %s", session_id, shortcut_id);
 
   if (global_shortcuts_session && !global_shortcuts_session->closed)
-    xdp_dbus_global_shortcuts_emit_deactivated (data, session_id, shortcut_id, timestamp, options);
+    g_dbus_connection_emit_signal (connection,
+                                   session->sender,
+                                   "/org/freedesktop/portal/desktop",
+                                   "org.freedesktop.portal.GlobalShortcuts",
+                                   "Deactivated",
+                                   g_variant_new ("(ost@a{sv})",
+                                                  session_id, shortcut_id,
+                                                  timestamp, options),
+                                   NULL);
 }
 
 static void
@@ -621,13 +639,20 @@ shortcuts_changed_cb (XdpDbusImplGlobalShortcuts *impl,
                       GVariant *shortcuts,
                       gpointer data)
 {
+  GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   g_autoptr(Session) session = lookup_session (session_id);
   GlobalShortcutsSession *global_shortcuts_session = (GlobalShortcutsSession *)session;
 
   g_debug ("Received ShortcutsChanged %s", session_id);
 
   if (global_shortcuts_session && !global_shortcuts_session->closed)
-    xdp_dbus_global_shortcuts_emit_shortcuts_changed (data, session_id, shortcuts);
+    g_dbus_connection_emit_signal (connection,
+                                   session->sender,
+                                   "/org/freedesktop/portal/desktop",
+                                   "org.freedesktop.portal.GlobalShortcuts",
+                                   "ShortcutsChanged",
+                                   g_variant_new ("(o@a(sa{sv}))", session_id, shortcuts),
+                                   NULL);
 }
 
 GDBusInterfaceSkeleton *


### PR DESCRIPTION
Currently the Global Shortcuts portal emits the 3 signals of the D-Bus interface (Activated, Deactivated, and the ShortcutsChanged signals) using the auto-generated D-Bus functions (xdp_dbus_global_shortcuts_emit_*).

These functions end up calling their GObject signals, which call into the signal handlers, which then finally call g_dbus_connection_emit_signal().

The problem is that they call g_dbus_connection_emit_signal() passing NULL to the 'destination_bus_name' parameters, which GDBus documents it to "emit to all listeners". That means we are actively sending these shortcut events to all applications that are willing to listen to these signals!

Fix that by calling g_dbus_connection_emit_signal() directly, and passing the sender bus name properly. This is the same approach that the Inhibit and Location portals use to limit the broadcast of their own signals.

(This has only been compile tested)