### PR TITLE
Fix two issues with the spelling of PipeWire

### DIFF
--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -41,7 +41,7 @@
         method together with certain methods on the #org.freedesktop.portal.ScreenCast and
         #org.freedesktop.portal.Clipboard interfaces. Specifically, you can call
         org.freedesktop.portal.ScreenCast.SelectSources() to also get screen content,
-        and org.freedesktop.portal.ScreenCast.OpenPipewireRemote() to acquire a file
+        and org.freedesktop.portal.ScreenCast.OpenPipeWireRemote() to acquire a file
         descriptor for a PipeWire remote. See #org.freedesktop.portal.ScreenCast for
         more information on how to use those methods. To capture clipboard content,
         you can call org.freedesktop.portal.Clipboard.RequestClipboard(). See 

--- a/src/request.c
+++ b/src/request.c
@@ -337,7 +337,7 @@ get_token (GDBusMethodInvocation *invocation)
         {
           options = g_variant_get_child_value (parameters, 0);
         }
-      else if (strcmp (method, "OpenPipewireRemote") == 0)
+      else if (strcmp (method, "OpenPipeWireRemote") == 0)
         {
           // no request objects
         }


### PR DESCRIPTION
One is just a documentation issue, the second one *should*'ve produced warnings on every use of  `Camera.OpenPipeWireRemote` so I'm a bit worried why this hasn't shown up anywhere.