### PR TITLE
docs: Add more detail to the OpenDirectory() method

### DIFF
--- a/data/org.freedesktop.portal.OpenURI.xml
+++ b/data/org.freedesktop.portal.OpenURI.xml
@@ -133,7 +133,9 @@
         @options: Vardict with optional further information
         @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
 
-        Asks to open the directory containing a local file in the file browser.
+        Asks to open the directory containing a local file in the file browser. This is implemented using
+        the ``org.freedesktop.FileManager1.ShowItems()`` D-Bus API and if that service doesn't exist falls back
+        to the ``OpenURI`` method on the directory of the file.
 
         Supported keys in the @options vardict include:
 


### PR DESCRIPTION
This clarifies in more detail why you would use this over OpenFile() and how it operates in general.