### PR TITLE
docs: Clarify PrepareInstall response

### DIFF
--- a/data/org.freedesktop.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.portal.DynamicLauncher.xml
@@ -153,7 +153,13 @@
           <varlistentry>
             <term>name s</term>
             <listitem><para>
-              The name chosen by the user for the launcher.
+              The name chosen by the user for the launcher or the predefined one.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>icon v</term>
+            <listitem><para>
+              The icon chosen by the user for the launcher or the predefined one.
             </para></listitem>
           </varlistentry>
           <varlistentry>


### PR DESCRIPTION
It was missing the icon field + mentioning it would always return a value even if the used doesn't set the editable icon / editable name options