### PR TITLE
Set gtk as the default fallback portals backend

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -167,6 +167,11 @@ if bwrap.found()
   helper_def = '-DHELPER="@0@"'.format(bwrap.full_path())
 endif
 
+install_data(
+  'portals.conf',
+  install_dir: datadir / 'xdg-desktop-portal',
+)
+
 executable(
   'xdg-desktop-portal-validate-icon',
   'validate-icon.c',

--- a/src/portals.conf
+++ b/src/portals.conf
@@ -1,0 +1,5 @@
+[preferred]
+# This is the ultimate fallback for when nothing else is configured.
+# xdg-desktop-portal-gtk is fairly desktop neutral and implements many interfaces so it is a reasonable default.
+# See `man portals.conf` for more information on configuration.
+default=gtk


### PR DESCRIPTION
Some users don't actually use a desktop so it makes sense to fallback to *something* and gtk is a good choice.

```
XDP: Preferred portals for interface 'default': gtk
XDP: Using portal configuration file '/home/tingping/jhbuild/install/share/xdg-desktop-portal/portals.conf' for non-specific desktop
```