### PR TITLE
tests: Check for python3.9

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -273,7 +273,7 @@ python = pymod.find_installation(
   required: get_option('pytest'),
 )
 
-enable_pytest = pytest.found() and python.found()
+enable_pytest = pytest.found() and python.found() and python.language_version().version_compare('>=3.9')
 
 if enable_pytest
   subdir('templates')


### PR DESCRIPTION
Some of our typing annotations use features from 3.9 - that version is now almost 3 years old which should be enough for an in-tree test suite.

Fixes #1067

---

quickfix, we can probably clean up a few things after this but that'll have to wait until I'm back.