### PR TITLE
Add mapping_id to streams

### DIFF
--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -23,7 +23,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes version 5 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.ScreenCast">
     <!--
@@ -235,6 +235,19 @@
               The type of the content which is being screen casted.
               For available source types, see the AvailableSourceTypes property.
               This property was added in version 3 of this interface.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>mapping_id s</term>
+            <listitem><para>
+              An optional identifier used to map different aspects of the
+              resource this stream corresponds to.
+            </para><para>
+              When used in a remote desktop session, the mapping_id can be used to
+              match a libei region of absolute libei devices. There may be
+              multiple absolute libei devices, and each device may have multiple
+              regions, but a mapping_id will only match one of these regions per
+              device. This property was added in version 5 of this interface.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -462,6 +462,10 @@
         the EIS connection. Any events submitted via NotifyPointerMotion,
         NotifyKeyboardKeycode and other Notify* methods will return an error.
 
+        To see how to pair a PipeWire stream with a libei device region, see the
+        documentation for the mapping_id stream property in
+        #org.freedesktop.portal.RemoteDesktop.Start().
+
         This method was added in version 2 of this interface.
     -->
     <method name="ConnectToEIS">

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -23,7 +23,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes version 5 of this interface.
   -->
   <interface name="org.freedesktop.portal.ScreenCast">
     <!--
@@ -263,6 +263,19 @@
               The type of the content which is being screen casted.
               For available source types, see the AvailableSourceTypes property.
               This property was added in version 3 of this interface.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>mapping_id s</term>
+            <listitem><para>
+              An optional identifier used to map different aspects of the
+              resource this stream corresponds to.
+            </para><para>
+              When used in a remote desktop session, the mapping_id can be used to
+              match a libei region of absolute libei devices. There may be
+              multiple absolute libei devices, and each device may have multiple
+              regions, but a mapping_id will only match one of these regions per
+              device. This property was added in version 5 of this interface.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -1067,7 +1067,7 @@ on_supported_cursor_modes_changed (GObject *gobject,
 static void
 screen_cast_init (ScreenCast *screen_cast)
 {
-  xdp_dbus_screen_cast_set_version (XDP_DBUS_SCREEN_CAST (screen_cast), 4);
+  xdp_dbus_screen_cast_set_version (XDP_DBUS_SCREEN_CAST (screen_cast), 5);
 
   g_signal_connect (impl, "notify::supported-source-types",
                     G_CALLBACK (on_supported_source_types_changed),


### PR DESCRIPTION
From the commit that introduces it:

This uuid is intended to be used for matching a PipeWire stream with a
libei region, so that one e.g. can emit absolute pointer events using
libei on a window screen cast. This was not possible before, since there
was no way to match a region with a stream. This also makes it easier to
pair streams and libei regions in general, as one doesn't need to look
at any sizes or positions.

See https://gitlab.freedesktop.org/libinput/libei/-/merge_requests/246.

Cc: @whot
