### PR TITLE
README: fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The portal interfaces include APIs for file access, opening URIs, printing
 and others.
 
 Documentation for the available D-Bus interfaces can be found	
-[here](https://flatpak.github.io/xdg-desktop-portal/portal-docs.html).
+[here](https://flatpak.github.io/xdg-desktop-portal/docs/).
 
 ## Version numbering
 


### PR DESCRIPTION
This pull fix the docs link inside the README.md