### PR TITLE
open-uri: Pass activation token to the FileManager1 interface

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -1074,7 +1074,7 @@ handle_open_directory (XdpDbusOpenURI *object,
     g_object_set_data_full (G_OBJECT (request), "activation-token", g_strdup (activation_token), g_free);
 
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
-  xdp_dbus_open_uri_complete_open_file (object, invocation, NULL, request->id);
+  xdp_dbus_open_uri_complete_open_directory (object, invocation, NULL, request->id);
 
   task = g_task_new (object, NULL, NULL, NULL);
   g_task_set_task_data (task, g_object_ref (request), g_object_unref);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -741,7 +741,7 @@ handle_open_in_thread_func (GTask *task,
                                                   FILE_MANAGER_DBUS_PATH,
                                                   FILE_MANAGER_DBUS_IFACE,
                                                   FILE_MANAGER_SHOW_ITEMS,
-                                                  g_variant_new ("(ass)", uris_builder, ""),
+                                                  g_variant_new ("(ass)", uris_builder, activation_token),
                                                   NULL,   /* ignore returned type */
                                                   G_DBUS_CALL_FLAGS_NONE,
                                                   -1,


### PR DESCRIPTION
Fixes #876

I've also notices a typo in handle_open_directory, apparently because it was copied from handle_open_file...