### PR TITLE
file-transfer: return a value from task

### DIFF
--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -566,6 +566,7 @@ stop_file_transfers_in_thread_func (GTask        *task,
         }
     }
   G_UNLOCK (transfers);
+  g_task_return_boolean (task, TRUE);
 }
 
 void


### PR DESCRIPTION
- This fixes "GTask finalized without ever returning (using g_task_return_*()). This potentially indicates a bug in the program." errors.