### PR TITLE
tests: Add a devenv for our most common test environment

### DIFF
--- a/tests/.pytest.ini
+++ b/tests/.pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore-glob=meson-logs

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -332,6 +332,13 @@ if enable_pytest
       )
     endif
   endforeach
+
+  configure_file(
+    input: '.pytest.ini',
+    output: '@PLAINNAME@',
+    copy: true,
+    install: false
+  )
 endif
 
 if enable_installed_tests

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -388,3 +388,5 @@ if enable_installed_tests
       )
   endforeach
 endif
+
+meson.add_devenv(test_env)


### PR DESCRIPTION
Trying to figure out the environment variables to set to run the tests
manually is annoying, so let's use technology to solve that and pretend
we're living in the future where technology actually helps us.
And this glorious future now allows us to do:
```
  $ meson devenv -Cbuilddir
  $ pytest
  $ ./tests/test-portals
```
and so on.