### PR TITLE
meson.build: Increase meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'xdg-desktop-portal',
   'c',
   version: '1.19.0',
-  meson_version: '>= 0.58',
+  meson_version: '>= 0.60',
   license: 'LGPL-2.0-or-later',
   default_options: ['warning_level=2'])
 


### PR DESCRIPTION
This fixes WARNING: Project specifies a minimum meson_version '>= 0.58' but uses features which were added in newer versions:
 * 0.60.0: {'list.<plus>'}