### PR TITLE
Allow building man pages without docbook

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -36,31 +36,30 @@ if build_docbook
         install_dir: docs_dir,
       )
   endforeach
+endif
 
-  rst2man = find_program('rst2man', 'rst2man.py', required: false)
-  if rst2man.found()
-    rst2man_flags = [
-      '--syntax-highlight=none',
-    ]
-    
-    man_pages = [
-      { 'input': 'portals-conf.rst', 'output': 'portals.conf', 'section': '5' },
-    ]
+if rst2man.found()
+  rst2man_flags = [
+    '--syntax-highlight=none',
+  ]
+  
+  man_pages = [
+    { 'input': 'portals-conf.rst', 'output': 'portals.conf', 'section': '5' },
+  ]
 
-    foreach man_page: man_pages
-      man_input = man_page.get('input')
-      man_output = man_page.get('output', man_input)
-      man_section = man_page.get('section', '1')
-      man_full = '@0@.@1@'.format(man_output, man_section)
+  foreach man_page: man_pages
+    man_input = man_page.get('input')
+    man_output = man_page.get('output', man_input)
+    man_section = man_page.get('section', '1')
+    man_full = '@0@.@1@'.format(man_output, man_section)
 
-      custom_target('man-' + man_output,
-        input: man_input,
-        output: man_full,
-        command: [ rst2man, rst2man_flags, '@INPUT@' ],
-        capture: true,
-        install: true,
-        install_dir: get_option('mandir') / 'man@0@'.format(man_section),
-      )
-    endforeach
-  endif
+    custom_target('man-' + man_output,
+      input: man_input,
+      output: man_full,
+      command: [ rst2man, rst2man_flags, '@INPUT@' ],
+      capture: true,
+      install: true,
+      install_dir: get_option('mandir') / 'man@0@'.format(man_section),
+    )
+  endforeach
 endif

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,8 @@ if xmlto.found()
     endif
 endif
 
+rst2man = find_program('rst2man', 'rst2man.py', required: get_option('man-pages'))
+
 enable_installed_tests = get_option('installed-tests')
 
 ###### systemd units, dbus service files, pkgconfig
@@ -187,6 +189,7 @@ summary({
     'Enable libportal support': have_libportal,
     'Enable installed tests:': enable_installed_tests,
     'Enable python test suite': enable_pytest,
+    'Build man pages': rst2man.found(),
   },
   section: 'Optional builds',
   bool_yn: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -42,3 +42,7 @@ option('pytest',
         type: 'feature',
         value: 'auto',
         description: 'Enable the pytest-based test suite')
+option('man-pages',
+       type: 'feature',
+       value: 'auto',
+       description: 'Build man pages (requires rst2man)')


### PR DESCRIPTION
Downstream distributions will want to build and package man pages, but generally won't need to build the docbook themselves.