### PR TITLE
utils: Handle host apps in app_info_map_pids

### DIFF
--- a/src/realtime.c
+++ b/src/realtime.c
@@ -56,23 +56,21 @@ G_DEFINE_TYPE_WITH_CODE (Realtime, realtime, XDP_DBUS_TYPE_REALTIME_SKELETON,
                                                 realtime_iface_init));
 
 static gboolean
-map_pid_if_needed (XdpAppInfo *app_info, pid_t *pid, pid_t *tid, GError **error)
+map_pid (XdpAppInfo *app_info, pid_t *pid, pid_t *tid, GError **error)
 {
-  if (!xdp_app_info_is_host (app_info))
-  {
-    if (!xdp_app_info_map_pids (app_info, pid, 1, error))
+  if (!xdp_app_info_map_pids (app_info, pid, 1, error))
     {
       g_prefix_error (error, "Could not map pid: ");
       g_warning ("Realtime error: %s", (*error)->message);
       return FALSE;
     }
-    if (!xdp_app_info_map_tids (app_info, *pid, tid, 1, error))
+
+  if (!xdp_app_info_map_tids (app_info, *pid, tid, 1, error))
     {
       g_prefix_error (error, "Could not map tid: ");
       g_warning ("Realtime error: %s", (*error)->message);
       return FALSE;
     }
-  }
 
   return TRUE;
 }
@@ -129,7 +127,7 @@ handle_make_thread_realtime_with_pid (XdpDbusRealtime       *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  if (!map_pid_if_needed (request->app_info, pids, tids, &error))
+  if (!map_pid (request->app_info, pids, tids, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
@@ -180,7 +178,7 @@ handle_make_thread_high_priority_with_pid (XdpDbusRealtime       *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  if (!map_pid_if_needed (request->app_info, pids, tids, &error))
+  if (!map_pid (request->app_info, pids, tids, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2167,6 +2167,9 @@ app_info_map_pids (XdpAppInfo  *app_info,
   g_return_val_if_fail (app_info != NULL, FALSE);
   g_return_val_if_fail (pids != NULL, FALSE);
 
+  if (app_info->kind == XDP_APP_INFO_KIND_HOST)
+    return TRUE;
+
   if (app_info->kind != XDP_APP_INFO_KIND_FLATPAK)
     {
       g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,


### PR DESCRIPTION
Mapping pids/tids is only necessary when apps are running inside another pid namespace. Apps on the host usually do not. If they put parts of themselves into one, it's their responsibility to do the mapping.

Instead of having to make sure that the app is not a host app before calling this function, handle host apps trivially by not mapping anything and returning success.

---

This change should only affect the gamemode portal when called from a host app.