### PR TITLE
Fix linker error and compiler warnings when building without bwrap

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -113,10 +113,9 @@ pipewire_dep = dependency('libpipewire-0.3', version: '>= 0.2.90')
 libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))
 
 
-use_bwrap = get_option('sandboxed-image-validation')
-bwrap = find_program('bwrap', required: use_bwrap)
+bwrap = find_program('bwrap', required: get_option('sandboxed-image-validation'))
 
-if not use_bwrap
+if not bwrap.found()
   warning('''
     Sandboxed image validation with Bubblewrap is DISABLED.
     If your system can run Bubblewrap, it's **hightly** recommended that you enable this
@@ -201,7 +200,7 @@ summary({
     'Enable python test suite': enable_pytest,
     'Build man pages': rst2man.found(),
     'Build flatpak interfaces': flatpak_intf_dir != '',
-    'Sandboxed image validation': use_bwrap,
+    'Sandboxed image validation': bwrap.found(),
   },
   section: 'Optional builds',
   bool_yn: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -51,6 +51,6 @@ option('man-pages',
        value: 'auto',
        description: 'Build man pages (requires rst2man)')
 option('sandboxed-image-validation',
-       type: 'boolean',
-       value: true,
+       type: 'feature',
+       value: 'enabled',
        description: 'Use Bubblewrap to sandbox image validation. Disabling this option may lead to security vulnerabilities.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -162,19 +162,16 @@ configure_file(
   install_dir: dbus_service_dir,
 )
 
-helper_def = ''
+validate_icon_c_args = ['-D_GNU_SOURCE=1']
 if bwrap.found()
-  helper_def = '-DHELPER="@0@"'.format(bwrap.full_path())
+  validate_icon_c_args += '-DHELPER="@0@"'.format(bwrap.full_path())
 endif
 
 executable(
   'xdg-desktop-portal-validate-icon',
   'validate-icon.c',
   dependencies: [gdk_pixbuf_dep],
-  c_args: [
-      '-D_GNU_SOURCE=1',
-      helper_def
-  ],
+  c_args: validate_icon_c_args,
   install: true,
   install_dir: libexecdir,
 )

--- a/src/validate-icon.c
+++ b/src/validate-icon.c
@@ -119,6 +119,8 @@ validate_icon (const char *arg_width,
   return 0;
 }
 
+#ifdef HELPER
+
 G_GNUC_NULL_TERMINATED
 static void
 add_args (GPtrArray *argv_array, ...)
@@ -131,21 +133,6 @@ add_args (GPtrArray *argv_array, ...)
     g_ptr_array_add (argv_array, g_strdup (arg));
   va_end (args);
 }
-
-const char *
-flatpak_get_bwrap (void)
-{
-  const char *e = g_getenv ("FLATPAK_BWRAP");
-
-  if (e != NULL)
-    return e;
-#ifdef HELPER
-  return HELPER;
-#else
-  return NULL;
-#endif
-}
-
 
 static gboolean
 path_is_usrmerged (const char *dir)
@@ -164,6 +151,17 @@ path_is_usrmerged (const char *dir)
 
   return (stat_buf_src.st_dev == stat_buf_target.st_dev) &&
          (stat_buf_src.st_ino == stat_buf_target.st_ino);
+}
+
+const char *
+flatpak_get_bwrap (void)
+{
+  const char *e = g_getenv ("FLATPAK_BWRAP");
+
+  if (e != NULL)
+    return e;
+
+  return HELPER;
 }
 
 static int
@@ -249,6 +247,7 @@ rerun_in_sandbox (const char *arg_width,
   g_printerr ("Icon validation: execvpe %s: %s\n", flatpak_get_bwrap (), g_strerror (errno));
   return 1;
 }
+#endif
 
 static gboolean opt_sandbox;
 


### PR DESCRIPTION
this fixed #1197.

the last commit also changes the bwrap flag to be a feature enabled by default, thus allowing to make sure bwrap is not searched for when disabled.

it now also prints the warning whenever bwrap is not found, be it because the user disabled the flag, or passed in `auto` and meson did not find bwrap.