### PR TITLE
build: Bump version to 1.17.99

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'xdg-desktop-portal',
   'c',
-  version: '1.17.0',
+  version: '1.17.99',
   meson_version: '>= 0.56.2',
   license: 'LGPL-2.0-or-later',
   default_options: ['warning_level=2'])


### PR DESCRIPTION
This is to let users depend on > 1.17 when it needs portal APIs pending release.