### PR TITLE
Add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: flatpak


### PR DESCRIPTION
Points to Flatpak's OpenCollective. GitHub doesn't support OpenCollective projects, but exposing the funding button is probably better than nothing.