### PR TITLE
Use dbusmock via a pytest fixture

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -334,9 +334,6 @@ class PortalTest(dbusmock.DBusTestCase):
 
     @classmethod
     def setUpClass(cls):
-        logging.basicConfig(
-            format="%(levelname).1s|%(name)s: %(message)s", level=logging.DEBUG
-        )
         cls.PORTAL_NAME = cls.__name__.removeprefix("Test")
         cls.INTERFACE_NAME = f"org.freedesktop.portal.{cls.PORTAL_NAME}"
         cls.start_session_bus()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -160,7 +160,7 @@ class Request(Closable):
         # GLib makes assertions in callbacks impossible, so we wrap all
         # callbacks into a try: except and store the error on the request to
         # be raised later when we're back in the main context
-        self.error = None
+        self.error: Optional[Exception] = None
 
         proxy = bus.get_object("org.freedesktop.portal.Desktop", self.handle)
         self.mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
@@ -343,7 +343,7 @@ class PortalTest(dbusmock.DBusTestCase):
     def setUp(self):
         self.p_mock = None
         self.xdp = None
-        self.portal_interfaces = {}
+        self.portal_interfaces: Dict[str, dbus.Interface] = {}
         self.dbus_monitor = None
 
     def start_impl_portal(self, params=None, portal=None):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -327,24 +327,26 @@ class Session(Closable):
         return cls(bus, response.results["session_handle"])
 
 
-class PortalTest(dbusmock.DBusTestCase):
+class PortalMock:
     """
     Parent class for portal tests.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.PORTAL_NAME = cls.__name__.removeprefix("Test")
-        cls.INTERFACE_NAME = f"org.freedesktop.portal.{cls.PORTAL_NAME}"
-        cls.start_session_bus()
-        cls.dbus_con = cls.get_dbus(system_bus=False)
-        assert cls.dbus_con
-
-    def setUp(self):
+    def __init__(self, session_bus, portal_name: str):
+        self.bus = session_bus
+        self.portal_name = portal_name
         self.p_mock = None
         self.xdp = None
         self.portal_interfaces: Dict[str, dbus.Interface] = {}
         self.dbus_monitor = None
+
+    @property
+    def interface_name(self) -> str:
+        return f"org.freedesktop.portal.{self.portal_name}"
+
+    @property
+    def dbus_con(self):
+        return self.bus.dbus_con
 
     def start_impl_portal(self, params=None, portal=None):
         """
@@ -352,8 +354,8 @@ class PortalTest(dbusmock.DBusTestCase):
         the portal name is derived from the class name of the test, e.g.
         ``TestFoo`` will start ``org.freedesktop.impl.portal.Foo``.
         """
-        portal = portal or self.PORTAL_NAME
-        self.p_mock, self.obj_portal = self.spawn_server_template(
+        portal = portal or self.portal_name
+        self.p_mock, self.obj_portal = self.bus.spawn_server_template(
             template=f"tests/templates/{portal.lower()}.py",
             parameters=params,
             stdout=subprocess.PIPE,
@@ -414,11 +416,13 @@ class PortalTest(dbusmock.DBusTestCase):
         xdp = subprocess.Popen(argv, env=env)
 
         for _ in range(50):
-            if self.dbus_con.name_has_owner("org.freedesktop.portal.Desktop"):
+            if self.bus.dbus_con.name_has_owner("org.freedesktop.portal.Desktop"):
                 break
             time.sleep(0.1)
         else:
-            self.fail("Timeout while waiting for xdg-desktop-portal to claim the bus")
+            assert (
+                False
+            ), "Timeout while waiting for xdg-desktop-portal to claim the bus"
 
         self.xdp = xdp
 
@@ -454,7 +458,7 @@ class PortalTest(dbusmock.DBusTestCase):
         try:
             return self._xdp_dbus_object
         except AttributeError:
-            obj = self.dbus_con.get_object(
+            obj = self.bus.dbus_con.get_object(
                 "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop"
             )
             # Useful for debugging:
@@ -474,12 +478,12 @@ class PortalTest(dbusmock.DBusTestCase):
         For portals, it's enough to specify the portal name (e.g. "InputCapture").
         If no name is provided, guess from the test class name.
         """
-        name = name or self.INTERFACE_NAME
+        name = name or self.interface_name
         if "." not in name:
             name = f"org.freedesktop.portal.{name}"
 
         try:
-            intf = self.portal_interfaces[name]
+            intf = getattr(self, "portal_interfaces", {})[name]
         except KeyError:
             intf = dbus.Interface(self.get_xdp_dbus_object(), name)
             assert intf
@@ -494,15 +498,14 @@ class PortalTest(dbusmock.DBusTestCase):
         """
         Helper function to check for a portal's version. Use as:
 
-            >>> class TestFoo(PortalTest):
+            >>> class TestFoo(PortalMock):
             ...     def test_version(self):
             ...         self.check_version(2)
             >>>
         """
-        self.start_xdp()
         properties_intf = self.get_dbus_interface("org.freedesktop.DBus.Properties")
         try:
-            portal_version = properties_intf.Get(self.INTERFACE_NAME, "version")
+            portal_version = properties_intf.Get(self.interface_name, "version")
             assert int(portal_version) == expected_version
         except dbus.exceptions.DBusException as e:
             logger.critical(e)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -486,6 +486,10 @@ class PortalTest(dbusmock.DBusTestCase):
             self.portal_interfaces[name] = intf
         return intf
 
+    def create_request(self, intf_name: Optional[str] = None) -> Request:
+        intf = self.get_dbus_interface(intf_name)
+        return Request(self.dbus_con, intf)
+
     def check_version(self, expected_version):
         """
         Helper function to check for a portal's version. Use as:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+from typing import Any, Iterator
+
+import pytest
+import dbus
+import dbusmock
+
+from tests import PortalMock
+
+
+class SessionBusMock(dbusmock.DBusTestCase):
+    def __init__(self):
+        super().__init__()
+        self._dbus_con = None
+
+    @property
+    def dbus_con(self) -> "dbus.Bus":
+        return self._dbus_con
+
+
+@pytest.fixture()
+def session_bus() -> Iterator[SessionBusMock]:
+    """
+    Fixture to yield a DBusTestCase with a started session bus.
+    """
+    bus = SessionBusMock()
+    bus.setUp()
+    bus.start_session_bus()
+    con = bus.get_dbus(system_bus=False)
+    assert con
+    bus._dbus_con = con
+    yield bus
+    bus.tearDown()
+    bus.tearDownClass()
+
+
+@pytest.fixture
+def portal_name() -> str:
+    raise NotImplementedError("All test files need to define the portal_name fixture")
+
+
+@pytest.fixture
+def portal_has_impl() -> bool:
+    """
+    Default fixture for signaling that a portal has an impl.portal as well.
+
+    For tests of portals that do not have an impl, override this fixture to
+    return False in the respective test_foo.py.
+    """
+    return True
+
+
+@pytest.fixture
+def params() -> dict[str, Any]:
+    """
+    Default fixture providing empty parameters that get passed to the impl.portal.
+    To use this in test cases, pass the parameters via
+
+        @pytest.mark.parametrize("params", ({"foo": "bar"}, ))
+
+    Note that this must be a tuple as pytest will iterate over the value.
+    """
+    return {}
+
+
+@pytest.fixture
+def portal_mock(session_bus, portal_name, params, portal_has_impl) -> PortalMock:
+    """
+    Fixture yielding a PortalMock object with the impl started, if applicable.
+    """
+    pmock = PortalMock(session_bus, portal_name)
+    if portal_has_impl:
+        pmock.start_impl_portal(params)
+    pmock.start_xdp()
+    return pmock

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -287,6 +287,7 @@ if enable_pytest
   endif
 
   pytest_files = [
+    'conftest.py',
     '__init__.py',
     'test_clipboard.py',
     'test_email.py',

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -5,9 +5,8 @@
 from tests.templates import Response, init_template_logger, ImplRequest, ImplSession
 import dbus
 import dbus.service
-import socket
 import time
-from dbusmock import MOCK_IFACE, mockobject
+from dbusmock import MOCK_IFACE
 
 from gi.repository import GLib
 

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -173,7 +173,7 @@ def ConnectToEIS(self, session_handle, app_id, options):
         assert session_handle in self.sessions
 
         if self.fail_connect_to_eis:
-            raise dbus.exceptions.DBusException(f"Purposely failing ConnectToEIS")
+            raise dbus.exceptions.DBusException("Purposely failing ConnectToEIS")
 
         sockets = socket.socketpair()
         self.eis_socket = sockets[0]

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -126,32 +126,15 @@ def assertRaisesErrno(error_nr, func, *args, **kwargs):
         )
 
 
-def assertEmpty(a_set):
-    if len(a_set) != 0:
-        raise AssertionError("Set was not empty as expected (was: {0})".format(a_set))
-
-
-def assertEqual(a, b):
-    if a != b:
-        raise AssertionError("{} was not the expected {}".format(a, b))
-
-
-def assertIn(element, container):
-    if element not in container:
-        raise AssertionError(
-            "{} was not in the container {}".format(element, container)
-        )
-
-
 def assertFileHasContent(path, expected_content):
     with open(path) as f:
         file_content = f.read()
-        assertEqual(file_content, expected_content)
+        assert file_content == expected_content
 
 
 def assertFdHasContent(fd, expected_content):
     content = readFdContent(fd)
-    assertEqual(content, expected_content)
+    assert content == expected_content
 
 
 def assertSameStat(a, b, b_mode_mask):
@@ -448,12 +431,12 @@ class DocPortal:
 
 
 def check_virtual_stat(info, writable=False):
-    assertEqual(info.st_uid, os.getuid())
-    assertEqual(info.st_gid, os.getgid())
+    assert info.st_uid == os.getuid()
+    assert info.st_gid == os.getgid()
     if writable:
-        assertEqual(info.st_mode, stat.S_IFDIR | 0o700)
+        assert info.st_mode == stat.S_IFDIR | 0o700
     else:
-        assertEqual(info.st_mode, stat.S_IFDIR | 0o500)
+        assert info.st_mode == stat.S_IFDIR | 0o500
 
 
 def verify_virtual_dir(path, files, volatile_files=None):
@@ -492,8 +475,8 @@ def verify_doc(doc, app_id=None):
     for file in doc.files:
         filepath = dir + "/" + file
         info = os.lstat(filepath)
-        assertEqual(info.st_uid, os.getuid())
-        assertEqual(info.st_gid, os.getgid())
+        assert info.st_uid == os.getuid()
+        assert info.st_gid == os.getgid()
 
         assert os.access(filepath, os.R_OK)
         if doc.is_writable_by(app_id):
@@ -775,8 +758,8 @@ def check_directory_doc_perms(doc, app_id):
     assertFileHasContent(dir + "/realfile", "real1")
     assertFileHasContent(dir + "/readonly", "readonly")
     assertFileHasContent(dir + "/subdir/hardlink", "real1")
-    assertEqual(
-        os.lstat(dir + "/realfile").st_ino, os.lstat(dir + "/subdir/hardlink").st_ino
+    assert (
+        os.lstat(dir + "/realfile").st_ino == os.lstat(dir + "/subdir/hardlink").st_ino
     )
     assertSymlink(dir + "/symlink", "realfile")
     assertSymlink(dir + "/broken-symlink", "the-void")
@@ -806,8 +789,8 @@ def check_directory_doc_perms(doc, app_id):
         assertFdHasContent(fd2, "filedata-more")
 
         os.link(filepath, filepath2)
-        assertEqual(os.lstat(filepath).st_ino, os.lstat(filepath2).st_ino)
-        assertEqual(os.lstat(filepath).st_ino, os.fstat(fd).st_ino)
+        assert os.lstat(filepath).st_ino == os.lstat(filepath2).st_ino
+        assert os.lstat(filepath).st_ino == os.fstat(fd).st_ino
         assertFileHasContent(filepath2, "filedata-more")
         assertFileHasContent(real_filepath2, "filedata-more")
 
@@ -940,10 +923,10 @@ def export_a_doc():
     logv("exported %s as %s" % (path, doc))
 
     lookup = portal.lookup(path)
-    assertEqual(lookup, doc.id)
+    assert lookup == doc.id
 
     lookup_on_fuse = portal.lookup(doc.get_doc_path(None) + "/" + doc.filename)
-    assertEqual(lookup_on_fuse, doc.id)
+    assert lookup_on_fuse == doc.id
 
     reused_doc = portal.add(path)
     assert doc is reused_doc
@@ -958,7 +941,7 @@ def export_a_doc():
     # Should not be able to add a tempfile on the fuse mount, or look it up
     assertRaises(GLib.Error, portal.add, tmppath)
     lookup = portal.lookup(tmppath)
-    assertEqual(lookup, "")
+    assert lookup == ""
 
     os.unlink(tmppath)
 
@@ -970,7 +953,7 @@ def export_a_named_doc(create_file):
 
     if create_file:
         lookup = portal.lookup(path)
-        assertEqual(lookup, doc.id)
+        assert lookup == doc.id
 
     reused_doc = portal.add_named(path)
     assert doc is reused_doc
@@ -985,18 +968,18 @@ def export_a_dir_doc():
     logv("exported (dir) %s as %s" % (dir, doc))
 
     lookup = portal.lookup(dir)
-    assertEqual(lookup, doc.id)
+    assert lookup == doc.id
 
     lookup_on_fuse = portal.lookup(doc.get_doc_path(None))
-    assertEqual(lookup_on_fuse, doc.id)
+    assert lookup_on_fuse == doc.id
 
     # We should not be able to portal lookup a file in the dir doc
     subpath = doc.get_doc_path(None) + "/sub"
     setFileContent(subpath, "sub")
     doc = portal.lookup(subpath)
-    assertEqual(doc, "")
+    assert doc == ""
     doc2 = portal.lookup(dir + "/sub")
-    assertEqual(doc2, "")
+    assert doc2 == ""
 
     # But we should be able to re-export the file
     reexported_doc = portal.add(subpath)

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
-import os, sys, stat, random, errno, argparse
+import argparse
+import errno
+import os
+import random
+import stat
+import sys
+
 from gi.repository import Gio, GLib
 
 
@@ -131,7 +137,7 @@ def assertEqual(a, b):
 
 
 def assertIn(element, container):
-    if not element in container:
+    if element not in container:
         raise AssertionError(
             "{} was not in the container {}".format(element, container)
         )
@@ -216,7 +222,7 @@ def assertDirFiles(path, expected_files, exhaustive=True, volatile_files=None):
     for file in expected_files:
         if file in remaining:
             remaining.remove(file)
-        elif not file in volatile_files:
+        elif file not in volatile_files:
             raise AssertionError(
                 "Expected file {} not found in dir {} (all: {})".format(
                     file, path, found_files
@@ -276,7 +282,7 @@ class Doc:
         name = self.id
         if self.is_dir:
             return "%s(dir)" % (name)
-        elif self.content == None:
+        elif self.content is None:
             return "%s(missing)" % (name)
         else:
             return "%s" % (name)
@@ -407,7 +413,7 @@ class DocPortal:
         return docs
 
     def ensure_app_id(self, app_id, volatile=False):
-        if not app_id in self.apps:
+        if app_id not in self.apps:
             self.apps.append(app_id)
         if volatile:
             self.volatile_apps.add(app_id)
@@ -458,7 +464,7 @@ def verify_virtual_dir(path, files, volatile_files=None):
 
     assertRaises(FileNotFoundError, os.lstat, path + "/not-existing-file")
 
-    if files != None:
+    if files is not None:
         assertDirFiles(path, files, ensure_no_remaining, volatile_files)
 
 
@@ -500,7 +506,6 @@ def verify_doc(doc, app_id=None):
         real_path = doc.real_path
         if doc.content:
             assertFileExist(main_path)
-            content = None
             assertFileHasContent(main_path, doc.content)
             assertFileHasContent(real_path, doc.content)
 
@@ -944,7 +949,7 @@ def export_a_doc():
     assert doc is reused_doc
 
     not_reused_doc = portal.add(path, False)
-    assert not doc is not_reused_doc
+    assert doc is not not_reused_doc
 
     # We should not be able to re-export a tmpfile
     tmppath = doc.get_doc_path(None) + "/tmpfile"
@@ -971,7 +976,7 @@ def export_a_named_doc(create_file):
     assert doc is reused_doc
 
     not_reused_doc = portal.add_named(path, False)
-    assert not doc is not_reused_doc
+    assert doc is not not_reused_doc
 
 
 def export_a_dir_doc():
@@ -991,7 +996,7 @@ def export_a_dir_doc():
     doc = portal.lookup(subpath)
     assertEqual(doc, "")
     doc2 = portal.lookup(dir + "/sub")
-    assertEqual(doc, "")
+    assertEqual(doc2, "")
 
     # But we should be able to re-export the file
     reexported_doc = portal.add(subpath)

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -2,34 +2,39 @@
 #
 # This file is formatted with Python Black
 
-from tests import PortalTest, Session
+from tests import PortalMock, Session
 import dbus
+import pytest
 import os
 
 
-class TestClipboard(PortalTest):
-    def test_version(self):
-        self.check_version(1)
+@pytest.fixture
+def portal_name():
+    return "Clipboard"
 
-    def start_session(self, params={}):
-        self.start_impl_portal(params=params)
-        self.add_template(portal="RemoteDesktop", params=params)
-        self.start_xdp()
 
-        clipboard_interface = self.get_dbus_interface()
+class TestClipboard:
+    def test_version(self, portal_mock):
+        portal_mock.check_version(1)
 
-        create_session_request = self.create_request("RemoteDesktop")
+    def start_session(self, pmock, params={}):
+        pmock.start_impl_portal(params=params)
+        pmock.add_template(portal="RemoteDesktop", params=params)
+        pmock.start_xdp()
+
+        create_session_request = pmock.create_request("RemoteDesktop")
         create_session_response = create_session_request.call(
             "CreateSession", options={"session_handle_token": "1234"}
         )
         assert create_session_response.response == 0
         assert str(create_session_response.results["session_handle"])
 
-        session = Session.from_response(self.dbus_con, create_session_response)
+        session = Session.from_response(pmock.dbus_con, create_session_response)
 
+        clipboard_interface = pmock.get_dbus_interface()
         clipboard_interface.RequestClipboard(session.handle, {})
 
-        start_session_request = self.create_request("RemoteDesktop")
+        start_session_request = pmock.create_request("RemoteDesktop")
         start_session_response = start_session_request.call(
             "Start", session_handle=session.handle, parent_window="", options={}
         )
@@ -38,32 +43,36 @@ class TestClipboard(PortalTest):
 
         return (session, start_session_response.results.get("clipboard_enabled"))
 
-    def test_request_clipboard_and_start_session(self):
+    def test_request_clipboard_and_start_session(self, session_bus):
+        pmock = PortalMock(session_bus, "Clipboard")
         params = {"force-clipboard-enabled": True}
-        _, clipboard_enabled = self.start_session(params)
+        _, clipboard_enabled = self.start_session(pmock, params)
 
         assert clipboard_enabled
 
-    def test_clipboard_checks_clipboard_enabled(self):
-        session, clipboard_enabled = self.start_session()
-        clipboard_interface = self.get_dbus_interface()
+    def test_clipboard_checks_clipboard_enabled(self, session_bus):
+        pmock = PortalMock(session_bus, "Clipboard")
+        session, clipboard_enabled = self.start_session(pmock)
+        clipboard_interface = pmock.get_dbus_interface()
 
-        self.assertFalse(clipboard_enabled)
+        assert not clipboard_enabled
 
-        with self.assertRaises(dbus.exceptions.DBusException):
+        with pytest.raises(dbus.exceptions.DBusException):
             clipboard_interface.SetSelection(session.handle, {})
 
-    def test_clipboard_set_selection(self):
+    def test_clipboard_set_selection(self, session_bus):
+        pmock = PortalMock(session_bus, "Clipboard")
         params = {"force-clipboard-enabled": True}
-        session, _ = self.start_session(params)
-        clipboard_interface = self.get_dbus_interface()
+        session, _ = self.start_session(pmock, params)
+        clipboard_interface = pmock.get_dbus_interface()
 
         clipboard_interface.SetSelection(session.handle, {})
 
-    def test_clipboard_selection_write(self):
+    def test_clipboard_selection_write(self, session_bus):
+        pmock = PortalMock(session_bus, "Clipboard")
         params = {"force-clipboard-enabled": True}
-        session, _ = self.start_session(params)
-        clipboard_interface = self.get_dbus_interface()
+        session, _ = self.start_session(pmock, params)
+        clipboard_interface = pmock.get_dbus_interface()
 
         fd_object: dbus.types.UnixFd = clipboard_interface.SelectionWrite(
             session.handle, 1234
@@ -78,10 +87,11 @@ class TestClipboard(PortalTest):
 
         clipboard_interface.SelectionWriteDone(session.handle, 1234, True)
 
-    def test_clipboard_selection_read(self):
+    def test_clipboard_selection_read(self, session_bus):
+        pmock = PortalMock(session_bus, "Clipboard")
         params = {"force-clipboard-enabled": True}
-        session, _ = self.start_session(params)
-        clipboard_interface = self.get_dbus_interface()
+        session, _ = self.start_session(pmock, params)
+        clipboard_interface = pmock.get_dbus_interface()
 
         fd_object: dbus.types.UnixFd = clipboard_interface.SelectionRead(
             session.handle, "mimetype"

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests import Request, PortalTest, Session
+from tests import PortalTest, Session
 import dbus
 import os
 
@@ -16,10 +16,9 @@ class TestClipboard(PortalTest):
         self.add_template(portal="RemoteDesktop", params=params)
         self.start_xdp()
 
-        remote_desktop_interface = self.get_dbus_interface("RemoteDesktop")
         clipboard_interface = self.get_dbus_interface()
 
-        create_session_request = Request(self.dbus_con, remote_desktop_interface)
+        create_session_request = self.create_request("RemoteDesktop")
         create_session_response = create_session_request.call(
             "CreateSession", options={"session_handle_token": "1234"}
         )
@@ -30,7 +29,7 @@ class TestClipboard(PortalTest):
 
         clipboard_interface.RequestClipboard(session.handle, {})
 
-        start_session_request = Request(self.dbus_con, remote_desktop_interface)
+        start_session_request = self.create_request("RemoteDesktop")
         start_session_response = start_session_request.call(
             "Start", session_handle=session.handle, parent_window="", options={}
         )

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -2,9 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from logging import debug
 from tests import Request, PortalTest, Session
-from gi.repository import GLib
 import dbus
 import os
 

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -4,7 +4,6 @@
 
 
 from tests import Request, PortalTest
-from gi.repository import GLib
 
 import dbus
 import time

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -3,7 +3,7 @@
 # This file is formatted with Python Black
 
 
-from tests import Request, PortalTest
+from tests import PortalTest
 
 import dbus
 import time
@@ -21,8 +21,7 @@ class TestEmail(PortalTest):
         subject = "Re: portal tests"
         body = "You have to see this"
 
-        email_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, email_intf)
+        request = self.create_request()
         options = {
             "addresses": addresses,
             "subject": subject,
@@ -53,8 +52,7 @@ class TestEmail(PortalTest):
 
         addresses = ["gibberish! not an email address\n%Q"]
 
-        email_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, email_intf)
+        request = self.create_request()
         options = {
             "addresses": addresses,
         }
@@ -81,8 +79,7 @@ class TestEmail(PortalTest):
 
         subject = "not\na\nvalid\nsubject line"
 
-        email_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, email_intf)
+        request = self.create_request()
         options = {
             "subject": subject,
         }
@@ -111,8 +108,7 @@ class TestEmail(PortalTest):
 
         assert len(subject) > 200
 
-        email_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, email_intf)
+        request = self.create_request()
         options = {
             "subject": subject,
         }
@@ -146,8 +142,7 @@ class TestEmail(PortalTest):
         subject = "delay test"
         addresses = ["mclasen@redhat.com"]
 
-        email_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, email_intf)
+        request = self.create_request()
         options = {
             "addresses": addresses,
             "subject": subject,
@@ -191,8 +186,7 @@ class TestEmail(PortalTest):
         subject = "cancel test"
         addresses = ["mclasen@redhat.com"]
 
-        email_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, email_intf)
+        request = self.create_request()
         options = {
             "addresses": addresses,
             "subject": subject,
@@ -231,8 +225,7 @@ class TestEmail(PortalTest):
         subject = "close test"
         addresses = ["mclasen@redhat.com"]
 
-        email_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, email_intf)
+        request = self.create_request()
         request.schedule_close(1000)
         options = {
             "addresses": addresses,

--- a/tests/test_globalshortcuts.py
+++ b/tests/test_globalshortcuts.py
@@ -3,7 +3,7 @@
 # This file is formatted with Python Black
 
 
-from tests import Request, PortalTest, Session
+from tests import PortalTest, Session
 from gi.repository import GLib
 
 import dbus
@@ -18,8 +18,7 @@ class TestGlobalShortcuts(PortalTest):
         self.start_impl_portal()
         self.start_xdp()
 
-        gs_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, gs_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -51,8 +50,7 @@ class TestGlobalShortcuts(PortalTest):
         self.start_impl_portal(params=params)
         self.start_xdp()
 
-        gs_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, gs_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -83,8 +81,7 @@ class TestGlobalShortcuts(PortalTest):
         self.start_impl_portal()
         self.start_xdp()
 
-        gs_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, gs_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -114,7 +111,7 @@ class TestGlobalShortcuts(PortalTest):
             ),
         ]
 
-        request = Request(self.dbus_con, gs_intf)
+        request = self.create_request()
         response = request.call(
             "BindShortcuts",
             session_handle=session.handle,
@@ -123,7 +120,7 @@ class TestGlobalShortcuts(PortalTest):
             options={},
         )
 
-        request = Request(self.dbus_con, gs_intf)
+        request = self.create_request()
         options = {}
         response = request.call(
             "ListShortcuts",
@@ -145,8 +142,7 @@ class TestGlobalShortcuts(PortalTest):
         self.start_impl_portal()
         self.start_xdp()
 
-        gs_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, gs_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -169,7 +165,7 @@ class TestGlobalShortcuts(PortalTest):
             ),
         ]
 
-        request = Request(self.dbus_con, gs_intf)
+        request = self.create_request()
         response = request.call(
             "BindShortcuts",
             session_handle=session.handle,
@@ -205,6 +201,7 @@ class TestGlobalShortcuts(PortalTest):
             assert shortcut_id == "binding1"
             deactivated_count += 1
 
+        gs_intf = self.get_dbus_interface()
         gs_intf.connect_to_signal("Activated", cb_activated)
         gs_intf.connect_to_signal("Deactivated", cb_deactivated)
 

--- a/tests/test_globalshortcuts.py
+++ b/tests/test_globalshortcuts.py
@@ -7,7 +7,6 @@ from tests import Request, PortalTest, Session
 from gi.repository import GLib
 
 import dbus
-import socket
 import time
 
 

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -3,7 +3,7 @@
 # This file is formatted with Python Black
 
 
-from tests import Request, PortalTest, Session
+from tests import PortalTest, Session
 from gi.repository import GLib
 
 import dbus
@@ -18,8 +18,7 @@ class TestRemoteDesktop(PortalTest):
         self.start_impl_portal()
         self.start_xdp()
 
-        rd_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -51,8 +50,7 @@ class TestRemoteDesktop(PortalTest):
         self.start_impl_portal(params=params)
         self.start_xdp()
 
-        rd_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -83,8 +81,7 @@ class TestRemoteDesktop(PortalTest):
         self.start_impl_portal()
         self.start_xdp()
 
-        rd_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -96,7 +93,7 @@ class TestRemoteDesktop(PortalTest):
         assert response.response == 0
 
         session = Session.from_response(self.dbus_con, response)
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "types": dbus.UInt32(0x3),
         }
@@ -107,7 +104,7 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {}
         response = request.call(
             "Start",
@@ -117,6 +114,7 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
+        rd_intf = self.get_dbus_interface()
         fd = rd_intf.ConnectToEIS(session.handle, dbus.Dictionary({}, signature="sv"))
         eis_socket = socket.fromfd(fd.take(), socket.AF_UNIX, socket.SOCK_STREAM)
         assert eis_socket.recv(10) == b"HELLO"
@@ -126,8 +124,7 @@ class TestRemoteDesktop(PortalTest):
         self.start_impl_portal(params=params)
         self.start_xdp()
 
-        rd_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -139,7 +136,7 @@ class TestRemoteDesktop(PortalTest):
         assert response.response == 0
 
         session = Session.from_response(self.dbus_con, response)
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "types": dbus.UInt32(0x3),
         }
@@ -150,7 +147,7 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {}
         response = request.call(
             "Start",
@@ -161,6 +158,7 @@ class TestRemoteDesktop(PortalTest):
         assert response.response == 0
 
         with self.assertRaises(dbus.exceptions.DBusException) as cm:
+            rd_intf = self.get_dbus_interface()
             _ = rd_intf.ConnectToEIS(
                 session.handle, dbus.Dictionary({}, signature="sv")
             )
@@ -170,8 +168,7 @@ class TestRemoteDesktop(PortalTest):
         self.start_impl_portal()
         self.start_xdp()
 
-        rd_intf = self.get_dbus_interface()
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -183,7 +180,7 @@ class TestRemoteDesktop(PortalTest):
         assert response.response == 0
 
         session = Session.from_response(self.dbus_con, response)
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {
             "types": dbus.UInt32(0x3),
         }
@@ -194,7 +191,7 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        request = Request(self.dbus_con, rd_intf)
+        request = self.create_request()
         options = {}
         response = request.call(
             "Start",
@@ -217,6 +214,7 @@ class TestRemoteDesktop(PortalTest):
             {"name": "NotifyTouchUp", "args": (0,)},
         ]:
             with self.assertRaises(dbus.exceptions.DBusException) as cm:
+                rd_intf = self.get_dbus_interface()
                 func = getattr(rd_intf, notifyfunc["name"])
                 assert func is not None
                 func(

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -161,7 +161,7 @@ class TestRemoteDesktop(PortalTest):
         assert response.response == 0
 
         with self.assertRaises(dbus.exceptions.DBusException) as cm:
-            fd = rd_intf.ConnectToEIS(
+            _ = rd_intf.ConnectToEIS(
                 session.handle, dbus.Dictionary({}, signature="sv")
             )
         assert "Purposely failing ConnectToEIS" in cm.exception.get_dbus_message()

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -3,22 +3,25 @@
 # This file is formatted with Python Black
 
 
-from tests import PortalTest, Session
+from tests import PortalMock, Session
 from gi.repository import GLib
 
 import dbus
+import pytest
 import socket
 
 
-class TestRemoteDesktop(PortalTest):
-    def test_version(self):
-        self.check_version(2)
+@pytest.fixture
+def portal_name():
+    return "RemoteDesktop"
 
-    def test_remote_desktop_create_close_session(self):
-        self.start_impl_portal()
-        self.start_xdp()
 
-        request = self.create_request()
+class TestRemoteDesktop:
+    def test_version(self, portal_mock):
+        portal_mock.check_version(2)
+
+    def test_remote_desktop_create_close_session(self, portal_mock):
+        request = portal_mock.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -29,9 +32,9 @@ class TestRemoteDesktop(PortalTest):
 
         assert response.response == 0
 
-        session = Session.from_response(self.dbus_con, response)
+        session = Session.from_response(portal_mock.dbus_con, response)
         # Check the impl portal was called with the right args
-        method_calls = self.mock_interface.GetMethodCalls("CreateSession")
+        method_calls = portal_mock.mock_interface.GetMethodCalls("CreateSession")
         assert len(method_calls) > 0
         _, args = method_calls[-1]
         assert args[1] == session.handle
@@ -45,12 +48,9 @@ class TestRemoteDesktop(PortalTest):
 
         assert session.closed
 
-    def test_remote_desktop_create_session_signal_closed(self):
-        params = {"force-close": 500}
-        self.start_impl_portal(params=params)
-        self.start_xdp()
-
-        request = self.create_request()
+    @pytest.mark.parametrize("params", ({"force-close": 500},))
+    def test_remote_desktop_create_session_signal_closed(self, portal_mock):
+        request = portal_mock.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -61,9 +61,9 @@ class TestRemoteDesktop(PortalTest):
 
         assert response.response == 0
 
-        session = Session.from_response(self.dbus_con, response)
+        session = Session.from_response(portal_mock.dbus_con, response)
         # Check the impl portal was called with the right args
-        method_calls = self.mock_interface.GetMethodCalls("CreateSession")
+        method_calls = portal_mock.mock_interface.GetMethodCalls("CreateSession")
         assert len(method_calls) > 0
         _, args = method_calls[-1]
         assert args[1] == session.handle
@@ -77,11 +77,8 @@ class TestRemoteDesktop(PortalTest):
 
         assert session.closed
 
-    def test_remote_desktop_connect_to_eis(self):
-        self.start_impl_portal()
-        self.start_xdp()
-
-        request = self.create_request()
+    def test_remote_desktop_connect_to_eis(self, portal_mock):
+        request = portal_mock.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -92,8 +89,8 @@ class TestRemoteDesktop(PortalTest):
 
         assert response.response == 0
 
-        session = Session.from_response(self.dbus_con, response)
-        request = self.create_request()
+        session = Session.from_response(portal_mock.dbus_con, response)
+        request = portal_mock.create_request()
         options = {
             "types": dbus.UInt32(0x3),
         }
@@ -104,7 +101,7 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        request = self.create_request()
+        request = portal_mock.create_request()
         options = {}
         response = request.call(
             "Start",
@@ -114,17 +111,14 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        rd_intf = self.get_dbus_interface()
+        rd_intf = portal_mock.get_dbus_interface()
         fd = rd_intf.ConnectToEIS(session.handle, dbus.Dictionary({}, signature="sv"))
         eis_socket = socket.fromfd(fd.take(), socket.AF_UNIX, socket.SOCK_STREAM)
         assert eis_socket.recv(10) == b"HELLO"
 
-    def test_remote_desktop_connect_to_eis_fail(self):
-        params = {"fail-connect-to-eis": True}
-        self.start_impl_portal(params=params)
-        self.start_xdp()
-
-        request = self.create_request()
+    @pytest.mark.parametrize("params", ({"fail-connect-to-eis": True},))
+    def test_remote_desktop_connect_to_eis_fail(self, portal_mock):
+        request = portal_mock.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -135,8 +129,8 @@ class TestRemoteDesktop(PortalTest):
 
         assert response.response == 0
 
-        session = Session.from_response(self.dbus_con, response)
-        request = self.create_request()
+        session = Session.from_response(portal_mock.dbus_con, response)
+        request = portal_mock.create_request()
         options = {
             "types": dbus.UInt32(0x3),
         }
@@ -147,7 +141,7 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        request = self.create_request()
+        request = portal_mock.create_request()
         options = {}
         response = request.call(
             "Start",
@@ -157,18 +151,15 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        with self.assertRaises(dbus.exceptions.DBusException) as cm:
-            rd_intf = self.get_dbus_interface()
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            rd_intf = portal_mock.get_dbus_interface()
             _ = rd_intf.ConnectToEIS(
                 session.handle, dbus.Dictionary({}, signature="sv")
             )
-        assert "Purposely failing ConnectToEIS" in cm.exception.get_dbus_message()
+        assert "Purposely failing ConnectToEIS" in excinfo.value.get_dbus_message()
 
-    def test_remote_desktop_connect_to_eis_fail_notifies(self):
-        self.start_impl_portal()
-        self.start_xdp()
-
-        request = self.create_request()
+    def test_remote_desktop_connect_to_eis_fail_notifies(self, portal_mock):
+        request = portal_mock.create_request()
         options = {
             "session_handle_token": "session_token0",
         }
@@ -179,8 +170,8 @@ class TestRemoteDesktop(PortalTest):
 
         assert response.response == 0
 
-        session = Session.from_response(self.dbus_con, response)
-        request = self.create_request()
+        session = Session.from_response(portal_mock.dbus_con, response)
+        request = portal_mock.create_request()
         options = {
             "types": dbus.UInt32(0x3),
         }
@@ -191,7 +182,7 @@ class TestRemoteDesktop(PortalTest):
         )
         assert response.response == 0
 
-        request = self.create_request()
+        request = portal_mock.create_request()
         options = {}
         response = request.call(
             "Start",
@@ -213,8 +204,8 @@ class TestRemoteDesktop(PortalTest):
             {"name": "NotifyTouchMotion", "args": (0, 0, 1, 1)},
             {"name": "NotifyTouchUp", "args": (0,)},
         ]:
-            with self.assertRaises(dbus.exceptions.DBusException) as cm:
-                rd_intf = self.get_dbus_interface()
+            with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+                rd_intf = portal_mock.get_dbus_interface()
                 func = getattr(rd_intf, notifyfunc["name"])
                 assert func is not None
                 func(
@@ -225,5 +216,5 @@ class TestRemoteDesktop(PortalTest):
             # Not the best error message but...
             assert (
                 "Session is not allowed to call Notify"
-                in cm.exception.get_dbus_message()
+                in excinfo.value.get_dbus_message()
             )

--- a/tests/test_trash.py
+++ b/tests/test_trash.py
@@ -6,9 +6,7 @@
 from tests import PortalTest
 from pathlib import Path
 
-import dbus
 import os
-import time
 import tempfile
 
 

--- a/tests/test_trash.py
+++ b/tests/test_trash.py
@@ -3,32 +3,38 @@
 # This file is formatted with Python Black
 
 
-from tests import PortalTest
 from pathlib import Path
 
 import os
+import pytest
 import tempfile
 
 
-class TestTrash(PortalTest):
-    def test_version(self):
-        self.check_version(1)
+@pytest.fixture
+def portal_name():
+    return "Trash"
 
-    def test_trash_file_fails(self):
-        self.start_xdp()
 
-        trash_intf = self.get_dbus_interface()
+@pytest.fixture
+def portal_has_impl():
+    return False
+
+
+class TestTrash:
+    def test_version(self, portal_mock):
+        portal_mock.check_version(1)
+
+    def test_trash_file_fails(self, portal_mock):
+        trash_intf = portal_mock.get_dbus_interface()
         with open("/proc/cmdline") as fd:
             result = trash_intf.TrashFile(fd.fileno())
 
         assert result == 0
 
-    def test_trash_file(self):
-        self.start_xdp()
+    def test_trash_file(self, portal_mock):
+        trash_intf = portal_mock.get_dbus_interface()
 
-        trash_intf = self.get_dbus_interface()
-
-        fd, name = tempfile.mkstemp(prefix="trash_portal_test_", dir=Path.home())
+        fd, name = tempfile.mkstemp(prefix="trash_portal_mock_", dir=Path.home())
         result = trash_intf.TrashFile(fd)
         if result != 1:
             os.unlink(name)


### PR DESCRIPTION
A few cleanups to the test suite, the meat is in the last patch though which changes our dbusmock use-case from subclassing (and thus using the unittest approach) to a manually handled fixture. This means we can use all of pytest' features, now, including things like `pytest.mark.parametrize()`.

We no longer need the test classes now but they provide a convenient namespacing.

Note that #714 needs updates if this one gets merged, or vice versa.