### PR TITLE
Typo fix. Move the alt text attribute to an element where it is allowed and works

### DIFF
--- a/doc/website/index.md
+++ b/doc/website/index.md
@@ -20,9 +20,9 @@ The portal interfaces include APIs for file access, opening URIs, printing
 and others.
 
 
-<a href="https://flatpak.github.io/xdg-desktop-portal/docs" class="pixelbutton"><picture alt="Documentation for the available D-Bus interfaces">
+<a href="https://flatpak.github.io/xdg-desktop-portal/docs" class="pixelbutton"><picture>
     <source srcset="assets/docs-button-dark.png" media="(prefers-color-scheme: dark)">
-    <img src="assets/docs-button.png">
+    <img alt="Documentation for the available D-Bus interfaces" src="assets/docs-button.png">
 </picture></a>
 
 ## Version Numbering


### PR DESCRIPTION
According to the HTML specification, `alt` is specified by `img`, and there is no additional workaround in the web platform for the authors' errors in calculating the accessible name for the `picture` case.