### PR TITLE
Ensure FileChooser dialog only sends file:// URIs to apps

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -25,6 +25,10 @@
       The FileChooser portal allows sandboxed applications to ask
       the user for access to files outside the sandbox. The portal
       backend will present the user with a file chooser dialog.
+
+      Backends must normalize URIs of locations selected by the
+      user into "file://" URIs. URIs that cannot be normalized
+      should be discarded.
   -->
   <interface name="org.freedesktop.impl.portal.FileChooser">
     <!--
@@ -100,7 +104,8 @@
           <varlistentry>
             <term>uris as</term>
             <listitem><para>
-              An array of strings containing the uris of the selected files.
+              An array of strings containing the uris of the selected files. All
+              URIs must have the "file://" scheme.
             </para></listitem>
           </varlistentry>
           <varlistentry>
@@ -214,7 +219,8 @@
           <varlistentry>
             <term>uris as</term>
             <listitem><para>
-              An array of strings containing the uri of the selected file.
+              An array of strings containing the uri of the selected file. All
+              URIs must have the "file://" scheme.
             </para></listitem>
           </varlistentry>
           <varlistentry>
@@ -315,12 +321,17 @@
       <variablelist>
         <varlistentry>
           <term>uris as</term>
-          <listitem><para>
-            An array of strings containing the uri corresponding to
-            each file given by @options, in the same order. Note that
-            the file names may have changed, for example if a file
-            with the same name in the selected folder already exists.
-          </para></listitem>
+          <listitem>
+            <para>
+              An array of strings containing the uri corresponding to
+              each file given by @options, in the same order. Note that
+              the file names may have changed, for example if a file
+              with the same name in the selected folder already exists.
+            </para>
+            <para>
+               All URIs must have the "file://" scheme.
+            </para>
+        </listitem>
         </varlistentry>
         <varlistentry>
           <term>choices a(ss)</term>

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -167,7 +167,8 @@
         <varlistentry>
           <term>uris as</term>
           <listitem><para>
-            An array of strings containing the uris of the selected files.
+            An array of strings containing the uris of the selected files. All
+            URIs have the "file://" scheme.
           </para></listitem>
         </varlistentry>
         <varlistentry>
@@ -297,7 +298,8 @@
         <varlistentry>
           <term>uris as</term>
           <listitem><para>
-            An array of strings containing the uri of the selected file.
+            An array of strings containing the uri of the selected file. All
+            URIs have the "file://" scheme.
           </para></listitem>
         </varlistentry>
         <varlistentry>
@@ -425,12 +427,17 @@
       <variablelist>
         <varlistentry>
           <term>uris as</term>
-          <listitem><para>
-            An array of strings containing the uri corresponding to
-            each file given by @options, in the same order. Note that
-            the file names may have changed, for example if a file
-            with the same name in the selected folder already exists.
-          </para></listitem>
+          <listitem>
+            <para>
+              An array of strings containing the uri corresponding to
+              each file given by @options, in the same order. Note that
+              the file names may have changed, for example if a file
+              with the same name in the selected folder already exists.
+            </para>
+            <para>
+               All URIs have the "file://" scheme.
+            </para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>choices a(ss)</term>

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -117,6 +117,14 @@ send_response_in_thread_func (GTask        *task,
           g_autofree char *ruri = NULL;
           g_autoptr(GError) error = NULL;
 
+          g_assert (uris[i] != NULL);
+
+          if (!g_str_has_prefix (uris[i], "file://"))
+            {
+              g_warning ("Only URIs with the \"file://\" scheme are allowed");
+              continue;
+            }
+
           if (xdp_app_info_is_host (request->app_info))
             ruri = g_strdup (uris[i]);
           else

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -142,6 +142,8 @@ out:
                                       g_variant_builder_end (&results));
       request_unexport (request);
     }
+
+  g_task_return_boolean (task, TRUE);
 }
 
 /* Calling Lookup on a nonexisting path does not work, so we


### PR DESCRIPTION
xdg-desktop-portal does not do the normalization, this is up to backends, and it's now documented that they have to do this. But we can validate the received URIs. Do that.