### PR TITLE
Add fallback configuration for what to do if no portal is found via UseIn

### DIFF
--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -541,6 +541,14 @@ portal_impl_matches_config (const PortalConfig *config,
   return FALSE;
 }
 
+static void
+warn_please_use_portals_conf (void)
+{
+  g_warning_once ("The preferred method to match portal implementations "
+                  "to desktop environments is to use the portals.conf(5) "
+                  "configuration file");
+}
+
 PortalImplementation *
 find_portal_implementation (const char *interface)
 {
@@ -578,10 +586,7 @@ find_portal_implementation (const char *interface)
             {
               g_warning ("Choosing %s.portal for %s via the deprecated UseIn key",
                          impl->source, interface);
-              g_warning_once ("The preferred method to match portal implementations "
-                              "to desktop environments is to use the portals.conf(5) "
-                              "configuration file");
-
+              warn_please_use_portals_conf ();
               g_debug ("Using %s.portal for %s in %s (fallback)", impl->source, interface, desktops[i]);
               return impl;
             }

--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -160,7 +160,7 @@ get_current_lowercase_desktops (void)
 }
 /* }}} */
 
-static PortalConfig *config = NULL;
+static PortalConfig *global_config = NULL;
 static GList *implementations = NULL;
 
 static gboolean
@@ -400,7 +400,7 @@ load_config_directory (const char *dir,
             g_debug ("Using portal configuration file '%s/%s' for desktop '%s'",
                      dir, portals_conf, desktops[i]);
 
-          config = g_steal_pointer (&conf);
+          global_config = g_steal_pointer (&conf);
           return TRUE;
         }
     }
@@ -413,7 +413,7 @@ load_config_directory (const char *dir,
         g_debug ("Using portal configuration file '%s/%s' for non-specific desktop",
                  dir, "portals.conf");
 
-      config = g_steal_pointer (&conf);
+      global_config = g_steal_pointer (&conf);
       return TRUE;
     }
 
@@ -517,7 +517,8 @@ portal_impl_name_matches (const PortalImplementation *impl,
 }
 
 static gboolean
-portal_impl_matches_config (const PortalImplementation *impl,
+portal_impl_matches_config (const PortalConfig *config,
+                            const PortalImplementation *impl,
                             const char                 *interface)
 {
   if (config == NULL)
@@ -554,7 +555,7 @@ find_portal_implementation (const char *interface)
       if (!g_strv_contains ((const char **)impl->interfaces, interface))
         continue;
 
-      if (portal_impl_matches_config (impl, interface))
+      if (portal_impl_matches_config (global_config, impl, interface))
         {
           g_debug ("Using %s.portal for %s (config)", impl->source, interface);
           return impl;


### PR DESCRIPTION
See #1102. This is an untested implementation of option 2 (but with a slightly different filename, `fallback.conf` might be better).