### PR TITLE
Fix lead of file descriptors for PhysicalInode:s

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -239,7 +239,7 @@ portal_delete (GDBusMethodInvocation *invocation,
   g_autofree const char **old_apps = NULL;
   int i;
 
-  g_variant_get (parameters, "(s)", &id);
+  g_variant_get (parameters, "(&s)", &id);
 
   g_debug ("portal_delete %s", id);
 

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -724,7 +724,8 @@ permission_db_set_entry (PermissionDb      *self,
 void
 permission_db_update (PermissionDb *self)
 {
-  GHashTable *root, *main_h, *apps_h;
+  g_autoptr(GHashTable) root = NULL;
+  GHashTable *main_h, *apps_h;
   GBytes *new_contents;
   GvdbTable *new_gvdb;
   int i;

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -1007,7 +1007,6 @@ permission_db_entry_get_permissions_variant (PermissionDbEntry *entry,
   GVariant *v = (GVariant *) entry;
 
   g_autoptr(GVariant) app_array = NULL;
-  GVariant *child;
   GVariant *res = NULL;
   gsize n_children, start, end, m;
   const char *child_app_id;
@@ -1021,6 +1020,8 @@ permission_db_entry_get_permissions_variant (PermissionDbEntry *entry,
   end = n_children;
   while (start < end)
     {
+      g_autoptr(GVariant) child = NULL;
+
       m = (start + end) / 2;
 
       child = g_variant_get_child_value (app_array, m);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -183,7 +183,7 @@ _xdp_parse_app_id_from_unit_name (const char *unit)
 
   if (match != NULL)
     {
-      const char *escaped_app_id;
+      g_autofree char *escaped_app_id = NULL;
       /* Unescape the unit name which may have \x hex codes in it, e.g.
        * "app-gnome-org.gnome.Evolution\x2dalarm\x2dnotify-2437.scope"
        */

--- a/tests/account.c
+++ b/tests/account.c
@@ -40,16 +40,19 @@ account_cb (GObject *obj,
       res = g_variant_lookup (ret, "id", "&s", &s); 
       g_assert (res == (t != NULL));
       if (t) g_assert_cmpstr (s, ==, t);
+      free(t);
 
       t = g_key_file_get_string (keyfile, "account", "name", NULL);
       res = g_variant_lookup (ret, "name", "&s", &s); 
       g_assert (res == (t != NULL));
       if (t) g_assert_cmpstr (s, ==, t);
+      free(t);
 
       t = g_key_file_get_string (keyfile, "account", "image", NULL);
       res = g_variant_lookup (ret, "image", "&s", &s); 
       g_assert (res == (t != NULL));
       if (t) g_assert_cmpstr (s, ==, t);
+      free(t);
     }
   else if (response == 1)
     g_assert_error (error, G_IO_ERROR, G_IO_ERROR_CANCELLED);

--- a/tests/limited-portals.c
+++ b/tests/limited-portals.c
@@ -102,8 +102,7 @@ update_data_dirs (void)
 {
   const char *data_dirs;
   gssize len = 0;
-  GString *str;
-  char *new_val;
+  g_autoptr(GString) str = NULL;
 
   data_dirs = g_getenv ("XDG_DATA_DIRS");
   if (data_dirs != NULL &&
@@ -123,11 +122,9 @@ update_data_dirs (void)
   if (str->len > 0)
     g_string_append_c (str, ':');
   g_string_append (str, "/usr/local/share/:/usr/share/");
-  new_val = g_string_free (str, FALSE);
 
-  g_debug ("Setting XDG_DATA_DIRS to %s", new_val);
-  g_setenv ("XDG_DATA_DIRS", new_val, TRUE);
-  /* new_val is leaked */
+  g_debug ("Setting XDG_DATA_DIRS to %s", str->str);
+  g_setenv ("XDG_DATA_DIRS", str->str, TRUE);
 }
 
 static void
@@ -444,6 +441,9 @@ int
 main (int argc, char **argv)
 {
   int res;
+
+  /* Better leak reporting without gvfs */
+  g_setenv ("GIO_USE_VFS", "local", TRUE);
 
   g_log_writer_default_set_use_stderr (TRUE);
 

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -499,7 +499,7 @@ test_create_docs (void)
   g_autofree char *path2 = NULL;
   int fd1, fd2;
   guint32 fd_ids[2];
-  GUnixFDList *fd_list = NULL;
+  g_autoptr(GUnixFDList) fd_list = NULL;
   gboolean res;
   g_auto(GStrv) out_doc_ids = NULL;
   g_autoptr(GVariant) out_extra = NULL;
@@ -745,7 +745,7 @@ static gboolean
 rm_rf_dir (GFile         *dir,
            GError       **error)
 {
-  GFileEnumerator *enumerator = NULL;
+  g_autoptr(GFileEnumerator) enumerator = NULL;
   g_autoptr(GFileInfo) child_info = NULL;
   GError *temp_error = NULL;
 
@@ -860,6 +860,9 @@ int
 main (int argc, char **argv)
 {
   int res;
+
+  /* Better leak reporting without gvfs */
+  g_setenv ("GIO_USE_VFS", "local", TRUE);
 
   g_test_init (&argc, &argv, NULL);
 

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -1025,43 +1025,46 @@ def add_an_app(num_docs):
         doc.apps.append(write_app)
     logv("granted acces to %s and %s for %s" % (read_app, write_app, ids))
 
+try:
+    log("Connecting to portal")
+    portal = DocPortal()
 
-log("Connecting to portal")
-portal = DocPortal()
-
-log("Running fuse tests...")
-create_app_by_lookup()
-verify_fs_layout()
-
-log("Creating some docs")
-for i in range(10):
-    export_a_doc()
-verify_fs_layout()
-
-log("Creating some named docs (existing)")
-for i in range(10):
-    export_a_named_doc(True)
-verify_fs_layout()
-
-log("Creating some named docs (non-existing)")
-for i in range(10):
-    export_a_named_doc(False)
-verify_fs_layout()
-
-log("Creating some dir docs")
-for i in range(10):
-    export_a_dir_doc()
-verify_fs_layout()
-
-log("Creating some apps")
-for i in range(10):
-    add_an_app(6)
-verify_fs_layout()
-
-for i in range(args.iterations):
-    log("Checking permissions, pass %d" % (i + 1))
-    check_perms()
+    log("Running fuse tests...")
+    create_app_by_lookup()
     verify_fs_layout()
 
-log("fuse tests ok")
-sys.exit(0)
+    log("Creating some docs")
+    for i in range(10):
+        export_a_doc()
+        verify_fs_layout()
+
+    log("Creating some named docs (existing)")
+    for i in range(10):
+        export_a_named_doc(True)
+    verify_fs_layout()
+
+    log("Creating some named docs (non-existing)")
+    for i in range(10):
+        export_a_named_doc(False)
+    verify_fs_layout()
+
+    log("Creating some dir docs")
+    for i in range(10):
+        export_a_dir_doc()
+    verify_fs_layout()
+
+    log("Creating some apps")
+    for i in range(10):
+        add_an_app(6)
+    verify_fs_layout()
+
+    for i in range(args.iterations):
+        log("Checking permissions, pass %d" % (i + 1))
+        check_perms()
+        verify_fs_layout()
+
+    log("fuse tests ok")
+    sys.exit(0)
+except Exception as e:
+    log("fuse tests failed: %s" % e)
+    sys.exit(1)

--- a/tests/test-document-fuse.py
+++ b/tests/test-document-fuse.py
@@ -34,9 +34,9 @@ if args.prefix:
 
 def log(str):
     if args.prefix:
-        print("%s: %s" % (args.prefix, str))
+        print("%s: %s" % (args.prefix, str), file=sys.stderr)
     else:
-        print(str)
+        print(str, file=sys.stderr)
 
 
 def logv(str):

--- a/tests/test-document-fuse.sh
+++ b/tests/test-document-fuse.sh
@@ -80,7 +80,8 @@ fi
 # Only do this when running uninstalled; when running as an installed-test,
 # we rely on D-Bus activation.
 if [ -n "${XDP_UNINSTALLED:-}" ]; then
-    ./xdg-document-portal -r &
+    $test_builddir/../document-portal/xdg-document-portal -r &
+    sleep 0.2 # Make sure the portal has connected to dbus
 fi
 
 # First run a basic single-thread test

--- a/tests/test-document-fuse.sh
+++ b/tests/test-document-fuse.sh
@@ -84,12 +84,12 @@ if [ -n "${XDP_UNINSTALLED:-}" ]; then
 fi
 
 # First run a basic single-thread test
-echo Testing single-threaded
+echo Testing single-threaded &>2
 "${test_srcdir}/test-document-fuse.py" --iterations ${ITERATIONS} -v
 echo "ok single-threaded"
 
 # Then a bunch of copies in parallel to stress-test
-echo Testing in parallel
+echo Testing in parallel &>2
 PIDS=()
 for i in $(seq ${PARALLEL_TESTS}); do
     "${test_srcdir}/test-document-fuse.py" --iterations ${PARALLEL_ITERATIONS} --prefix "$i" &
@@ -97,6 +97,6 @@ for i in $(seq ${PARALLEL_TESTS}); do
     PIDS+=( "$PID" )
 done
 
-echo waiting for pids "${PIDS[@]}"
+echo waiting for pids "${PIDS[@]}" &>2
 wait "${PIDS[@]}"
 echo "ok load-test"

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -507,7 +507,7 @@ test_get_permission2 (void)
 {
   gboolean res;
   const char * in_perms[] = { "yes", NULL };
-  g_autofree char **out_perms = NULL;
+  g_auto(GStrv) out_perms = NULL;
   g_autoptr(GError) error = NULL;
 
   res = xdg_permission_store_call_set_permission_sync (permissions,
@@ -595,7 +595,7 @@ static gboolean
 rm_rf_dir (GFile         *dir,
            GError       **error)
 {
-  GFileEnumerator *enumerator = NULL;
+  g_autoptr(GFileEnumerator) enumerator = NULL;
   g_autoptr(GFileInfo) child_info = NULL;
   GError *temp_error = NULL;
 
@@ -663,6 +663,9 @@ int
 main (int argc, char **argv)
 {
   int res;
+
+  /* Better leak reporting without gvfs */
+  g_setenv ("GIO_USE_VFS", "local", TRUE);
 
   g_log_writer_default_set_use_stderr (TRUE);
   g_test_init (&argc, &argv, NULL);

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -101,8 +101,7 @@ update_data_dirs (void)
 {
   const char *data_dirs;
   gssize len = 0;
-  GString *str;
-  char *new_val;
+  g_autoptr(GString) str = NULL;
 
   data_dirs = g_getenv ("XDG_DATA_DIRS");
   if (data_dirs != NULL &&
@@ -122,11 +121,9 @@ update_data_dirs (void)
   if (str->len > 0)
     g_string_append_c (str, ':');
   g_string_append (str, "/usr/local/share/:/usr/share/");
-  new_val = g_string_free (str, FALSE);
 
-  g_debug ("Setting XDG_DATA_DIRS to %s", new_val);
-  g_setenv ("XDG_DATA_DIRS", new_val, TRUE);
-  /* new_val is leaked */
+  g_debug ("Setting XDG_DATA_DIRS to %s", str->str);
+  g_setenv ("XDG_DATA_DIRS", str->str, TRUE);
 }
 
 static void
@@ -291,6 +288,8 @@ global_setup (void)
   g_subprocess_launcher_setenv (launcher, "PATH", g_getenv ("PATH"), TRUE);
   g_subprocess_launcher_take_stdout_fd (launcher, xdup (STDERR_FILENO));
 
+  g_clear_pointer (&argv0, g_free);
+
   if (g_getenv ("XDP_UNINSTALLED") != NULL)
     argv0 = g_test_build_filename (G_TEST_BUILT, "..", XDG_DP_BUILDDIR, "xdg-desktop-portal", NULL);
   else
@@ -307,7 +306,6 @@ global_setup (void)
   g_test_message ("Launched %s with pid %s\n", argv[0],
                   g_subprocess_get_identifier (subprocess));
   test_procs = g_list_append (test_procs, g_steal_pointer (&subprocess));
-  g_clear_pointer (&argv0, g_free);
 
   name_timeout = g_timeout_add (1000 * timeout_mult, timeout_cb, "Failed to launch xdg-desktop-portal");
 
@@ -459,6 +457,9 @@ int
 main (int argc, char **argv)
 {
   int res;
+
+  /* Better leak reporting without gvfs */
+  g_setenv ("GIO_USE_VFS", "local", TRUE);
 
   g_log_writer_default_set_use_stderr (TRUE);
 


### PR DESCRIPTION
This fixes https://github.com/flatpak/xdg-desktop-portal/issues/689

The mechanism we're using to flush the dcache and thus avoiding long-term caching of physical inodes which keep a file descriptor open doesn't seem to work quite right.

A trivial test of cat /run/user/1000/doc/$docid/$filename properly leads to the PhysicalFile being freed. However, an application that keeps the file open for a longer time (longer than the delay we have before the current dcache flush workaround is run), ends up with the dcache entry for the inode to be kept in cache. This means that we when the last other kernel reference (like an open fd) to the inode is gone we don't get a FORGET event from fuse, and thus we never free the PhysicalInode.

This is clearly visible, because if you end up with the file descriptor leak like in the issue, then flushing the dcache (`sudo sh -c 'echo 2 > /proc/sys/vm/drop_caches'`) fixes the leak.

It seems the current workaround of just invalidating the toplevel directory entry doesn't work, so we replace it with tracking each individual lookup that ends up with a physical inode and flush all of them. This seems to fix the issue for me.