### PR TITLE
xdg-utils: Properly quote flatpak command

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -397,8 +397,10 @@ xdp_app_info_rewrite_commandline (XdpAppInfo *app_info,
           for (i = 1; commandline[i]; i++)
             g_ptr_array_add (args, maybe_quote (commandline[i], quote_escape));
         }
-      else
+      else if (quote_escape)
         g_ptr_array_add (args, g_shell_quote (app_info->id));
+      else
+        g_ptr_array_add (args, g_strdup (app_info->id));
       g_ptr_array_add (args, NULL);
 
       return (char **)g_ptr_array_free (g_steal_pointer (&args), FALSE);


### PR DESCRIPTION
`xdp_app_info_rewrite_commandline` has to respect `quote_escape` also when no commandline is given.