### PR TITLE
Draft: Colour filter hint in Settings Portal

### DIFF
--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -56,7 +56,7 @@
         <listitem><para>
           Indicates the system's preferred color filter.
           Applications should only use this to adjust themselves for the current filter.
-          It is the compositor's job to apply the colour filter globally.
+          It is the compositor's job to apply the color filter globally.
           Supported values are:
           <simplelist>
             <member>0: No preference</member>

--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -51,6 +51,25 @@
           Out-of-range RGB values should be treated as an unset accent color.
         </para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term>org.freedesktop.appearance color-filter u</term>
+        <listitem><para>
+          Indicates the system's preferred color filter.
+          Applications should only use this to adjust themselves for the current filter.
+          It is the compositor's job to apply the colour filter globally.
+          Supported values are:
+          <simplelist>
+            <member>0: No preference</member>
+            <member>1: Protanopia</member>
+            <member>2: Protanopia (higher color contrast)</member>
+            <member>1: Deuteranopia</member>
+            <member>2: Deuteranopia (higher color contrast)</member>
+            <member>1: Tritanopia</member>
+            <member>1: Grayscale</member>
+          </simplelist>
+          Unknown values should be treated as 0 (no preference).
+        </para></listitem>
+      </varlistentry>
     </variablelist>
 
     Implementations can provide other keys; they are entirely

--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -62,10 +62,10 @@
             <member>0: No preference</member>
             <member>1: Protanopia</member>
             <member>2: Protanopia (higher color contrast)</member>
-            <member>1: Deuteranopia</member>
-            <member>2: Deuteranopia (higher color contrast)</member>
-            <member>1: Tritanopia</member>
-            <member>1: Grayscale</member>
+            <member>3: Deuteranopia</member>
+            <member>4: Deuteranopia (higher color contrast)</member>
+            <member>5: Tritanopia</member>
+            <member>6: Grayscale</member>
           </simplelist>
           Unknown values should be treated as 0 (no preference).
         </para></listitem>

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -56,7 +56,7 @@
         <listitem><para>
           Indicates the system's preferred color filter.
           Applications should only use this to adjust themselves for the current filter.
-          It is the compositor's job to apply the colour filter globally.
+          It is the compositor's job to apply the color filter globally.
           Supported values are:
           <simplelist>
             <member>0: No preference</member>

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -51,6 +51,25 @@
           Out-of-range RGB values should be treated as an unset accent color.
         </para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term>org.freedesktop.appearance color-filter u</term>
+        <listitem><para>
+          Indicates the system's preferred color filter.
+          Applications should only use this to adjust themselves for the current filter.
+          It is the compositor's job to apply the colour filter globally.
+          Supported values are:
+          <simplelist>
+            <member>0: No preference</member>
+            <member>1: Protanopia</member>
+            <member>2: Protanopia (higher color contrast)</member>
+            <member>1: Deuteranopia</member>
+            <member>2: Deuteranopia (higher color contrast)</member>
+            <member>1: Tritanopia</member>
+            <member>1: Grayscale</member>
+          </simplelist>
+          Unknown values should be treated as 0 (no preference).
+        </para></listitem>
+      </varlistentry>
     </variablelist>
 
     Implementations can provide other keys; they are entirely

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -62,10 +62,10 @@
             <member>0: No preference</member>
             <member>1: Protanopia</member>
             <member>2: Protanopia (higher color contrast)</member>
-            <member>1: Deuteranopia</member>
-            <member>2: Deuteranopia (higher color contrast)</member>
-            <member>1: Tritanopia</member>
-            <member>1: Grayscale</member>
+            <member>3: Deuteranopia</member>
+            <member>4: Deuteranopia (higher color contrast)</member>
+            <member>5: Tritanopia</member>
+            <member>6: Grayscale</member>
           </simplelist>
           Unknown values should be treated as 0 (no preference).
         </para></listitem>


### PR DESCRIPTION
Unlike the high contrast one, this one is a draft because I know Desktop Environments like GNOME don't yet have a concrete idea about the design they would prefer for this, the colour blindness filters they want to expose, etc.

As such, I expect this MR to thoroughly change before it exits Draft status, and for it to take forever to even exit Draft status.

Fixes #647, #1151 

# Introduction
Colour blindness is a prevalent problem, and Operating Systems in the XDG-compliant space are starting to realise this and accommodate to those suffering from such issues with their sight. So far, elementary OS and KDE Plasma have implemented colour filters for the colour blind users, by means of compositor shaders. However, this implementation has a design limitation that this pull request sets sight on allowing a fix to be made for.

# Details
A new key on the settings portal, `color-filter`, would be introduced into the `org.freedesktop.appearance` namescape. This key currently consists of all colour blindness filters implemented by elementary OS, as well as accommodating for greyscale, however more filters could be added at a later date to this pool of values.

As aforementioned, this is largely inspired by elementary OS's implementation of their colour shaders, although this design may always be changed to accommodate for the requests of other Desktop Environments.

This hint is designed with being paired with colour shaders in mind - applications should only use this hint to adjust their user interface for the current filter.

Additionally, greyscale is made available here to allow implementations of greyscale shaders, such as elementary OS's, to be officially recognised as shaders that applications should account for.

Brown Monotone was originally considered as a shader, here, however this is easily supplemented by allowing greyscale to be redshifted.

# Cases for colour filter hints for applications

## Libadwaita

Libadwaita has a high reliance on colours to denote certain types of buttons, however if colour blindness filters are not accounted for, on certain colour blindness filters the denotation can end up being too similar to be uniquely identifiable.

![image](https://github.com/flatpak/xdg-desktop-portal/assets/11057934/16562392-1c24-4349-a60d-3479fbc7c75a)

This would obviously especially be the case on greyscale filters, where colours are just not usable for denotation, period.

![image](https://github.com/flatpak/xdg-desktop-portal/assets/11057934/a191d67a-ded8-4547-ab13-0ae4dfa23dda)

If Libadwaita applications were able to know a colour filter is in use, they could then adjust themselves accordingly to better take advantage of the limited, or non-existent, colour pool.

## Games, such as Geometry Dash

While not native so not able to yet leverage this standard if merged, I'd still like to use Geometry Dash to illustrate a gaming context for why applications would want to know about the current colour filter.

Before 2.2, one of the biggest aspects of Geometry Dash's gameplay, the portals and orbs, were similarly denoted by colours only. However, after concerns for colourblind players, the upcoming 2.2 update adds the option for colourblind players to add symbols to portals and orbs to allow denotion without colours (_this would obviously be useful on greyscale filters, too_).

![image](https://github.com/flatpak/xdg-desktop-portal/assets/11057934/57614c36-f723-40c8-8afd-6f323217ec65)

If games are able to know which colour filter is in use, such as via this hint, they could technically automatically enable such optimisations, in their gameplay, for audiences using these colour filters.

# Acks

This may be a draft currently, but to save George the effort, using the acks list from #815 
- [ ] @alice-mkh (GNOME)
- [ ] @JoshStrobl (Budgie)
- [ ] @Sodivad (KDE)
- [ ] @jackpot51 (Cosmic)
- [ ] @danirabbit (Elementary)