### PR TITLE
doc: Correct a few impl.portals refering to the Request.Response signal

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -40,7 +40,7 @@
 
         Create a global shortcuts session.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned in the @results vardict:
         <variablelist>
           <varlistentry>
             <term>session_id s</term>
@@ -98,7 +98,7 @@
 
         List shortcuts registered in the global shortcuts session.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned in the @results vardict:
         <variablelist>
           <varlistentry>
             <term>shortcuts a(sa{sv})</term>

--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -41,7 +41,7 @@
         org.freedesktop.portal.ScreenCast), but may only be started and stopped
         with this interface.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned in the @results vardict:
         <variablelist>
           <varlistentry>
             <term>session s</term>
@@ -115,8 +115,8 @@
             </para>
             <para>
               If the permission for the session to persist is granted, "restore_data"
-              will be returned via the #org.freedesktop.portal.Request::Response
-              signal of the #org.freedesktop.impl.portal.RemoteDesktop.Start method.
+              will be returned in the results of the
+              #org.freedesktop.impl.portal.RemoteDesktop.Start method.
             </para>
             <para>
               This option was added in version 2 of this interface.
@@ -161,8 +161,7 @@
           </varlistentry>
         </variablelist>
 
-        The following results get returned via the
-        #org.freedesktop.portal.Request::Response signal:
+        The following results get returned in the @results vardict:
         <variablelist>
           <varlistentry>
             <term>devices u</term>

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -37,7 +37,7 @@
 
         Create a screen cast session.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned in the @results vardict:
         <variablelist>
           <varlistentry>
             <term>session_id s</term>
@@ -128,8 +128,7 @@
             </para>
             <para>
               If the permission for the session to persist is granted,
-              "persist_mode" will be returned via the
-              #org.freedesktop.portal.Request::Response signal of the
+              "persist_mode" will be returned in the results of the
               #org.freedesktop.impl.portal.ScreenCast.Start method.
             </para>
             <para>
@@ -163,7 +162,7 @@
         Start the screen cast session. This will typically result the portal presenting
         a dialog letting the user do the selection set up by SelectSources.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned in the @results vardict:
         <variablelist>
           <varlistentry>
             <term>streams a(ua{sv})</term>


### PR DESCRIPTION
impl.portals don't use that, they just return the results direct.