### PR TITLE
impl-request: Do not load properties on construction

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -189,7 +189,7 @@ handle_get_user_information (XdpDbusAccount *object,
   REQUEST_AUTOLOCK (request);
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);

--- a/src/background.c
+++ b/src/background.c
@@ -917,7 +917,7 @@ handle_request_background (XdpDbusBackground *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (access_impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (access_impl)),
                                           request->id,
                                           NULL, &error);

--- a/src/device.c
+++ b/src/device.c
@@ -150,7 +150,7 @@ device_query_permission_sync (const char *app_id,
         }
 
       impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                           G_DBUS_PROXY_FLAGS_NONE,
+                                                           G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                            g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                            request->id,
                                                            NULL, &error);
@@ -297,7 +297,7 @@ handle_access_device (XdpDbusDevice *object,
   g_object_set_data_full (G_OBJECT (request), "device", g_strdup (devices[0]), g_free);
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);

--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -600,7 +600,7 @@ handle_prepare_install (XdpDbusDynamicLauncher *object,
   REQUEST_AUTOLOCK (request);
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);

--- a/src/email.c
+++ b/src/email.c
@@ -219,7 +219,7 @@ handle_compose_email (XdpDbusEmail *object,
   REQUEST_AUTOLOCK (request);
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -571,7 +571,7 @@ handle_open_file (XdpDbusFileChooser *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -737,7 +737,7 @@ handle_save_file (XdpDbusFileChooser *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -842,7 +842,7 @@ handle_save_files (XdpDbusFileChooser *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);

--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -238,7 +238,7 @@ handle_create_session (XdpDbusGlobalShortcuts *object,
   options = g_variant_builder_end (&options_builder);
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -416,7 +416,7 @@ handle_bind_shortcuts (XdpDbusGlobalShortcuts *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -531,7 +531,7 @@ handle_list_shortcuts (XdpDbusGlobalShortcuts *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -225,7 +225,7 @@ handle_inhibit (XdpDbusInhibit *object,
   g_object_set_data_full (G_OBJECT (request), "options", g_variant_ref (options), (GDestroyNotify)g_variant_unref);
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);
@@ -406,7 +406,7 @@ handle_create_monitor (XdpDbusInhibit *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);

--- a/src/input-capture.c
+++ b/src/input-capture.c
@@ -240,7 +240,7 @@ handle_create_session (XdpDbusInputCapture   *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -402,7 +402,7 @@ handle_get_zones (XdpDbusInputCapture   *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -557,10 +557,10 @@ handle_set_pointer_barriers (XdpDbusInputCapture   *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                     G_DBUS_PROXY_FLAGS_NONE,
-                                     g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
-                                     request->id,
-                                     NULL, &error);
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
+                                          g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
+                                          request->id,
+                                          NULL, &error);
   if (!impl_request)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);

--- a/src/location.c
+++ b/src/location.c
@@ -515,7 +515,7 @@ handle_start_in_thread_func (GTask *task,
       const char *body;
 
       impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (access_impl)),
-                                                           G_DBUS_PROXY_FLAGS_NONE,
+                                                           G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                            g_dbus_proxy_get_name (G_DBUS_PROXY (access_impl)),
                                                            request->id,
                                                            NULL, NULL);

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -897,7 +897,7 @@ handle_open_in_thread_func (GTask *task,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, NULL);

--- a/src/print.c
+++ b/src/print.c
@@ -132,7 +132,7 @@ handle_print (XdpDbusPrint *object,
   REQUEST_AUTOLOCK (request);
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);
@@ -245,7 +245,7 @@ handle_prepare_print (XdpDbusPrint *object,
   REQUEST_AUTOLOCK (request);
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -313,7 +313,7 @@ handle_create_session (XdpDbusRemoteDesktop *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -540,7 +540,7 @@ handle_select_devices (XdpDbusRemoteDesktop *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -757,7 +757,7 @@ handle_start (XdpDbusRemoteDesktop *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -1682,3 +1682,4 @@ remote_desktop_session_class_init (RemoteDesktopSessionClass *klass)
   quark_request_session =
     g_quark_from_static_string ("-xdp-request-remote-desktop-session");
 }
+

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -231,7 +231,7 @@ handle_create_session (XdpDbusScreenCast *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -555,7 +555,7 @@ handle_select_sources (XdpDbusScreenCast *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -892,7 +892,7 @@ handle_start (XdpDbusScreenCast *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -302,7 +302,7 @@ query_impl:
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);
@@ -412,7 +412,7 @@ handle_pick_color (XdpDbusScreenshot *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);

--- a/src/secret.c
+++ b/src/secret.c
@@ -136,7 +136,7 @@ handle_retrieve_secret (XdpDbusSecret *object,
 
   impl_request =
     xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                           g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                           request->id,
                                           NULL, &error);

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -273,7 +273,7 @@ handle_set_wallpaper_in_thread_func (GTask *task,
     }
 
   impl_request = xdp_dbus_impl_request_proxy_new_sync (g_dbus_proxy_get_connection (G_DBUS_PROXY (impl)),
-                                                       G_DBUS_PROXY_FLAGS_NONE,
+                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                                                        g_dbus_proxy_get_name (G_DBUS_PROXY (impl)),
                                                        request->id,
                                                        NULL, &error);


### PR DESCRIPTION
The org.freedesktop.impl.portal.Request interface has no properties, and is constructed against a different object path. We don't need to fetch properties for that.

Don't do that.

Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1241