### PR TITLE
portal-impl: Hard-code x-d-p-gtk as a last-resort fallback

### DIFF
--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -587,19 +587,30 @@ find_portal_implementation (const char *interface)
         }
     }
 
-#if 0
-  /* Fall back to *any* installed implementation */
+  /* As a last resort, if nothing was selected for this desktop by
+   * ${desktop}-portals.conf or portals.conf, and no portal volunteered
+   * itself as suitable for this desktop via the legacy UseIn mechanism,
+   * try to fall back to x-d-p-gtk, which has historically been the portal
+   * UI backend used by desktop environments with no backend of their own.
+   * If it isn't installed, that is not an error: we just don't use it. */
   for (l = implementations; l != NULL; l = l->next)
     {
       PortalImplementation *impl = l->data;
 
+      if (!g_str_equal (impl->dbus_name, "org.freedesktop.impl.portal.desktop.gtk"))
+        continue;
+
       if (!g_strv_contains ((const char **)impl->interfaces, interface))
         continue;
 
-      g_debug ("Falling back to %s.portal for %s", impl->source, interface);
+      g_warning ("Choosing %s.portal for %s as a last-resort fallback",
+                 impl->source, interface);
+      g_warning_once ("The preferred method to match portal implementations "
+                      "to desktop environments is to use the portals.conf(5) "
+                      "configuration file");
+
       return impl;
     }
-#endif
 
   return NULL;
 }

--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -540,6 +540,14 @@ portal_impl_matches_config (const PortalImplementation *impl,
   return FALSE;
 }
 
+static void
+warn_please_use_portals_conf (void)
+{
+  g_warning_once ("The preferred method to match portal implementations "
+                  "to desktop environments is to use the portals.conf(5) "
+                  "configuration file");
+}
+
 PortalImplementation *
 find_portal_implementation (const char *interface)
 {
@@ -577,10 +585,7 @@ find_portal_implementation (const char *interface)
             {
               g_warning ("Choosing %s.portal for %s via the deprecated UseIn key",
                          impl->source, interface);
-              g_warning_once ("The preferred method to match portal implementations "
-                              "to desktop environments is to use the portals.conf(5) "
-                              "configuration file");
-
+              warn_please_use_portals_conf ();
               g_debug ("Using %s.portal for %s in %s (fallback)", impl->source, interface, desktops[i]);
               return impl;
             }
@@ -605,10 +610,7 @@ find_portal_implementation (const char *interface)
 
       g_warning ("Choosing %s.portal for %s as a last-resort fallback",
                  impl->source, interface);
-      g_warning_once ("The preferred method to match portal implementations "
-                      "to desktop environments is to use the portals.conf(5) "
-                      "configuration file");
-
+      warn_please_use_portals_conf ();
       return impl;
     }
 


### PR DESCRIPTION
x-d-p-gtk has historically been used as the portal implementation of last resort, and in particular, users of assemble-it-yourself desktop environments or otherwise-unsupported desktop environments have tended to rely on it for basic functionality, particularly now that its GNOME-specific parts have been removed.

We don't want to install a /usr/share/x-d-p/portals.conf that makes it the fallback (as proposed in xdg-desktop-portal#1192) because that would be higher-precedence than the fallback to the legacy UseIn mechanism. For example, x-d-p-wlr has UseIn=...;Wayfire;... which means that it will be used to provide screenshots and screencasts under Wayfire (even without fixing WayfireWM/wayfire#1995), but installing a /usr/share/x-d-p/portals.conf with only default=gtk would defeat that.

Instead, search for x-d-p-gtk as a lower precedence than the legacy UseIn mechanism. This means that (for example) users of Wayfire will get screenshots from x-d-p-wlr and file choosers from x-d-p-gtk unless configured otherwise, while users of environments with no more appropriate portal configuration at all (for example fvwm) will get x-d-p-gtk.

This change was previously a Debian-specific patch with a slightly different warning.

Resolves: #1102

---

Alternative to #1192 and the unfinished #1103.