### PR TITLE
meson.build: fix building when flatpak-interfaces-dir is explicitly specified

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -200,7 +200,7 @@ summary({
     'Enable installed tests:': enable_installed_tests,
     'Enable python test suite': enable_pytest,
     'Build man pages': rst2man.found(),
-    'Build flatpak interfaces': flatpak_dep.found(),
+    'Build flatpak interfaces': flatpak_intf_dir != '',
     'Sandboxed image validation': use_bwrap,
   },
   section: 'Optional builds',


### PR DESCRIPTION
In this case flatpak_dep is never set and meson fails while generating the summery. And the interfaces are build based on the content of flatpak_intf_dir anyways, so use that in the summary.