### PR TITLE
tests: run pytest with -n auto if pytest-xdist is available

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Install dependencies for the pytest test suite
       run: |
         $RUN_CMD apt-get install --quiet -y --no-install-recommends \
-          python3-pytest python3-dbusmock python3-dbus
+          python3-pytest python3-pytest-xdist python3-dbusmock python3-dbus
 
     - name: Check out xdg-desktop-portal
       uses: actions/checkout@v3

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -294,10 +294,17 @@ if enable_pytest
     )
   endforeach
 
+  pytest_args = ['--verbose', '--log-level=DEBUG']
+
+  # pytest xdist is nice because it significantly speeds up our
+  # test process, but it's not required
+  if pymod.find_installation('python3', modules: ['xdist'], required: false).found()
+    pytest_args += ['-n', 'auto']
+  endif
   test(
     'pytest',
     pytest,
-    args: ['--verbose', '--log-level=DEBUG'],
+    args: pytest_args,
     suite: ['pytest'],
     timeout: 120,
   )


### PR DESCRIPTION
All our tests must be invocable in parallel, so let's make use of that. This brings the pytest run down to around 8 seconds on my machine.

Unfortunately the -n auto command is available only if xdist is available too and pytest fails if we provide it otherwise so we need to check if we have that module.

This reduces the need for #1057