### PR TITLE
meson.build: allow linux to build without flatpak installed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,8 +112,19 @@ libportal_dep = dependency('libportal',
 pipewire_dep = dependency('libpipewire-0.3', version: '>= 0.2.90')
 libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))
 
-bwrap_required = host_machine.system() in ['linux']
-bwrap = find_program('bwrap', required: bwrap_required)
+
+use_bwrap = get_option('sandboxed-image-validation')
+bwrap = find_program('bwrap', required: use_bwrap)
+
+if not use_bwrap
+  warning('''
+    Sandboxed image validation with Bubblewrap is DISABLED.
+    If your system can run Bubblewrap, it's **hightly** recommended that you enable this
+    option. Bitmap validation and processing is a common attack vector.
+    By proceeding with sandboxed image validation disabled, you acknowledge that you
+    are lowering your system's security, and are subject to known or unknown exploits.
+    ''')
+endif
 
 have_libportal = libportal_dep.found()
 if have_libportal
@@ -190,6 +201,7 @@ summary({
     'Enable python test suite': enable_pytest,
     'Build man pages': rst2man.found(),
     'Build flatpak interfaces': flatpak_dep.found(),
+    'Sandboxed image validation': use_bwrap,
   },
   section: 'Optional builds',
   bool_yn: true,

--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,7 @@ endif
 
 flatpak_intf_dir = get_option('flatpak-interfaces-dir')
 if flatpak_intf_dir == ''
-    flatpak_required = host_machine.system() in ['linux']
-    flatpak_dep = dependency('flatpak', version: '>= 1.5.0', required : flatpak_required)
+    flatpak_dep = dependency('flatpak', version: '>= 1.5.0', required: get_option('flatpak-interfaces'))
     if flatpak_dep.found()
       flatpak_intf_dir = flatpak_dep.get_variable(pkgconfig: 'interfaces_dir')
     endif
@@ -190,6 +189,7 @@ summary({
     'Enable installed tests:': enable_installed_tests,
     'Enable python test suite': enable_pytest,
     'Build man pages': rst2man.found(),
+    'Build flatpak interfaces': flatpak_dep.found(),
   },
   section: 'Optional builds',
   bool_yn: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,10 @@ option('dbus-service-dir',
        type: 'string',
        value: '',
        description: 'directory for dbus service files (default: PREFIX/share/dbus-1/services)')
+option('flatpak-interfaces',
+       type: 'feature',
+       value: 'auto',
+       description: 'Build flatpak interfaces')
 option('flatpak-interfaces-dir',
        type: 'string',
        value: '',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -50,3 +50,7 @@ option('man-pages',
        type: 'feature',
        value: 'auto',
        description: 'Build man pages (requires rst2man)')
+option('sandboxed-image-validation',
+       type: 'boolean',
+       value: true,
+       description: 'Use Bubblewrap to sandbox image validation. Disabling this option may lead to security vulnerabilities.')


### PR DESCRIPTION
the old automake scripts would allow for building without flatpak, as the xml file would just not be copied (because it doesn't exist) so it wouldn't be used to generate files.

this allows similar behaviour by not requiring the flatpak dependency in meson.

fix for #1099