### PR TITLE
Setup the issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,9 @@
+---
+name: Bug Report
+about: Report a bug or crash
+title: ''
+labels: ''
+assignees: ''
+
+---
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Help/Support
+    url: https://matrix.to/#/#xdg-desktop-portals:matrix.org
+    about: Questions or issues about how to use and configure xdg-desktop-portal


### PR DESCRIPTION
A request from @GeorgesStavracas that I accepted to do.

It makes the user choose between:
- Creating an issue for a bug report
- View the security policy (since a SECURITY.md is in place)
- The XDG Desktop Portals Matrix room for help/support

Note: My fork is set with this PR branch as default, so you can check the result on it