### PR TITLE
Delete transient permissions when peer dies

### DIFF
--- a/src/restore-token.c
+++ b/src/restore-token.c
@@ -89,6 +89,29 @@ xdp_session_persistence_delete_transient_permissions (Session *session,
   g_hash_table_remove (transient_permissions, id);
 }
 
+void
+xdp_session_persistence_delete_transient_permissions_for_sender (const char *sender_name)
+{
+
+  g_autoptr(GMutexLocker) locker = NULL;
+  GHashTableIter iter;
+  const char *key;
+
+  locker = g_mutex_locker_new (&transient_permissions_lock);
+
+  if (!transient_permissions)
+    return;
+
+  g_hash_table_iter_init (&iter, transient_permissions);
+  while (g_hash_table_iter_next (&iter, (gpointer *) &key, NULL))
+    {
+      g_auto(GStrv) split = g_strsplit (key, "/", 2);
+
+      if (split && split[0] && g_strcmp0 (split[0], sender_name) == 0)
+        g_hash_table_iter_remove (&iter);
+    }
+}
+
 GVariant *
 xdp_session_persistence_get_transient_permissions (Session *session,
                                                    const char *restore_token)

--- a/src/restore-token.h
+++ b/src/restore-token.h
@@ -34,6 +34,8 @@ void xdp_session_persistence_set_transient_permissions (Session *session,
 void xdp_session_persistence_delete_transient_permissions (Session *session,
                                                            const char *restore_token);
 
+void xdp_session_persistence_delete_transient_permissions_for_sender (const char *sender_name);
+
 GVariant * xdp_session_persistence_get_transient_permissions (Session *session,
                                                               const char *restore_token);
 

--- a/src/session.c
+++ b/src/session.c
@@ -24,15 +24,6 @@
 
 enum
 {
-  INTERNAL_CLOSED,
-
-  N_SIGNALS
-};
-
-static guint signals[N_SIGNALS];
-
-enum
-{
   PROP_0,
 
   PROP_SENDER,
@@ -182,8 +173,6 @@ session_close (Session *session,
     return;
 
   SESSION_GET_CLASS (session)->close (session);
-
-  g_signal_emit (session, signals[INTERNAL_CLOSED], 0);
 
   if (notify_closed)
     {
@@ -539,11 +528,4 @@ session_class_init (SessionClass *klass)
                          G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
-
-  signals[INTERNAL_CLOSED] = g_signal_new ("internal-closed",
-                                           G_TYPE_FROM_CLASS (klass),
-                                           G_SIGNAL_RUN_LAST,
-                                           0,
-                                           NULL, NULL, NULL,
-                                           G_TYPE_NONE, 0);
 }

--- a/src/session.h
+++ b/src/session.h
@@ -45,10 +45,6 @@ struct _Session
   char *impl_dbus_name;
   GDBusConnection *impl_connection;
   XdpDbusImplSession *impl_session;
-
-  struct {
-    gboolean has_transient_permissions;
-  } persistence;
 };
 
 struct _SessionClass

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -57,6 +57,7 @@
 #include "realtime.h"
 #include "remote-desktop.h"
 #include "request.h"
+#include "restore-token.h"
 #include "screen-cast.h"
 #include "screenshot.h"
 #include "secret.h"
@@ -229,6 +230,7 @@ peer_died_cb (const char *name)
 {
   close_requests_for_sender (name);
   close_sessions_for_sender (name);
+  xdp_session_persistence_delete_transient_permissions_for_sender (name);
 }
 
 static void


### PR DESCRIPTION
Not when the session is closed. See patches.

Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1124