### PR TITLE
Draft background: Add ability to specify timers to start app

### DIFF
--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -103,6 +103,30 @@
     </method>
 
     <!--
+      EnableTimer:
+      @app_id: App id of the application
+      @timer: List of times the app should be started
+      @commandline: The commandline to used to start the app at the specificied time
+      @flags: Flags influencing the details of the timer
+      @result: TRUE if timer was enabled, FALSE otherwise
+
+      Enables or disables autostart for an application.
+
+      The following flags are understood:
+      <simplelist>
+        <member>1: Wake system from suspend</member>
+        <member>2: Use D-Bus activation</member>
+      </simplelist>
+    -->
+    <method name='EnableTimer'>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="as" name="timer" direction="in"/>
+      <arg type="as" name="commandline" direction="in"/>
+      <arg type="u" name="flags" direction="in"/>
+      <arg type="b" name="result" direction="out"/>
+    </method>
+
+    <!--
       RunningApplicationsChanged:
 
       This signal gets emitted when applications change their state

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -66,7 +66,8 @@
           <varlistentry>
             <term>commandline as</term>
             <listitem><para>
-              Commandline to use add when autostarting at login.
+              Commandline to use add when autostarting at login
+              or when starting the app with a timer
               If this is not specified, the Exec line from the
               desktop file will be used.
             </para></listitem>
@@ -74,7 +75,19 @@
           <varlistentry>
             <term>dbus-activatable b</term>
             <listitem><para>
-              If TRUE, use D-Bus activation for autostart.
+              If TRUE, use D-Bus activation for autostart and timer start.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>timer as</term>
+            <listitem><para>
+              List of times the APP should be started
+            </para></listitem>
+          </varlistentry>
+	  <varlistentry>
+            <term>wake-system b</term>
+            <listitem><para>
+              If TRUE, the system is woken form susped to start the app
             </para></listitem>
           </varlistentry>
         </variablelist>
@@ -93,6 +106,12 @@
           <term>autostart b</term>
           <listitem><para>
             TRUE if the application is will be autostarted.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>timer b</term>
+          <listitem><para>
+            TRUE if the application will be started at the specificed times.
           </para></listitem>
         </varlistentry>
       </variablelist>

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -397,8 +397,11 @@ xdp_app_info_rewrite_commandline (XdpAppInfo *app_info,
           for (i = 1; commandline[i]; i++)
             g_ptr_array_add (args, maybe_quote (commandline[i], quote_escape));
         }
-      else
+      else if (quote_escape) {
         g_ptr_array_add (args, g_shell_quote (app_info->id));
+      } else {
+        g_ptr_array_add (args, g_strdup (app_info->id));
+      }
       g_ptr_array_add (args, NULL);
 
       return (char **)g_ptr_array_free (g_steal_pointer (&args), FALSE);


### PR DESCRIPTION
This is more a proof of concept therefore it's marked as draft.

Since autostart on system start and autostarting an app in ad a specific time are closely related it makes sense for me to not introduce a new portal but add an additional feature to the `Background` portal. 

I implemented the timer backend in `xdg-dekstop-portal-gnome` using systemd user timers. (https://gitlab.gnome.org/jsparber/xdg-desktop-portal-gnome/-/commits/add_timer_background)

And in gnome clocks https://gitlab.gnome.org/jsparber/gnome-clocks/-/commits/use_background_portal