### PR TITLE
High Contrast hint on settings portal

### DIFF
--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -46,6 +46,16 @@
       in the sRGB color space, in the range [0,1].
       Out-of-range RGB values should be treated as an unset accent color.
 
+    * ``org.freedesktop.appearance``  ``contrast`` (``u``)
+
+      Indicates the system's preferred contrast level.
+      Supported values are:
+
+      - ``0``: No preference (normal contrast)
+      - ``1``: Higher contrast
+
+      Unknown values should be treated as 0 (no preference).
+
     Implementations can provide other keys; they are entirely
     implementation details that are undocumented. If you are a
     toolkit and want to use this please open an issue.

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -46,6 +46,16 @@
       the sRGB color space, in the range [0,1]. Out-of-range RGB values should
       be treated as an unset accent color.
 
+    * ``org.freedesktop.appearance``  ``contrast`` (``u``)
+
+      Indicates the system's preferred contrast level.
+      Supported values are:
+
+        * ``0``: No preference (normal contrast)
+        * ``1``: Higher contrast
+
+      Unknown values should be treated as ``0`` (no preference).
+
     Implementations can provide other keys; they are entirely
     implementation details that are undocumented. If you are a
     toolkit and want to use this please open an issue.


### PR DESCRIPTION
# Introduction
High Contrast is a feature where, much as the name implies, the contrast of applications that support the feature is increased, whether it be adding more opacity to lines in applications, or in the rare case changing the entire palette of an application to be of the maximum possible colour contrast. Irregardless of implementation, this hint has existed for quite a long time in the UNIX space, as well as existing in most other Operating Systems, and this pull request gives this long-standing accessibility hint a standardised location for both existing and future uses of high contrast to come.

# Details
A new key on the settings portal, `high-contrast`, would be introduced into the `org.freedesktop.appearance` namescape. This key will use a boolean value.

The design of this key is based on every existing instance of a high contrast switch - in all platforms I know of, including those in the UNIX space who provide this value in a non-standardised manner, it has always been a simple boolean value which, if True, enables high contrast, but otherwise restores normal application styling if False.

This serves as a hint, just like its non-standardised variations, informing applications of the desire for contrast to be increased - applications are absolutely free to ignore it if, for example, they believe their default application appearance is of high enough contrast.

The hope for a standardised high contrast switch is that it will allow toolkits' existing high contrast options to be easily accessible from other Desktop Environments, such as GTK's high contrast option outside of GNOME, as well as encouraging programs, natively supported on XDG-compliant platforms, that technically have high contrast support programmed in, such as Mozilla Firefox and the Chromium Project, to expose this functionality on XDG-compliant platforms too.

# Acks

- [x] @snwh (GNOME)
- [x] @sonnyp (GNOME)
- [x] @JoshStrobl (Budgie)
- [x] @CarlSchwan (KDE)
- [x] @mmstick (Cosmic)
- [x] @danirabbit (Elementary)
- [x] @emilio (Gecko (Firefox's) Browser Engine)
- [x] @nothingneko (Helium)

# Implementations of High Contrast

- [ ] KDE Plasma: https://invent.kde.org/plasma/breeze/-/merge_requests/397
- GNOME, and all GTK-powered Desktop Environments: High Contrast boolean-switch in Settings
- Firefox: Currently only available on GNOME

Technically also exists in Chromium, although is currently inaccessible on Linux.

# Implementations using this standard

None yet.