### PR TITLE
docs: Clarify InputCapture.Enable options

### DIFF
--- a/data/org.freedesktop.portal.InputCapture.xml
+++ b/data/org.freedesktop.portal.InputCapture.xml
@@ -296,18 +296,6 @@
         merely enables the capturing to be triggered at some future point
         (e.g. by the cursor moving across a barrier). If and when that happens,
         the #org.freedesktop.portal.InputCapture::Activated signal is emitted.
-
-        Supported keys in the @options vardict include:
-        <variablelist>
-          <varlistentry>
-            <term>handle_token s</term>
-            <listitem><para>
-              A string that will be used as the last element of the @handle. Must be a valid
-              object path element. See the #org.freedesktop.portal.Request documentation for
-              more information about the @handle.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
     -->
     <method name="Enable">
       <arg type="o" name="session_handle" direction="in"/>


### PR DESCRIPTION
Currently the documentation mentions the need of passing a handle token but it is not used as the method itself doesn't return an object path.

The Disable/Release methods don't take such option, so I assumed it is a copy/paste failure

cc @whot 