### PR TITLE
doc: Fix broken rST refs

### DIFF
--- a/data/org.freedesktop.impl.portal.Access.xml
+++ b/data/org.freedesktop.impl.portal.Access.xml
@@ -37,7 +37,7 @@
         @subtitle: Subtitle for the dialog
         @body: Body text, may be ""
         @options: Vardict with optional further information
-        @response: Numeric response. The values allowed match the values allowed for #org.freedesktop.portal.Request::Response signal.
+        @response: Numeric response. The values allowed match the values allowed for :ref:`org.freedesktop.portal.Request::Response` signal.
         @results: Vardict with the results of the call
 
         Presents a "deny/grant" question to the user.
@@ -63,14 +63,14 @@
         * ``choices`` (``a(ssa(ss)s)``)
 
           List of serialized choices.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         The following results get returned via the @results vardict:
 
         * ``choices`` (``a(ss)``)
 
           An array of pairs of strings, corresponding to the passed-in choices.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
      -->
     <method name="AccessDialog">
       <arg type="o" name="handle" direction="in"/>

--- a/data/org.freedesktop.impl.portal.Clipboard.xml
+++ b/data/org.freedesktop.impl.portal.Clipboard.xml
@@ -36,7 +36,7 @@
         This portal does NOT create it's own session. Instead, it offers existing sessions
         created from other portals the option to integrate with the clipboard. For whether
         this interface is supported for a given session, refer to that portal's documentation.
-        See #org.freedesktop.portal.RemoteDesktop to integrate clipboard with the 
+        See :ref:`org.freedesktop.portal.RemoteDesktop` to integrate clipboard with the
         remote desktop session.
     -->
     <method name="RequestClipboard">
@@ -51,7 +51,7 @@
         Sets the owner of the clipboard formats in 'mime_types' in @options to
         the session, i.e. this session has data for the advertised clipboard formats.
 
-        See #org.freedesktop.portal.FileTransfer to transfer files using the
+        See :ref:`org.freedesktop.portal.FileTransfer` to transfer files using the
         'application/vnd.portal.filetransfer' mimetype.
 
         May only be called if clipboard access was given after starting the session.
@@ -150,10 +150,10 @@
 
         Notifies the session of a request for clipboard content of the given mime type.  The 
         callee provides a serial to track the request, which any 
-        org.freedesktop.portal.Clipboard.SelectionWrite() responses must use.
+        :ref:`org.freedesktop.portal.Clipboard.SelectionWrite` responses must use.
 
         Once the caller is done handling the 'SelectionTransfer' request, they must call
-        org.freedesktop.portal.Clipboard.SelectionWriteDone() with the corresponding request's serial
+        :ref:`org.freedesktop.portal.Clipboard.SelectionWriteDone` with the corresponding request's serial
         and whether the request completed successfully. If the request is not handled, the caller should
         respond by setting 'success' to 'false'.
 

--- a/data/org.freedesktop.impl.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.impl.portal.DynamicLauncher.xml
@@ -99,9 +99,9 @@
         The @response returned by this method is used to determine whether to
         give an install token to the caller, which can be used to avoid the need
         for a confirmation dialog; the token can be passed to the
-        org.freedesktop.portal.DynamicLauncher.Install() method just as if it
+        :ref:`org.freedesktop.portal.DynamicLauncher.Install` method just as if it
         were acquired via the
-        org.freedesktop.portal.DynamicLauncher.PrepareInstall() method.
+        :ref:`org.freedesktop.portal.DynamicLauncher.PrepareInstall` method.
 
         It is up to the portal implementation to decide whether this method is
         allowed based on the @app_id of the caller.

--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -64,22 +64,22 @@
         * ``filters`` (``a(sa(us))``)
 
           A list of serialized file filters.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``current_filter`` (``(sa(us))``)
 
           Request that this filter be set by default at dialog creation.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``choices`` (``a(ssa(ss)s)``)
 
           A list of serialized combo boxes.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``current_folder`` (``ay``)
 
           A suggested folder to open the files from.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         The following results get returned via the @results vardict:
 
@@ -91,12 +91,12 @@
         * ``choices`` (``a(ss)``)
 
           An array of pairs of strings, corresponding to the passed-in choices.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``current_filter`` (``(sa(us))``)
 
           The filter that was selected.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``writable`` (``b``)
 
@@ -142,17 +142,17 @@
         * ``filters`` (``a(sa(us))``)
 
           A list of serialized file filters.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``current_filter`` (``(sa(us))``)
 
           Request that this filter be set by default at dialog creation.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``choices`` (``a(ssa(ss)s)``)
 
           A list of serialized combo boxes.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``current_name`` (``s``)
 
@@ -176,12 +176,12 @@
         * ``choices`` (``a(ss)``)
 
           An array of pairs of strings, corresponding to the passed-in choices.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
         * ``current_filter`` (``(sa(us))``)
 
           The filter that was selected.
-          See org.freedesktop.portal.FileChooser.OpenFile() for details.
+          See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
     -->
     <method name="SaveFile">
       <arg type="o" name="handle" direction="in"/>
@@ -230,7 +230,7 @@
       * ``choices`` (``a(ssa(ss)s)``)
 
         List of serialized combo boxes.
-        See org.freedesktop.portal.FileChooser.OpenFile() for details.
+        See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
 
       * ``current_folder`` (``ay``)
 
@@ -243,7 +243,7 @@
         arrays are expected to be null-terminated.
 
       The following results get returned via the
-      #org.freedesktop.portal.Request::Response signal:
+      :ref:`org.freedesktop.portal.Request::Response` signal:
 
       * ``uris`` (``as``)
 
@@ -257,7 +257,7 @@
       * ``choices`` (``a(ss)``)
 
         An array of pairs of strings, corresponding to the passed-in choices.
-        See org.freedesktop.portal.FileChooser.OpenFile() for details.
+        See :ref:`org.freedesktop.portal.FileChooser.OpenFile` for details.
     -->
     <method name="SaveFiles">
       <arg type="o" name="handle" direction="in"/>

--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -32,9 +32,9 @@
     <!--
         CreateSession:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session being created
+        @session_handle: Object path for the ref:`org.freedesktop.impl.portal.Session` object representing the session being created
         @app_id: App id of the application
-        @options: Vardict with optional further information. See org.freedesktop.portal.GlobalShortcuts.CreateSession()
+        @options: Vardict with optional further information. See :ref:`org.freedesktop.portal.GlobalShortcuts.CreateSession`
         @response: Numeric Request response
         @results: Vardict with the results of the call
 
@@ -60,8 +60,8 @@
     <!--
         BindShortcuts:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
-        @shortcuts: The list of shortcuts to bind. See @org.freedesktop.portal.GlobalShortcuts.BindShortcuts
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
+        @shortcuts: The list of shortcuts to bind. See :ref:`org.freedesktop.portal.GlobalShortcuts.BindShortcuts`
         @parent_window: Identifier for the application window, see :ref:`Common Conventions <window-identifiers>`
         @shortcuts: The identifier of the shortcuts we intend to register, empty for all shortcuts
         @results: Vardict with the results of the call
@@ -69,8 +69,8 @@
         Bind the shortcuts of this session. This will typically result the portal
         presenting a dialog letting the user configure shortcut triggers.
 
-        The results get returned via the #org.freedesktop.portal.Request::Response
-        signal. See org.freedesktop.portal.GlobalShortcuts.BindShortcuts() for the
+        The results get returned via the :ref:`org.freedesktop.portal.Request::Response`
+        signal. See :ref:`org.freedesktop.portal.GlobalShortcuts.BindShortcuts` for the
         list of supported properties of shortcuts.
     -->
     <method name="BindShortcuts">
@@ -89,7 +89,7 @@
     <!--
         ListShortcuts:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @results: Vardict with the results of the call
 
         List shortcuts registered in the global shortcuts session.
@@ -100,8 +100,8 @@
 
           A list of shortcuts.
 
-          See the #org.freedesktop.portal.Request::Response signal of the
-          org.freedesktop.portal.GlobalShortcuts.BindShortcuts() method for
+          See the :ref:`org.freedesktop.portal.Request::Response` signal of the
+          :ref:`org.freedesktop.portal.GlobalShortcuts.BindShortcuts` method for
           the list of supported properties of shortcuts.
     -->
     <method name="ListShortcuts">
@@ -153,8 +153,8 @@
 
         Emitted when shortcuts are changed.
 
-        The results get returned via the #org.freedesktop.portal.Request::Response
-        signal. See org.freedesktop.portal.GlobalShortcuts.BindShortcuts() for the
+        The results get returned via the :ref:`org.freedesktop.portal.Request::Response`
+        signal. See :ref:`org.freedesktop.portal.GlobalShortcuts.BindShortcuts` for the
         list of supported properties of shortcuts.
     -->
     <signal name="ShortcutsChanged">

--- a/data/org.freedesktop.impl.portal.Inhibit.xml
+++ b/data/org.freedesktop.impl.portal.Inhibit.xml
@@ -38,7 +38,7 @@
         Inhibits session status changes. As a side-effect of this call,
         a :ref:`org.freedesktop.impl.portal.Request` object is exported on the
         object path @handle. To end the inhibition, call
-        org.freedesktop.impl.portal.Request.Close() on that object.
+        :ref:`org.freedesktop.impl.portal.Request.Close` on that object.
 
         The flags determine what changes are inhibited:
 
@@ -65,7 +65,7 @@
     <!--
         CreateMonitor:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the created #org.freedesktop.impl.portal.Session object
+        @session_handle: Object path for the created :ref:`org.freedesktop.impl.portal.Session` object
         @app_id: App id of the application
         @window: the parent window
         @response: the result of the operation (0 == success)
@@ -116,9 +116,9 @@
 
     <!--
       QueryEndResponse:
-      @session_handle: Object path for the #org.freedesktop.impl.portal.Session object
+      @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object
 
-      Acknowledges that the caller received the #org.freedesktop.impl.portal.Inhibit::StateChanged
+      Acknowledges that the caller received the :ref:`org.freedesktop.impl.portal.Inhibit::StateChanged`
       signal. This method should be called within one second or receiving a StateChanged
       signal with the 'Query End' state.
     -->

--- a/data/org.freedesktop.impl.portal.InputCapture.xml
+++ b/data/org.freedesktop.impl.portal.InputCapture.xml
@@ -23,7 +23,7 @@
 
       The Capture Input portal allows clients to capture input from local
       devices. This portal is mostly a 1:1 mapping of the
-      #org.freedesktop.portal.InputCapture portal, see that portal's
+      :ref:`org.freedesktop.portal.InputCapture` portal, see that portal's
       documentation for details on methods, signals and arguments.
 
       This documentation describes version 1 of this interface.
@@ -32,7 +32,7 @@
     <!--
         CreateSession:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session being created
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session being created
         @app_id: App id of the application
         @parent_window: Identifier for the application window, see :ref:`Common Conventions <window-identifiers>`
         @options: Vardict with optional further information
@@ -73,7 +73,7 @@
     <!--
         GetZones:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @options: Vardict with optional further information
         @response: Numeric response
@@ -106,7 +106,7 @@
     <!--
         SetPointerBarriers:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @options: Vardict with optional further information
         @barriers: An array of vardicts, each specifying one barrier
@@ -152,7 +152,7 @@
 
     <!--
         Enable:
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @options: Vardict with optional further information
 
@@ -170,7 +170,7 @@
 
     <!--
         Disable:
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @options: Vardict with optional further information
 
@@ -188,7 +188,7 @@
 
     <!--
         Release:
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @options: Vardict with optional further information
 
@@ -229,10 +229,10 @@
 
         Set up the connection to an EIS implementation. Once input capturing starts,
         input events are sent via the EI protocol between the compositor and the application.
-        This call must be invoked before org.freedesktop.portal.InputCapture.Enable().
+        This call must be invoked before :ref:`org.freedesktop.portal.InputCapture.Enable`.
 
         A session only needs to set this up once, the EIS implementation is not affected by
-        calls to Disable() and org.freedesktop.portal.InputCapture.Enable() -
+        calls to Disable() and :ref:`org.freedesktop.portal.InputCapture.Enable` -
         the same context can be re-used until the session is closed.
     -->
     <method name="ConnectToEIS">
@@ -245,7 +245,7 @@
     </method>
     <!--
         Disabled:
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @options: Vardict with optional further information
 
         The Disabled signal is emitted when the application will no longer
@@ -260,7 +260,7 @@
 
     <!--
         Activated:
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @options: Vardict with optional further information
 
         The Activated signal is emitted when input capture starts and input events
@@ -322,12 +322,12 @@
 
     <!--
         Deactivated:
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @options: Vardict with optional further information
 
         The Deactivated signal is emitted when input capture stopped and input events
         are no longer sent to the application. To prevent future input
-        capture, an application must call org.freedesktop.portal.InputCapture.Disable().
+        capture, an application must call :ref:`org.freedesktop.portal.InputCapture.Disable`.
 
         Supported keys in the @options vardict include:
 
@@ -355,12 +355,12 @@
 
     <!--
         ZonesChanged:
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @options: Vardict with optional further information
 
         The ZonesChanged signal is emitted when one or more of the zones
         available **to this session** change. An application should immediately call
-        org.freedesktop.portal.InputCapture.GetZones() to update its state of the zones.
+        :ref:`org.freedesktop.portal.InputCapture.GetZones` to update its state of the zones.
     -->
     <signal name="ZonesChanged">
       <arg type="o" name="session_handle" direction="out"/>

--- a/data/org.freedesktop.impl.portal.Notification.xml
+++ b/data/org.freedesktop.impl.portal.Notification.xml
@@ -40,7 +40,7 @@
         the notification is replaced by the new one.
 
         The format of the @notification is the same as for
-        org.freedesktop.portal.Notification.AddNotification().
+        :ref:`org.freedesktop.portal.Notification.AddNotification`.
     -->
     <method name="AddNotification">
       <arg type="s" name="app_id" direction="in"/>

--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -111,7 +111,7 @@
           Token that can be passed to a subsequent org.freedesktop.impl.portal.Print.Print() call to
           bypass the print dialog.
 
-        The org.freedesktop.portal.Print.Print() documentation has details about
+        The :ref:`org.freedesktop.portal.Print.Print` documentation has details about
         the supported keys in settings and page-setup.
     -->
     <method name="PreparePrint">

--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -60,7 +60,7 @@
     <!--
         SelectDevices:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @options: Vardict with optional further information
         @response: Numeric response
@@ -146,14 +146,14 @@
         * ``clipboard_enabled`` (``b``)
 
           A boolean for whether the clipboard was enabled ('true') or not ('false').
-          See the #org.freedesktop.portal.Clipboard documentation for more information.
+          See the :ref:`org.freedesktop.portal.Clipboard` documentation for more information.
 
           Since version 2.
 
         * ``streams`` (``a(ua{sv})``)
 
           Equivalent to the streams entry documented in
-          #org.freedesktop.impl.portal.ScreenCast.Start.
+          :ref:`org.freedesktop.impl.portal.ScreenCast.Start`.
 
         * ``devices`` (``u``)
 
@@ -199,7 +199,7 @@
         Notify about a new absolute pointer motion event. The (x, y) position
         represents the new pointer position in the streams logical coordinate
         space (see the logical_size stream property in
-        #org.freedesktop.portal.ScreenCast).
+        :ref:`org.freedesktop.portal.ScreenCast`).
     -->
     <method name="NotifyPointerMotionAbsolute">
       <arg type="o" name="session_handle" direction="in"/>
@@ -337,7 +337,7 @@
         Notify about a new touch down event. The (x, y) position
         represents the new touch point position in the streams logical
         coordinate space (see the ``logical_size`` stream property in
-        #org.freedesktop.portal.ScreenCast).
+        :ref:`org.freedesktop.portal.ScreenCast`).
     -->
     <method name="NotifyTouchDown">
       <arg type="o" name="session_handle" direction="in"/>
@@ -362,7 +362,7 @@
         Notify about a new touch motion event. The (x, y) position
         represents where the touch point position in the streams logical
         coordinate space moved (see the ``logical_size`` stream property in
-        #org.freedesktop.portal.ScreenCast).
+        :ref:`org.freedesktop.portal.ScreenCast`).
     -->
     <method name="NotifyTouchMotion">
       <arg type="o" name="session_handle" direction="in"/>

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -29,7 +29,7 @@
     <!--
         CreateSession:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session being created
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session being created
         @app_id: App id of the application
         @options: Vardict with optional further information
         @response: Numeric response
@@ -56,7 +56,7 @@
     <!--
         SelectSources:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @options: Vardict with optional further information
         @response: Numeric response
@@ -128,7 +128,7 @@
     <!--
         Start:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @session_handle: Object path for the #org.freedesktop.impl.portal.Session object representing the session
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` object representing the session
         @app_id: App id of the application
         @parent_window: Identifier for the application window, see :ref:`Common Conventions <window-identifiers>`
         @options: Vardict with optional further information

--- a/data/org.freedesktop.portal.Account.xml
+++ b/data/org.freedesktop.portal.Account.xml
@@ -53,7 +53,7 @@
           information to be included with recipes you share with your friends".
 
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``id`` (``s``)
 

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -65,7 +65,7 @@
           true to use D-Bus activation for autostart.
 
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``background`` (``b``)
 

--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -39,7 +39,7 @@
           object path element. See the :ref:`org.freedesktop.portal.Request` documentation for
           more information about the @handle.
 
-        Following the #org.freedesktop.portal.Request::Response signal, if
+        Following the :ref:`org.freedesktop.portal.Request::Response` signal, if
         granted, org.freedesktop.portal.Camera.OpenPipeWireRemote() can be used to
         open a PipeWire remote.
     -->

--- a/data/org.freedesktop.portal.Clipboard.xml
+++ b/data/org.freedesktop.portal.Clipboard.xml
@@ -38,7 +38,7 @@
         This portal does NOT create it's own session. Instead, it offers existing sessions
         created from other portals the option to integrate with the clipboard. For whether
         this interface is supported for a given session, refer to that portal's documentation.
-        See #org.freedesktop.portal.RemoteDesktop to integrate clipboard with the 
+        See :ref:`org.freedesktop.portal.RemoteDesktop` to integrate clipboard with the
         remote desktop session.
     -->
     <method name="RequestClipboard">
@@ -53,7 +53,7 @@
         Sets the owner of the clipboard formats in ``mime_types`` in @options to
         the session, i.e. this session has data for the advertised clipboard formats.
 
-        See #org.freedesktop.portal.FileTransfer to transfer files using the
+        See :ref:`org.freedesktop.portal.FileTransfer` to transfer files using the
         ``application/vnd.portal.filetransfer`` mimetype.
 
         May only be called if clipboard access was given after starting the session.

--- a/data/org.freedesktop.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.portal.DynamicLauncher.xml
@@ -138,7 +138,7 @@
           If true, the user will be able to edit the icon of the launcher,
           if the implementation supports this. Defaults to false.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``name`` (``s``)
 

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -128,7 +128,7 @@
         The portal implementation is free to ignore this option.
 
 
-      The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+      The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
       * ``uris`` (``as``)
 
@@ -218,7 +218,7 @@
         system. The byte array is expected to be terminated by a nul byte.
 
 
-      The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+      The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
       * ``uris`` (``as``)
 
@@ -309,7 +309,7 @@
 
 
       The following results get returned via the
-      #org.freedesktop.portal.Request::Response signal:
+      :ref:`org.freedesktop.portal.Request::Response` signal:
 
       * ``uris`` (``as``)
 

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -63,7 +63,7 @@
           object path element. See the org.freedesktop.portal.Session documentation for
           more information about the session handle.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``session_handle`` (``o``)
 
@@ -110,7 +110,7 @@
           :ref:`org.freedesktop.portal.Request` documentation for more
           information about the @handle.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the ref::`org.freedesktop.portal.Request::Response` signal:
 
         * ``shortcuts`` (``a(sa{sv})``)
 
@@ -118,7 +118,7 @@
           below, and is different from the @shortcuts variable of this method.
 
         Each element of the @shortcuts array returned by the
-        #org.freedesktop.portal.Request::Response signal is a tuple composed of
+        :ref:`org.freedesktop.portal.Request::Response` signal is a tuple composed of
         a shortcut id, and a vardict with the following keys:
 
         * ``description`` (``s``)
@@ -157,13 +157,13 @@
           :ref:`org.freedesktop.portal.Request` documentation for more
           information about the @handle.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``shortcuts`` (``a(sa{sv})``)
 
           A list of shortcuts.
 
-          See the #org.freedesktop.portal.Request::Response signal of the
+          See the :ref:`org.freedesktop.portal.Request::Response` signal of the
           org.freedesktop.portal.GlobalShortcuts.BindShortcuts() method for
           the list of supported properties of shortcuts.
     -->
@@ -215,7 +215,7 @@
 
         Indicates that the information associated with some of the shortcuts has changed.
 
-        See the #org.freedesktop.portal.Request::Response signal of the
+        See the :ref:`org.freedesktop.portal.Request::Response` signal of the
         org.freedesktop.portal.GlobalShortcuts.BindShortcuts() method for the
         list of supported properties of shortcuts.
     -->

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -37,7 +37,7 @@
         @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
 
         Inhibits a session status changes. To remove the inhibition,
-        call org.freedesktop.portal.Request.Close() on the returned
+        call :ref:`org.freedesktop.portal.Request.Close` on the returned
         handle.
 
         The flags determine what changes are inhibited:
@@ -79,7 +79,7 @@
         A successfully created session can at any time be closed using
         org.freedesktop.portal.Session::Close, or may at any time be closed
         by the portal implementation, which will be signalled via
-        #org.freedesktop.portal.Session::Closed.
+        :ref:`org.freedesktop.portal.Session::Closed`.
 
         Supported keys in the @options vardict include:
 
@@ -95,7 +95,7 @@
           object path element. See the :ref:`org.freedesktop.portal.Session` documentation for
           more information about the session handle.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``session_handle`` (``o``)
 

--- a/data/org.freedesktop.portal.InputCapture.xml
+++ b/data/org.freedesktop.portal.InputCapture.xml
@@ -61,9 +61,9 @@
         @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
 
         Create a capture input session. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session.Close(), or may
+        any time be closed using :ref:`org.freedesktop.portal.Session.Close`, or may
         at any time be closed by the portal implementation, which will be
-        signalled via #org.freedesktop.portal.Session::Closed.
+        signalled via :ref:`org.freedesktop.portal.Session::Closed`.
 
         Supported keys in the @options vardict include:
 
@@ -84,7 +84,7 @@
           Bitmask of requested capabilities, see the SupportedCapabilities property.
           This value is required and must not be zero.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``session_handle`` (``o``)
 
@@ -148,7 +148,7 @@
         the zone_set ID by a sensible amount to allow for
         wrapping detection.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``zones`` (``a(uuii)``)
 
@@ -239,7 +239,7 @@
           pointer barrier must have y1 == y2, a vertical pointer barrier
           must have x1 == x2. Diagonal pointer barriers are not supported.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``failed_barriers`` (``au``)
 

--- a/data/org.freedesktop.portal.Location.xml
+++ b/data/org.freedesktop.portal.Location.xml
@@ -35,9 +35,9 @@
         @handle: Object path for the created :ref:`org.freedesktop.portal.Session` object
 
         Create a location session. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session.Close(), or may
+        any time be closed using :ref:`org.freedesktop.portal.Session.Close`, or may
         at any time be closed by the portal implementation, which will be
-        signalled via #org.freedesktop.portal.Session::Closed.
+        signalled via :ref:`org.freedesktop.portal.Session::Closed`.
 
         Supported keys in the @options vardict include:
 

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -110,7 +110,7 @@
 
           This option was added in version 2.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``settings`` (``a{sv}``)
 

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -38,14 +38,14 @@
 
         A remote desktop session may only be started and stopped with this interface,
         but you can use the :ref:`org.freedesktop.portal.Session` object created with this
-        method together with certain methods on the #org.freedesktop.portal.ScreenCast and
-        #org.freedesktop.portal.Clipboard interfaces. Specifically, you can call
-        org.freedesktop.portal.ScreenCast.SelectSources() to also get screen content,
-        and org.freedesktop.portal.ScreenCast.OpenPipeWireRemote() to acquire a file
-        descriptor for a PipeWire remote. See #org.freedesktop.portal.ScreenCast for
+        method together with certain methods on the :ref:`org.freedesktop.portal.ScreenCast` and
+        :ref:`org.freedesktop.portal.Clipboard` interfaces. Specifically, you can call
+        :ref:`org.freedesktop.portal.ScreenCast.SelectSources` to also get screen content,
+        and :ref:`org.freedesktop.portal.ScreenCast.OpenPipeWireRemote` to acquire a file
+        descriptor for a PipeWire remote. See :ref:`org.freedesktop.portal.ScreenCast` for
         more information on how to use those methods. To capture clipboard content,
-        you can call org.freedesktop.portal.Clipboard.RequestClipboard(). See 
-        #org.freedesktop.portal.Clipboard for more information on the clipboard
+        you can call :ref:`org.freedesktop.portal.Clipboard.RequestClipboard`. See
+        :ref:`org.freedesktop.portal.Clipboard` for more information on the clipboard
         integration.
 
         Supported keys in the @options vardict include:
@@ -63,7 +63,7 @@
           more information about the session handle.
 
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``session_handle`` (``o``)
 
@@ -120,7 +120,7 @@
           - ``2``: Permissions persist until explicitly revoked
 
           If the permission for the session to persist is granted, a restore token will
-          be returned via the #org.freedesktop.portal.Request::Response signal of the
+          be returned via the :ref:`org.freedesktop.portal.Request::Response` signal of the
           start method used to start the session.
 
           This option was added in version 2 of this interface.
@@ -153,7 +153,7 @@
           more information about the @handle.
 
         The following results get returned via the
-        #org.freedesktop.portal.Request::Response signal:
+        :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``devices`` (``u``)
 
@@ -162,7 +162,7 @@
         * ``clipboard_enabled`` (``b``)
 
           A boolean for whether the clipboard was enabled ('true') or not ('false').
-          See the #org.freedesktop.portal.Clipboard documentation for more information.
+          See the :ref:`org.freedesktop.portal.Clipboard` documentation for more information.
           Since version 2.
 
         * ``restore_token`` (``s``)
@@ -174,7 +174,7 @@
           This response option was added in version 2 of this interface.
 
         If a screen cast source was selected, the results of the
-        #org.freedesktop.portal.ScreenCast.Start response signal may be
+        :ref:`org.freedesktop.portal.ScreenCast.Start` response signal may be
         included.
     -->
     <method name="Start">
@@ -211,7 +211,7 @@
         Notify about a new absolute pointer motion event. The (x, y) position
         represents the new pointer position in the streams logical coordinate
         space (see the logical_size stream property in
-        #org.freedesktop.portal.ScreenCast).
+        :ref:`org.freedesktop.portal.ScreenCast`).
     -->
     <method name="NotifyPointerMotionAbsolute">
       <arg type="o" name="session_handle" direction="in"/>
@@ -350,7 +350,7 @@
         Notify about a new touch down event. The (x, y) position
         represents the new touch point position in the streams logical
         coordinate space (see the logical_size stream property in
-        #org.freedesktop.portal.ScreenCast).
+        :ref:`org.freedesktop.portal.ScreenCast`).
     -->
     <method name="NotifyTouchDown">
       <arg type="o" name="session_handle" direction="in"/>
@@ -375,7 +375,7 @@
         Notify about a new touch motion event. The (x, y) position
         represents where the touch point position in the streams logical
         coordinate space moved (see the logical_size stream property in
-        #org.freedesktop.portal.ScreenCast).
+        :ref:`org.freedesktop.portal.ScreenCast`).
     -->
     <method name="NotifyTouchMotion">
       <arg type="o" name="session_handle" direction="in"/>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -32,9 +32,9 @@
         @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
 
         Create a screen cast session. A successfully created session can at
-        any time be closed using org.freedesktop.portal.Session.Close(), or may
+        any time be closed using :ref:`org.freedesktop.portal.Session.Close`, or may
         at any time be closed by the portal implementation, which will be
-        signalled via #org.freedesktop.portal.Session::Closed.
+        signalled via :ref:`org.freedesktop.portal.Session::Closed`.
 
         Supported keys in the @options vardict include:
 
@@ -50,7 +50,7 @@
               object path element. See the :ref:`org.freedesktop.portal.Session` documentation for
               more information about the session handle.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``session_handle`` (``o``)
 
@@ -95,7 +95,7 @@
 
           Determines how the cursor will be drawn in the screen cast stream. It must be
           one of the cursor modes advertised in
-          #org.freedesktop.portal.ScreenCast.AvailableCursorModes. Setting a cursor mode
+          :ref:`org.freedesktop.portal.ScreenCast:AvailableCursorModes`. Setting a cursor mode
           not advertised will cause the screen cast session to be closed. The default
           cursor mode is 'Hidden'.
 
@@ -116,7 +116,7 @@
 
           Setting a restore_token is only allowed for screen cast sessions.
           Persistent remote desktop screen cast sessions can only be handled
-          via the #org.freedesktop.portal.RemoteDesktop interface.
+          via the :ref:`org.freedesktop.portal.RemoteDesktop` interface.
 
           This option was added in version 4 of this interface.
 
@@ -130,11 +130,11 @@
 
           Setting persist_mode is only allowed for screen cast sessions. Persistent
           remote desktop screen cast sessions can only be handled via the
-          #org.freedesktop.portal.RemoteDesktop interface.
+          :ref:`org.freedesktop.portal.RemoteDesktop` interface.
 
           If the permission for the session to persist is granted, a restore token will
-          be returned via the #org.freedesktop.portal.Request::Response signal of the
-          #org.freedesktop.portal.ScreenCast.Start method.
+          be returned via the :ref:`org.freedesktop.portal.Request::Response` signal of the
+          :ref:`org.freedesktop.portal.ScreenCast.Start` method.
 
           This option was added in version 4 of this interface.
 
@@ -169,7 +169,7 @@
           more information about the @handle.
 
         The following results get returned via the
-        #org.freedesktop.portal.Request::Response signal:
+        :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``streams`` (``a(ua{sv})``)
 

--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -57,7 +57,7 @@
           Hint whether the dialog should offer customization before taking a screenshot.
           Default is no.  **Since version 2.**
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response`
         signal:
 
         * ``uri`` (``s``)
@@ -85,7 +85,7 @@
           object path element. See the :ref:`org.freedesktop.portal.Request` documentation for
           more information about the @handle.
 
-        The following results get returned via the #org.freedesktop.portal.Request::Response signal:
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
         * ``color`` (``(ddd)``)
 

--- a/data/org.freedesktop.portal.Secret.xml
+++ b/data/org.freedesktop.portal.Secret.xml
@@ -54,7 +54,7 @@
 
         The portal may return an additional identifier associated with
         the secret in the results vardict of
-        #org.freedesktop.portal.Request::Response signal. In the next
+        :ref:`org.freedesktop.portal.Request::Response` signal. In the next
         call of this method, the application shall indicate it through
         a token element in @options.
 


### PR DESCRIPTION
Unfortunately relies on https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3751 to have fixed anchors generation to fix them all.

Fix all broken rST refs  (red links) in the documentation.