### PR TITLE
Make PipeWire dependency mandatory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,9 +110,7 @@ geoclue_dep = dependency('libgeoclue-2.0',
                          required: get_option('geoclue'))
 libportal_dep = dependency('libportal',
                            required: get_option('libportal'))
-pipewire_dep = dependency('libpipewire-0.3',
-                          version: '>= 0.2.90',
-                          required: get_option('pipewire'))
+pipewire_dep = dependency('libpipewire-0.3', version: '>= 0.2.90')
 libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))
 
 bwrap_required = host_machine.system() in ['linux']
@@ -126,11 +124,6 @@ endif
 have_geoclue = geoclue_dep.found()
 if have_geoclue
   config_h.set('HAVE_GEOCLUE', 1)
-endif
-
-have_pipewire = pipewire_dep.found()
-if have_pipewire
-  config_h.set('HAVE_PIPEWIRE', 1)
 endif
 
 have_libsystemd = libsystemd_dep.found()
@@ -189,7 +182,6 @@ configure_file(output: 'config.h', configuration: config_h)
 
 summary({
     'Enable docbook documentation': build_docbook,
-    'Enable pipewire support': have_pipewire,
     'Enable libsystemd support': have_libsystemd,
     'Enable geoclue support': have_geoclue,
     'Enable libportal support': have_libportal,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,10 +18,6 @@ option('geoclue',
        type: 'feature',
        value: 'auto',
        description: 'Enable Geoclue support. Needed for location portal')
-option('pipewire',
-       type: 'feature',
-       value: 'auto',
-       description: 'Enable PipeWire support. Needed for screen cast portal')
 option('systemd',
        type: 'feature',
        value: 'auto',

--- a/src/meson.build
+++ b/src/meson.build
@@ -50,6 +50,8 @@ xdg_desktop_portal_sources = files(
   'background.c',
   'background-monitor.c',
   'call.c',
+  'camera.c',
+  'clipboard.c',
   'device.c',
   'documents.c',
   'dynamic-launcher.c',
@@ -65,12 +67,16 @@ xdg_desktop_portal_sources = files(
   'notification.c',
   'open-uri.c',
   'permissions.c',
+  'pipewire.c',
   'portal-impl.c',
   'power-profile-monitor.c',
   'print.c',
   'proxy-resolver.c',
   'realtime.c',
+  'remote-desktop.c',
   'request.c',
+  'restore-token.c',
+  'screen-cast.c',
   'screenshot.c',
   'secret.c',
   'session.c',
@@ -88,17 +94,6 @@ xdg_desktop_portal_sources += [
   geoclue_built_sources,
   built_resources,
 ]
-
-if have_pipewire
-  xdg_desktop_portal_sources += files(
-      'screen-cast.c',
-      'remote-desktop.c',
-      'restore-token.c',
-      'pipewire.c',
-      'camera.c',
-      'clipboard.c',
-  )
-endif
 
 if have_geoclue
   xdg_desktop_portal_sources += files(

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -302,10 +302,9 @@ on_bus_acquired (GDBusConnection *connection,
                                                      access_impl->dbus_name,
                                                      lockdown));
 #endif
-#ifdef HAVE_PIPEWIRE
+
       export_portal_implementation (connection,
                                     camera_create (connection, lockdown));
-#endif
 
       tmp = find_portal_implementation ("org.freedesktop.impl.portal.Screenshot");
       if (tmp != NULL)
@@ -354,7 +353,6 @@ on_bus_acquired (GDBusConnection *connection,
     export_portal_implementation (connection,
                                   dynamic_launcher_create (connection, implementation->dbus_name));
 
-#ifdef HAVE_PIPEWIRE
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.ScreenCast");
   if (implementation != NULL)
     export_portal_implementation (connection,
@@ -369,7 +367,6 @@ on_bus_acquired (GDBusConnection *connection,
   if (implementation != NULL)
     export_portal_implementation (
         connection, clipboard_create (connection, implementation->dbus_name));
-#endif
 }
 
 static void

--- a/tests/camera.c
+++ b/tests/camera.c
@@ -82,14 +82,6 @@ camera_cb (GObject *obj,
   g_main_context_wakeup (NULL);
 }
 
-#ifdef HAVE_PIPEWIRE
-#define require_pipewire()
-#else
-#define require_pipewire() \
-  g_test_skip ("Skipping tests that require pipewire"); \
-  return;
-#endif
-
 void
 test_camera_basic (void)
 {
@@ -97,8 +89,6 @@ test_camera_basic (void)
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
-
-  require_pipewire ();
 
   reset_camera_permissions ();
 
@@ -128,8 +118,6 @@ test_camera_delay (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
-  require_pipewire ();
-
   reset_camera_permissions ();
 
   keyfile = g_key_file_new ();
@@ -158,8 +146,6 @@ test_camera_cancel (void)
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
-
-  require_pipewire ();
 
   reset_camera_permissions ();
 
@@ -202,8 +188,6 @@ test_camera_close (void)
   g_autofree char *path = NULL;
   g_autoptr(GCancellable) cancellable = NULL;
 
-  require_pipewire ();
-
   reset_camera_permissions ();
 
   keyfile = g_key_file_new ();
@@ -238,7 +222,6 @@ test_camera_lockdown (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
-  require_pipewire ();
   reset_camera_permissions ();
 
   tests_set_property_sync (G_DBUS_PROXY (lockdown),
@@ -286,8 +269,6 @@ test_camera_no_access1 (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
-  require_pipewire ();
-
   reset_camera_permissions ();
 
   keyfile = g_key_file_new ();
@@ -317,8 +298,6 @@ test_camera_no_access2 (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
 
-  require_pipewire ();
-
   set_camera_permissions ("no");
 
   keyfile = g_key_file_new ();
@@ -346,8 +325,6 @@ test_camera_parallel (void)
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autoptr(GError) error = NULL;
   g_autofree char *path = NULL;
-
-  require_pipewire ();
 
   reset_camera_permissions ();
 

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -382,17 +382,6 @@ global_teardown (void)
   g_object_unref (dbus);
 }
 
-#ifdef HAVE_PIPEWIRE
-#define check_pipewire(name)
-#else
-#define check_pipewire(name) \
- if (strcmp (name , "camera") == 0) \
-   { \
-     g_test_skip ("Skipping tests that require pipewire"); \
-     return; \
-   }
-#endif
-
 #ifdef HAVE_GEOCLUE
 #define check_geoclue(name)
 #else
@@ -416,7 +405,6 @@ test_##pp##_exists (void) \
   g_autoptr(GError) error = NULL; \
   g_autofree char *owner = NULL; \
  \
- check_pipewire ( #pp ) \
  check_geoclue ( #pp ) \
  \
   proxy = G_DBUS_PROXY (xdp_dbus_##pp##_proxy_new_sync (session_bus, \


### PR DESCRIPTION
PipeWire has solidified its position in the Linux world over the last few years, and nowadays pretty much all relevant Linux distributions ship PipeWire 0.3.

Make the PipeWire dependency required.