### PR TITLE
tests: Hook up clipboard tests

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -279,6 +279,7 @@ if enable_pytest
   subdir('templates')
   pytest_files = [
     '__init__.py',
+    'test_clipboard.py',
     'test_email.py',
     'test_remotedesktop.py',
     'test_trash.py',

--- a/tests/templates/meson.build
+++ b/tests/templates/meson.build
@@ -1,5 +1,6 @@
 template_files = [
   '__init__.py',
+  'clipboard.py',
   'email.py',
   'remotedesktop.py',
 ]


### PR DESCRIPTION
They were there, but they didn't run as part of `meson test`.

Cc: @maxhbooth 