### PR TITLE
inputcapture: add support for persist_mode and restore_token

### DIFF
--- a/data/org.freedesktop.impl.portal.InputCapture.xml
+++ b/data/org.freedesktop.impl.portal.InputCapture.xml
@@ -26,7 +26,7 @@
       #org.freedesktop.portal.InputCapture portal, see that portal's
       documentation for details on methods, signals and arguments.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.InputCapture">
     <!--
@@ -50,6 +50,47 @@
               SupportedCapabilities property. This value is required.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>restore_data (suv)</term>
+            <listitem><para>
+              The data to restore from a previous session.
+            </para>
+            <para>
+              If the stored session cannot be restored, this value is ignored
+              and the user will be prompted normally. This may happen when, for
+              example, the session contains a monitor or a window that is not
+              available anymore, or when the stored permissions are withdrawn.
+            </para>
+            <para>
+              The restore data is composed of the vendor name (e.g. "GNOME" or
+              "KDE"), the version of the implementation-specific private data,
+              and the implementation-specific private data itself.
+            </para>
+            <para>
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>persist_mode u</term>
+            <listitem><para>
+              How this session should persist. Default is 0. Accepted values are:
+            </para>
+            <para>
+              <simplelist>
+                <member>0: Do not persist (default)</member>
+                <member>1: Permissions persist as long as the application is running</member>
+                <member>2: Permissions persist until explicitly revoked</member>
+              </simplelist>
+            </para>
+            <para>
+              If the permission for the session to persist is granted, "restore_data"
+              will be returned via the #org.freedesktop.portal.Request::Response
+              signal.
+            </para>
+            <para>
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned in the @results vardict:
@@ -65,6 +106,12 @@
             <listitem><para>
               The capabilities available to this session. This is always a
               subset of the requested capabilities.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>restore_data (suv)</term>
+            <listitem><para>
+              The data to restore this session in a future session. See the persist_mode.
             </para></listitem>
           </varlistentry>
       </variablelist>

--- a/data/org.freedesktop.portal.InputCapture.xml
+++ b/data/org.freedesktop.portal.InputCapture.xml
@@ -51,7 +51,7 @@
       captured. The transport of actual input events is delegated to a
       transport layer, specifically libei. See org.freedesktop.portal.InputCapture.ConnectToEIS().
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
    -->
   <interface name="org.freedesktop.portal.InputCapture">
     <!--
@@ -90,6 +90,40 @@
               SupportedCapabilities property. This value is required and must not be zero.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>restore_token s</term>
+            <listitem><para>
+              The token to restore a previous session.
+
+              If the stored session cannot be restored, this value is ignored
+              and the user will be prompted normally. This may happen when, for
+              example, the session contains a monitor or a window that is not
+              available anymore, or when the stored permissions are withdrawn.
+
+              The restore token is invalidated after using it once. To restore
+              the same session again, use the new restore token sent in response
+              to starting this session.
+
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>persist_mode u</term>
+            <listitem><para>
+              How this session should persist. Default is 0. Accepted values are:
+
+              <simplelist>
+                <member>0: Do not persist (default)</member>
+                <member>1: Permissions persist as long as the application is running</member>
+                <member>2: Permissions persist until explicitly revoked</member>
+              </simplelist>
+
+              If the permission for the session to persist is granted, a restore token will
+              be returned via the #org.freedesktop.portal.Request::Response signal.
+
+              This option was added in version 2 of this interface.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
 
         The following results get returned via the #org.freedesktop.portal.Request::Response signal:
@@ -115,6 +149,16 @@
               It is best to view this set as a negative confirmation - a
               capability that was requested but is missing is an indication that
               this application may not capture events of that capability.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>restore_token s</term>
+            <listitem><para>
+              The restore token. This token is a single use token that can later
+              be used to restore a session. See
+              org.freedesktop.portal.InputCapture.CreateSession() for details.
+
+              This response option was added in version 2 of this interface.
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -430,50 +430,10 @@ validate_device_types (const char *key,
   return TRUE;
 }
 
-static gboolean
-validate_restore_token (const char *key,
-                        GVariant *value,
-                        GVariant *options,
-                        GError **error)
-{
-  const char *restore_token = g_variant_get_string (value, NULL);
-
-  if (!g_uuid_string_is_valid (restore_token))
-    {
-      g_set_error (error,
-                   XDG_DESKTOP_PORTAL_ERROR,
-                   XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Restore token is not a valid UUID string");
-      return FALSE;
-    }
-
-  return TRUE;
-}
-
-static gboolean
-validate_persist_mode (const char *key,
-                       GVariant *value,
-                       GVariant *options,
-                       GError **error)
-{
-  uint32_t mode = g_variant_get_uint32 (value);
-
-  if (mode > PERSIST_MODE_PERSISTENT)
-    {
-      g_set_error (error,
-                   XDG_DESKTOP_PORTAL_ERROR,
-                   XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Invalid persist mode %x", mode);
-      return FALSE;
-    }
-
-  return TRUE;
-}
-
 static XdpOptionKey remote_desktop_select_devices_options[] = {
   { "types", G_VARIANT_TYPE_UINT32, validate_device_types },
-  { "restore_token", G_VARIANT_TYPE_STRING, validate_restore_token },
-  { "persist_mode", G_VARIANT_TYPE_UINT32, validate_persist_mode },
+  { "restore_token", G_VARIANT_TYPE_STRING, xdp_session_persistence_validate_restore_token },
+  { "persist_mode", G_VARIANT_TYPE_UINT32, xdp_session_persistence_validate_persist_mode },
 };
 
 static gboolean

--- a/src/restore-token.c
+++ b/src/restore-token.c
@@ -362,8 +362,9 @@ xdp_session_persistence_replace_restore_data_with_token (Session *session,
                                                                *in_out_persist_mode,
                                                                in_out_restore_token,
                                                                in_out_restore_data);
-      g_variant_builder_add (&results_builder, "{sv}", "restore_token",
-                             g_variant_new_string (*in_out_restore_token));
+      if (*in_out_restore_token)
+        g_variant_builder_add (&results_builder, "{sv}", "restore_token",
+                               g_variant_new_string (*in_out_restore_token));
     }
   else
     {

--- a/src/restore-token.c
+++ b/src/restore-token.c
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include <stdint.h>
+
 #include "permissions.h"
 #include "restore-token.h"
 
@@ -369,4 +371,40 @@ xdp_session_persistence_replace_restore_data_with_token (Session *session,
     }
 
   *in_out_results = g_variant_builder_end (&results_builder);
+}
+
+gboolean
+xdp_session_persistence_validate_restore_token (const char *key,
+                                                GVariant *value,
+                                                GVariant *options,
+                                                GError **error)
+{
+  const char *restore_token = g_variant_get_string (value, NULL);
+
+  if (!g_uuid_string_is_valid (restore_token))
+    {
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "Restore token is not a valid UUID string");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+gboolean
+xdp_session_persistence_validate_persist_mode (const char *key,
+                                               GVariant *value,
+                                               GVariant *options,
+                                               GError **error)
+{
+  uint32_t mode = g_variant_get_uint32 (value);
+
+  if (mode > PERSIST_MODE_PERSISTENT)
+    {
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "Invalid persist mode %x", mode);
+      return FALSE;
+    }
+
+  return TRUE;
 }

--- a/src/restore-token.h
+++ b/src/restore-token.h
@@ -69,3 +69,13 @@ void xdp_session_persistence_generate_and_save_restore_token (Session *session,
                                                               PersistMode persist_mode,
                                                               char **in_out_restore_token,
                                                               GVariant **in_out_restore_data);
+
+gboolean xdp_session_persistence_validate_restore_token (const char *key,
+                                                         GVariant *value,
+                                                         GVariant *options,
+                                                         GError **error);
+
+gboolean xdp_session_persistence_validate_persist_mode (const char *key,
+                                                        GVariant *value,
+                                                        GVariant *options,
+                                                        GError **error);

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -360,7 +360,7 @@ validate_source_types (const char *key,
   return TRUE;
 }
 
-static gboolean
+gboolean
 validate_cursor_mode (const char *key,
                       GVariant *value,
                       GVariant *options,
@@ -385,48 +385,12 @@ validate_cursor_mode (const char *key,
   return TRUE;
 }
 
-static gboolean
-validate_restore_token (const char *key,
-                        GVariant *value,
-                        GVariant *options,
-                        GError **error)
-{
-  const char *restore_token = g_variant_get_string (value, NULL);
-
-  if (!g_uuid_string_is_valid (restore_token))
-    {
-      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Restore token is not a valid UUID string");
-      return FALSE;
-    }
-
-  return TRUE;
-}
-
-static gboolean
-validate_persist_mode (const char *key,
-                       GVariant *value,
-                       GVariant *options,
-                       GError **error)
-{
-  uint32_t mode = g_variant_get_uint32 (value);
-
-  if (mode > PERSIST_MODE_PERSISTENT)
-    {
-      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Invalid persist mode %x", mode);
-      return FALSE;
-    }
-
-  return TRUE;
-}
-
 static XdpOptionKey screen_cast_select_sources_options[] = {
   { "types", G_VARIANT_TYPE_UINT32, validate_source_types },
   { "multiple", G_VARIANT_TYPE_BOOLEAN, NULL },
   { "cursor_mode", G_VARIANT_TYPE_UINT32, validate_cursor_mode },
-  { "restore_token", G_VARIANT_TYPE_STRING, validate_restore_token },
-  { "persist_mode", G_VARIANT_TYPE_UINT32, validate_persist_mode },
+  { "restore_token", G_VARIANT_TYPE_STRING, xdp_session_persistence_validate_restore_token },
+  { "persist_mode", G_VARIANT_TYPE_UINT32, xdp_session_persistence_validate_persist_mode },
 };
 
 static gboolean

--- a/tests/test_inputcapture.py
+++ b/tests/test_inputcapture.py
@@ -3,7 +3,7 @@
 # This file is formatted with Python Black
 
 from gi.repository import GLib
-
+from . import Response
 from itertools import count
 
 import dbus
@@ -28,7 +28,11 @@ def zones():
 
 
 class TestInputCapture:
-    def create_session(self, portal_mock, capabilities=0xF):
+    def create_session(
+        self,
+        portal_mock,
+        capabilities=0xF,
+    ) -> Response:
         """
         Call CreateSession for the given capabilities and return the
         (response, results) tuple.
@@ -46,17 +50,15 @@ class TestInputCapture:
             signature="sv",
         )
 
-        response, results = request.call(
-            "CreateSession", parent_window="", options=options
-        )
-        assert response == 0
-        assert "session_handle" in results
-        assert "capabilities" in results
-        caps = results["capabilities"]
+        response = request.call("CreateSession", parent_window="", options=options)
+        assert response.response == 0
+        assert "session_handle" in response.results
+        assert "capabilities" in response.results
+        caps = response.results["capabilities"]
         # Returned capabilities must be a subset of the requested ones
         assert caps & ~capabilities == 0
 
-        self.current_session_handle = results["session_handle"]
+        self.current_session_handle = response.results["session_handle"]
 
         # Check the impl portal was called with the right args
         method_calls = portal_mock.mock_interface.GetMethodCalls("CreateSession")
@@ -65,7 +67,7 @@ class TestInputCapture:
         assert args[3] == ""  # parent window
         assert args[4]["capabilities"] == capabilities
 
-        return response, results
+        return response
 
     def get_zones(self, portal_mock):
         """


### PR DESCRIPTION
Identical to the existing RemoteDesktop/ScreenCast persist modes, just this time for InputCapture. This allows an application to keep the permissions past things like screen savers activating and whatnot.


Keeping this as draft until we have the mutter side for real-world testing beyond the test suite. libportal obviously will need updates as well.


cc @jadahl 