### PR TITLE
Automate method_needs_request() and token lookup

### DIFF
--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -1,6 +1,4 @@
-<!DOCTYPE node PUBLIC
-"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<?xml version="1.0"?>
 
 <!--
  Copyright (C) 2015 Red Hat, Inc.

--- a/src/generate-method-info.py
+++ b/src/generate-method-info.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+from typing import Callable
+
+import argparse
+import xml.etree.ElementTree as ElementTree
+
+
+def quote(s: str):
+    return f'"{s}"'
+
+
+def cbool(b: bool):
+    return "TRUE" if b else "FALSE"
+
+
+def handle_interface(interface: ElementTree.Element):
+    intf_name = interface.attrib["name"]
+    for method in interface.iter("method"):
+        method_name = method.attrib["name"]
+        uses_requests = False
+        option_arg = -1
+
+        for pos, arg in enumerate(method.iter("arg")):
+            arg_name = arg.attrib["name"]
+            arg_type = arg.attrib["type"]
+            arg_direction = arg.attrib.get("direction", "in")
+            if (
+                (arg_name == "handle" or arg_name == "request_handle")
+                and arg_type == "o"
+                and arg_direction == "out"
+            ):
+                uses_requests = True
+
+            if arg_name == "options" and arg_type == "a{sv}" and arg_direction == "in":
+                option_arg = pos
+
+        method_name = quote(method_name)
+        iname = quote(intf_name)
+        print(
+            f"  {{ .interface = {iname:40s}, .method = {method_name:32s}, .uses_request = {cbool(uses_requests)}, .option_arg = {option_arg:2d}, }},"
+        )
+
+
+def parse_portal_xml(filename: str):
+    tree = ElementTree.parse(filename)
+    root = tree.getroot()
+
+    for interface in root.iter("interface"):
+        handle_interface(interface)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", type=str, nargs="+")
+
+    args = parser.parse_args()
+
+    print('#include "glib.h"')
+    print('#include "xdp-method-info.h"')
+    print("")
+    print("static const XdpMethodInfo method_info[] = {")
+
+    for file in args.file:
+        parse_portal_xml(file)
+
+    print("  { .interface = NULL },")
+    print("};")
+    print("")
+    print(
+        "const XdpMethodInfo *xdp_method_info_get_all (void) { return method_info; };"
+    )
+    print("")
+    print(
+        "unsigned int xdp_method_info_get_count (void) { return G_N_ELEMENTS(method_info) - 1; };"
+    )

--- a/src/memory-monitor.c
+++ b/src/memory-monitor.c
@@ -25,7 +25,6 @@
 #include <gio/gio.h>
 
 #include "memory-monitor.h"
-#include "request.h"
 #include "xdp-dbus.h"
 #include "xdp-utils.h"
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,6 +45,14 @@ built_resources = gnome.compile_resources(
 
 sd_escape_sources = files('sd-escape.c')
 
+xdp_method_info_built_sources = configure_file(
+  command: [find_program('generate-method-info.py'), portal_sources],
+  capture: true,
+  output: 'xdp-method-info-generated.c',
+)
+
+xdp_method_info_sources = files('xdp-method-info.c') + xdp_method_info_built_sources
+
 xdp_utils_includes = include_directories('.')
 xdp_utils_sources = files('xdp-utils.c')
 
@@ -92,6 +100,7 @@ xdg_desktop_portal_sources = files(
 
 xdg_desktop_portal_sources += [
   xdp_utils_sources,
+  xdp_method_info_sources,
   portal_built_sources,
   impl_built_sources,
   background_monitor_sources,

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,6 +45,9 @@ built_resources = gnome.compile_resources(
 
 sd_escape_sources = files('sd-escape.c')
 
+xdp_utils_includes = include_directories('.')
+xdp_utils_sources = files('xdp-utils.c')
+
 xdg_desktop_portal_sources = files(
   'account.c',
   'background.c',
@@ -85,10 +88,10 @@ xdg_desktop_portal_sources = files(
   'trash.c',
   'wallpaper.c',
   'xdg-desktop-portal.c',
-  'xdp-utils.c',
 )
 
 xdg_desktop_portal_sources += [
+  xdp_utils_sources,
   portal_built_sources,
   impl_built_sources,
   background_monitor_sources,
@@ -133,9 +136,6 @@ xdg_desktop_portal = executable(
   install: true,
   install_dir: libexecdir,
 )
-
-xdp_utils_includes = include_directories('.')
-xdp_utils_sources = files('xdp-utils.c')
 
 configure_file(
   input: 'xdg-desktop-portal.service.in',

--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -24,7 +24,7 @@
 #include <gio/gio.h>
 
 #include "network-monitor.h"
-#include "request.h"
+#include "call.h"
 #include "xdp-dbus.h"
 #include "xdp-utils.h"
 
@@ -57,9 +57,9 @@ static gboolean
 handle_get_available (XdpDbusNetworkMonitor *object,
                       GDBusMethodInvocation *invocation)
 {
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
 
-  if (!xdp_app_info_has_network (request->app_info))
+  if (!xdp_app_info_has_network (call->app_info))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR,
@@ -81,9 +81,9 @@ static gboolean
 handle_get_metered (XdpDbusNetworkMonitor *object,
                     GDBusMethodInvocation *invocation)
 {
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
 
-  if (!xdp_app_info_has_network (request->app_info))
+  if (!xdp_app_info_has_network (call->app_info))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR,
@@ -105,9 +105,9 @@ static gboolean
 handle_get_connectivity (XdpDbusNetworkMonitor *object,
                          GDBusMethodInvocation *invocation)
 {
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
 
-  if (!xdp_app_info_has_network (request->app_info))
+  if (!xdp_app_info_has_network (call->app_info))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR,
@@ -129,9 +129,9 @@ static gboolean
 handle_get_status (XdpDbusNetworkMonitor *object,
                    GDBusMethodInvocation *invocation)
 {
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
 
-  if (!xdp_app_info_has_network (request->app_info))
+  if (!xdp_app_info_has_network (call->app_info))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR,
@@ -181,9 +181,9 @@ handle_can_reach (XdpDbusNetworkMonitor *object,
                   const char            *hostname,
                   guint                  port)
 {
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
 
-  if (!xdp_app_info_has_network (request->app_info))
+  if (!xdp_app_info_has_network (call->app_info))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR,

--- a/src/proxy-resolver.c
+++ b/src/proxy-resolver.c
@@ -24,7 +24,7 @@
 #include <gio/gio.h>
 
 #include "proxy-resolver.h"
-#include "request.h"
+#include "call.h"
 #include "xdp-dbus.h"
 #include "xdp-utils.h"
 
@@ -59,9 +59,9 @@ proxy_resolver_handle_lookup (XdpDbusProxyResolver *object,
                               const char *arg_uri)
 {
   ProxyResolver *resolver = (ProxyResolver *)object;
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
 
-  if (!xdp_app_info_has_network (request->app_info))
+  if (!xdp_app_info_has_network (call->app_info))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR,

--- a/src/realtime.c
+++ b/src/realtime.c
@@ -24,7 +24,7 @@
 #include <gio/gio.h>
 
 #include "realtime.h"
-#include "request.h"
+#include "call.h"
 #include "permissions.h"
 #include "xdp-dbus.h"
 #include "xdp-utils.h"
@@ -102,10 +102,10 @@ handle_make_thread_realtime_with_pid (XdpDbusRealtime       *object,
                                       guint32                priority)
 {
   g_autoptr (GError) error = NULL;
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
   pid_t pids[1] = { process };
   pid_t tids[1] = { thread };
-  const char *app_id = xdp_app_info_get_id (request->app_info);
+  const char *app_id = xdp_app_info_get_id (call->app_info);
   Permission permission;
 
   if (!realtime->rtkit_proxy)
@@ -127,7 +127,7 @@ handle_make_thread_realtime_with_pid (XdpDbusRealtime       *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  if (!map_pid (request->app_info, pids, tids, &error))
+  if (!map_pid (call->app_info, pids, tids, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
@@ -153,10 +153,10 @@ handle_make_thread_high_priority_with_pid (XdpDbusRealtime       *object,
                                            gint32                 priority)
 {
   g_autoptr (GError) error = NULL;
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
   pid_t pids[1] = { process };
   pid_t tids[1] = { thread };
-  const char *app_id = xdp_app_info_get_id (request->app_info);
+  const char *app_id = xdp_app_info_get_id (call->app_info);
   Permission permission;
 
   if (!realtime->rtkit_proxy)
@@ -178,7 +178,7 @@ handle_make_thread_high_priority_with_pid (XdpDbusRealtime       *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  if (!map_pid (request->app_info, pids, tids, &error))
+  if (!map_pid (call->app_info, pids, tids, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;

--- a/src/request.c
+++ b/src/request.c
@@ -21,6 +21,7 @@
 
 #include "request.h"
 #include "xdp-utils.h"
+#include "xdp-method-info.h"
 
 #include <string.h>
 
@@ -174,206 +175,22 @@ get_token (GDBusMethodInvocation *invocation)
   GVariant *parameters;
   g_autoptr(GVariant) options = NULL;
   const char *token = NULL;
+  const XdpMethodInfo *method_info;
 
   interface = g_dbus_method_invocation_get_interface_name (invocation);
   method = g_dbus_method_invocation_get_method_name (invocation);
   parameters = g_dbus_method_invocation_get_parameters (invocation);
 
-  if (strcmp (interface, "org.freedesktop.portal.Account") == 0)
+  method_info = xdp_method_info_find (interface, method);
+  if (method_info)
     {
-      options = g_variant_get_child_value (parameters, 1);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Device") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 2);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Email") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 1);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.FileChooser") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 2);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Inhibit") == 0)
-    {
-      if (strcmp (method, "Inhibit") == 0)
-        options = g_variant_get_child_value (parameters, 2);
-      else if (strcmp (method, "CreateMonitor") == 0)
-        options = g_variant_get_child_value (parameters, 1);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.InputCapture") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 1);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.NetworkMonitor") == 0)
-    {
-      // no methods
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Notification") == 0)
-    {
-      // no request objects
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.OpenURI") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 2);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Print") == 0)
-    {
-      if (strcmp (method, "Print") == 0)
-        options = g_variant_get_child_value (parameters, 3);
-      else if (strcmp (method, "PreparePrint") == 0)
-        options = g_variant_get_child_value (parameters, 4);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.ProxyResolver") == 0)
-    {
-      // no request objects
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Screenshot") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 1);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.ScreenCast") == 0)
-    {
-      if (strcmp (method, "CreateSession") == 0 )
-        {
-          options = g_variant_get_child_value (parameters, 0);
-        }
-      else if (strcmp (method, "SelectSources") == 0)
-        {
-          options = g_variant_get_child_value (parameters, 1);
-        }
-      else if (strcmp (method, "Start") == 0)
-        {
-          options = g_variant_get_child_value (parameters, 2);
-        }
-      else
-        {
-          g_warning ("Support for %s::%s missing in %s",
-                     interface, method, G_STRLOC);
-        }
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.RemoteDesktop") == 0)
-    {
-      if (strcmp (method, "CreateSession") == 0 )
-        {
-          options = g_variant_get_child_value (parameters, 0);
-        }
-      else if (strcmp (method, "SelectDevices") == 0)
-        {
-          options = g_variant_get_child_value (parameters, 1);
-        }
-      else if (strcmp (method, "Start") == 0)
-        {
-          options = g_variant_get_child_value (parameters, 2);
-        }
-      else
-        {
-          g_warning ("Support for %s::%s missing in %s",
-                     interface, method, G_STRLOC);
-        }
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Clipboard") == 0)
-    {
-      // no request objects
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Location") == 0)
-    {
-      if (strcmp (method, "CreateSession") == 0 )
-        {
-          options = g_variant_get_child_value (parameters, 0);
-        }
-      else if (strcmp (method, "SelectDetails") == 0)
-        {
-          options = g_variant_get_child_value (parameters, 1);
-        }
-      else if (strcmp (method, "Start") == 0)
-        {
-          options = g_variant_get_child_value (parameters, 2);
-        }
-      else
-        {
-          g_warning ("Support for %s::%s missing in %s",
-                     interface, method, G_STRLOC);
-        }
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Settings") == 0)
-    {
-      // no request objects
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.GameMode") == 0)
-    {
-      // no request objects
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Realtime") == 0)
-    {
-      // no request objects
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Trash") == 0)
-    {
-      // no request objects
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Background") == 0)
-    {
-        if (strcmp (method, "RequestBackground") == 0 )
-          {
-            options = g_variant_get_child_value (parameters, 1);
-          }
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.DynamicLauncher") == 0)
-    {
-        if (strcmp (method, "PrepareInstall") == 0 )
-          {
-            options = g_variant_get_child_value (parameters, 3);
-          }
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Wallpaper") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 2);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Camera") == 0)
-    {
-      if (strcmp (method, "AccessCamera") == 0 )
-        {
-          options = g_variant_get_child_value (parameters, 0);
-        }
-      else if (strcmp (method, "OpenPipeWireRemote") == 0)
-        {
-          // no request objects
-        }
-      else
-        {
-          g_warning ("Support for %s::%s missing in %s",
-                     interface, method, G_STRLOC);
-        }
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Secret") == 0)
-    {
-      options = g_variant_get_child_value (parameters, 1);
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.GlobalShortcuts") == 0)
-    {
-      if (strcmp (method, "CreateSession") == 0 )
-        {
-          options = g_variant_get_child_value (parameters, 0);
-        }
-      else if (strcmp (method, "BindShortcuts") == 0 )
-        {
-          options = g_variant_get_child_value (parameters, 3);
-        }
-      else if (strcmp (method, "ListShortcuts") == 0 )
-        {
-          options = g_variant_get_child_value (parameters, 1);
-        }
-      else
-        {
-          g_warning ("Support for %s::%s missing in %s",
-                     interface, method, G_STRLOC);
-        }
+      if (method_info->option_arg >= 0)
+        options = g_variant_get_child_value (parameters, method_info->option_arg);
     }
   else
     {
-      g_print ("Support for %s missing in " G_STRLOC, interface);
+      g_warning ("Support for %s::%s missing in %s",
+                 interface, method, G_STRLOC);
     }
 
   if (options)

--- a/src/sd-escape.c
+++ b/src/sd-escape.c
@@ -296,7 +296,7 @@ gssize cunescape_length_with_prefix(const char *s, gsize length, const char *pre
         else
           pl = strlen(prefix);
 
-        ans = g_new(char, pl+length+1);
+        ans = g_new (char, pl+length+1);
         if (!ans)
                 return -ENOMEM;
 

--- a/src/trash.c
+++ b/src/trash.c
@@ -33,7 +33,7 @@
 #include <gio/gunixfdlist.h>
 
 #include "trash.h"
-#include "request.h"
+#include "call.h"
 #include "documents.h"
 #include "xdp-dbus.h"
 #include "xdp-impl-dbus.h"
@@ -101,18 +101,16 @@ handle_trash_file (XdpDbusTrash *object,
                    GUnixFDList *fd_list,
                    GVariant *arg_fd)
 {
-  Request *request = request_from_invocation (invocation);
+  Call *call = call_from_invocation (invocation);
   int idx, fd;
   guint result;
 
   g_debug ("Handling TrashFile");
 
-  REQUEST_AUTOLOCK (request);
-
   g_variant_get (arg_fd, "h", &idx);
   fd = g_unix_fd_list_get (fd_list, idx, NULL);
 
-  result = trash_file (request->app_info, request->sender, fd);
+  result = trash_file (call->app_info, call->sender, fd);
 
   xdp_dbus_trash_complete_trash_file (object, invocation, NULL, result);
 

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -153,6 +153,13 @@ method_needs_request (GDBusMethodInvocation *invocation)
       else
         return TRUE;
     }
+  else if (strcmp (interface, "org.freedesktop.portal.Inhibit") == 0)
+    {
+      if (strcmp (method, "QueryEndResponse") == 0)
+        return FALSE;
+      else
+        return TRUE;
+    }
   else if (strcmp (interface, "org.freedesktop.portal.InputCapture") == 0)
     {
       if (strcmp (method, "ConnectToEIS") == 0 ||
@@ -162,6 +169,18 @@ method_needs_request (GDBusMethodInvocation *invocation)
         return FALSE;
       else
         return TRUE;
+    }
+  else if (strcmp (interface, "org.freedesktop.portal.Trash") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.Documents") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.FileTransfer") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.GameMode") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.MemoryMonitor") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.NetworkMonitor") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.ProxyResolver") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.Realtime") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.Settings") == 0)
+    {
+      return FALSE;
     }
   else
     {

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -30,6 +30,8 @@
 #include "xdp-utils.h"
 #include "xdp-dbus.h"
 #include "xdp-impl-dbus.h"
+#include "xdp-method-info.h"
+
 #include "account.h"
 #include "background.h"
 #include "call.h"
@@ -110,83 +112,18 @@ method_needs_request (GDBusMethodInvocation *invocation)
 {
   const char *interface;
   const char *method;
+  const XdpMethodInfo *method_info;
 
   interface = g_dbus_method_invocation_get_interface_name (invocation);
   method = g_dbus_method_invocation_get_method_name (invocation);
 
-  if (strcmp (interface, "org.freedesktop.portal.ScreenCast") == 0)
-    {
-      if (strcmp (method, "OpenPipeWireRemote") == 0)
-        return FALSE;
-      else
-        return TRUE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.RemoteDesktop") == 0)
-    {
-      if (strstr (method, "Notify") == method || strcmp (method, "ConnectToEIS") == 0)
-        return FALSE;
-      else
-        return TRUE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Clipboard") == 0)
-    {
-      return FALSE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Camera") == 0)
-    {
-      if (strcmp (method, "OpenPipeWireRemote") == 0)
-        return FALSE;
-      else
-        return TRUE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.DynamicLauncher") == 0)
-    {
-      if (strcmp (method, "PrepareInstall") == 0)
-        return TRUE;
-      else
-        return FALSE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Background") == 0)
-    {
-      if (strcmp (method, "SetStatus") == 0)
-        return FALSE;
-      else
-        return TRUE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Inhibit") == 0)
-    {
-      if (strcmp (method, "QueryEndResponse") == 0)
-        return FALSE;
-      else
-        return TRUE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.InputCapture") == 0)
-    {
-      if (strcmp (method, "ConnectToEIS") == 0 ||
-          strcmp (method, "Enable") == 0 ||
-          strcmp (method, "Disable") == 0 ||
-          strcmp (method, "Release") == 0)
-        return FALSE;
-      else
-        return TRUE;
-    }
-  else if (strcmp (interface, "org.freedesktop.portal.Trash") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.Documents") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.FileTransfer") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.GameMode") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.MemoryMonitor") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.Notification") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.NetworkMonitor") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.ProxyResolver") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.Realtime") == 0 ||
-           strcmp (interface, "org.freedesktop.portal.Settings") == 0)
-    {
-      return FALSE;
-    }
-  else
-    {
-      return TRUE;
-    }
+  method_info = xdp_method_info_find (interface, method);
+
+  if (!method_info)
+    g_warning ("Support for %s::%s missing in %s",
+               interface, method, G_STRLOC);
+
+  return method_info ?  method_info->uses_request : TRUE;
 }
 
 static gboolean

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -175,6 +175,7 @@ method_needs_request (GDBusMethodInvocation *invocation)
            strcmp (interface, "org.freedesktop.portal.FileTransfer") == 0 ||
            strcmp (interface, "org.freedesktop.portal.GameMode") == 0 ||
            strcmp (interface, "org.freedesktop.portal.MemoryMonitor") == 0 ||
+           strcmp (interface, "org.freedesktop.portal.Notification") == 0 ||
            strcmp (interface, "org.freedesktop.portal.NetworkMonitor") == 0 ||
            strcmp (interface, "org.freedesktop.portal.ProxyResolver") == 0 ||
            strcmp (interface, "org.freedesktop.portal.Realtime") == 0 ||

--- a/src/xdp-method-info.c
+++ b/src/xdp-method-info.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2023 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <glib.h>
+
+#include "xdp-method-info.h"
+
+const XdpMethodInfo *
+xdp_method_info_find (const char *interface,
+                      const char *method)
+{
+  const XdpMethodInfo *mi = NULL;
+  gboolean interface_found = FALSE;
+
+  mi = xdp_method_info_get_all ();
+  while (mi->interface != NULL)
+    {
+      if (strcmp (interface, mi->interface) == 0)
+        {
+          interface_found = TRUE;
+          if (strcmp (method, mi->method) == 0)
+            return mi;
+        }
+      else if (interface_found)
+        break;
+      mi++;
+    }
+
+  return NULL;
+}

--- a/src/xdp-method-info.h
+++ b/src/xdp-method-info.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <glib.h>
+
+typedef struct {
+  const char *interface;
+  const char *method;
+  gboolean uses_request;
+  int option_arg;
+} XdpMethodInfo;
+
+const XdpMethodInfo *
+xdp_method_info_find (const char *interface,
+                      const char *method);
+
+const XdpMethodInfo *
+xdp_method_info_get_all (void);
+
+unsigned int
+xdp_method_info_get_count (void);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -265,6 +265,23 @@ test(
   protocol: test_protocol,
 )
 
+test_method_info = executable(
+  'test-xdp-method-info',
+  'test-xdp-method-info.c',
+  xdp_method_info_sources,
+  dependencies: [common_deps],
+  include_directories: [common_includes, xdp_utils_includes],
+  install: enable_installed_tests,
+  install_dir: installed_tests_dir,
+)
+test(
+  'test-xdp-method-info',
+  test_method_info,
+  env: env_tests,
+  is_parallel: true,
+  protocol: test_protocol,
+)
+
 pytest = find_program('pytest-3', 'pytest', required: get_option('pytest'))
 pymod = import('python')
 python = pymod.find_installation(

--- a/tests/test-xdp-method-info.c
+++ b/tests/test-xdp-method-info.c
@@ -1,0 +1,69 @@
+#include "config.h"
+
+#include <glib.h>
+
+#include "xdp-method-info.h"
+
+static void
+test_method_info_all (void)
+{
+  unsigned int i;
+  unsigned int count = xdp_method_info_get_count ();
+  const XdpMethodInfo *method_info = xdp_method_info_get_all ();
+
+  g_assert_cmpint (count, >, 100);
+  g_assert_nonnull (method_info);
+
+  for (i = 0; i < count + 1; i++)
+    {
+      if (method_info->interface == NULL)
+        return;
+      g_assert_nonnull (method_info->method);
+      method_info++;
+    }
+
+  g_assert_not_reached();
+}
+
+static void
+test_method_info_find (void)
+{
+  const XdpMethodInfo *method_info;
+
+  method_info = xdp_method_info_find ("org.freedesktop.portal.Notification", "AddNotification");
+  g_assert_nonnull (method_info);
+  g_assert_cmpint (method_info->option_arg, ==, -1);
+  g_assert_false (method_info->uses_request);
+
+  method_info = xdp_method_info_find ("org.freedesktop.portal.Inhibit", "Inhibit");
+  g_assert_nonnull (method_info);
+  g_assert_cmpint (method_info->option_arg, ==, 2);
+  g_assert_true (method_info->uses_request);
+
+  method_info = xdp_method_info_find ("org.freedesktop.portal.Inhibit", "QueryEndResponse");
+  g_assert_nonnull (method_info);
+  g_assert_cmpint (method_info->option_arg, ==, -1);
+  g_assert_false (method_info->uses_request);
+
+  /* Prefix is required */
+  method_info = xdp_method_info_find ("Inhibit", "QueryEndResponse");
+  g_assert_null (method_info);
+
+  method_info = xdp_method_info_find ("DoesNotExist", "DoesNotExist");
+  g_assert_null (method_info);
+
+  method_info = xdp_method_info_find ("DoesNotExist", "DoesNotExist");
+  g_assert_null (method_info);
+
+  method_info = xdp_method_info_find ("org.freedesktop.portal.Inhibit", "DoesNotExist");
+  g_assert_null (method_info);
+
+}
+
+int main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/method-info/all", test_method_info_all);
+  g_test_add_func ("/method-info/find", test_method_info_find);
+  return g_test_run ();
+}


### PR DESCRIPTION
One of the more frustrating things to debug when adding interfaces was for me to hunt down where I needed to special-case a portal method so it initializes correctly, specifically `method_needs_request` and `get_token`.

Both can be automated with a generated file, though that requires a bit of cleanup first because some portals were using the fallthrough behaviour (making both of those functions more unpredictable than they need to be).