### PR TITLE
global-shortcuts: Convert timestamp to

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -124,7 +124,7 @@
         Activated:
         @session_handle: Session that requested the shortcut
         @shortcut_id: the application-provided ID for the notification
-        @timestamp: The timestamp, as seconds and microseconds since the Unix epoch.
+        @timestamp: the time of activation with millisecond granularity, with an undefined base.
         @options: Vardict with optional further information
 
         Emitted when a shortcut is activated.
@@ -141,7 +141,7 @@
         Deactivated:
         @session_handle: Session that requested the shortcut
         @shortcut_id: the application-provided ID for the notification
-        @timestamp: The timestamp, as seconds and microseconds since the Unix epoch.
+        @timestamp: the time of deactivation with millisecond granularity, with an undefined base.
         @options: Vardict with optional further information
 
         Emitted when a shortcut is deactivated.

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -216,7 +216,7 @@
         Activated:
         @session_handle: Session that requested the shortcut
         @shortcut_id: the application-provided ID for the notification
-        @timestamp: The timestamp, as seconds and microseconds since the Unix epoch.
+        @timestamp: the time of activation with millisecond granularity, with an undefined base.
         @options: Vardict with optional further information
 
         Notifies about a shortcut becoming active.
@@ -233,7 +233,7 @@
         Deactivated:
         @session_handle: Session that requested the shortcut
         @shortcut_id: the application-provided ID for the notification
-        @timestamp: The timestamp, as seconds and microseconds since the Unix epoch.
+        @timestamp: the time of deactivation with millisecond granularity, with an undefined base.
         @options: Vardict with optional further information
 
         Notifies that a shortcut is not active anymore.


### PR DESCRIPTION
On X11 and wayland timestamps are using the monotonic clock for input events, global shortcuts tie in closely with this. This patch brings it in line using the same wording as wayland events.

This is technically a breakage in the spec, but pragmatically brings it in line with the current real world implementations.

Fixes #1054