### PR TITLE
gtask: make sure to call g_task_return_*()

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -333,6 +333,7 @@ close_requests_in_thread_func (GTask        *task,
     }
 
   g_slist_free_full (list, g_object_unref);
+  g_task_return_boolean (task, TRUE);
 }
 
 void

--- a/src/session.c
+++ b/src/session.c
@@ -265,6 +265,7 @@ close_sessions_in_thread_func (GTask *task,
     }
 
   g_slist_free_full (list, g_object_unref);
+  g_task_return_boolean (task, TRUE);
 }
 
 void


### PR DESCRIPTION
The error where triggered with `G_MESSAGES_DEBUG=all` when starting `xdg-desktop-portal` and then starting Busttle (DBus tool). It also happen along while running in regular use.