### PR TITLE
docs: Add caveat on portal config file locations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ $ meson setup . _build
 $ meson compile -C _build
 ```
 
+Some distributions install portal configuration files in `/usr`, while Meson
+defaults to the prefix `/usr/local`. If the portal configuration files in your
+distribution are in `/usr/share/xdg-desktop-portal/portals`, re-configure
+Meson using `meson setup --reconfigure . _build --prefix /usr` and compile
+again.
+
 ### Running
 
 xdg-desktop-portal needs to own the D-Bus name and replace the user session


### PR DESCRIPTION
Add a caveat on portal file locations to CONTRIBUTING.md as Meson's defaults will cause xdg-desktop-portal to look for portal files in locations that are not used by distributions like Arch and Fedora.