### PR TITLE
ci: automate releases and refactor ci

### DIFF
--- a/.github/workflows/Containerfile
+++ b/.github/workflows/Containerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:latest
+
+RUN apt update
+RUN apt upgrade -y
+
+# Install dependencies
+RUN apt install -y --no-install-recommends \
+	    gcc clang \
+	    ca-certificates \
+	    desktop-file-utils \
+	    fuse3 \
+	    gettext \
+	    git \
+	    gnome-desktop-testing \
+	    gtk-doc-tools \
+	    libcap2-bin \
+	    libflatpak-dev \
+	    libfontconfig1-dev \
+	    libfuse3-dev \
+	    libgdk-pixbuf-2.0-dev \
+	    libgeoclue-2-dev \
+	    libglib2.0-dev \
+	    libjson-glib-dev \
+	    libpipewire-0.3-dev \
+	    libportal-dev \
+	    libsystemd-dev \
+	    libtool \
+	    llvm \
+	    python3-gi \
+	    shared-mime-info
+
+# Install meson
+RUN apt install -y --no-install-recommends meson
+
+# Install pytest
+RUN apt install -y --no-install-recommends \
+	    python3-pytest \
+	    python3-pytest-xdist \
+	    python3-dbusmock \
+	    python3-dbus

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,25 @@
+name: Create build container
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and push container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          file: .github/workflows/Containerfile
+          tags: ghcr.io/${{ github.repository_owner }}/xdg-desktop-portal-build:latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,135 +3,66 @@ name: Portal CI
 on: [push, pull_request]
 
 env:
-  DEBIAN_FRONTEND: noninteractive
   TESTS_TIMEOUT: 10 # in minutes
 
 jobs:
   check:
-    name: Ubuntu 22.04 build
-    runs-on: ubuntu-22.04
+    name: CI Build
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         compiler: ['gcc', 'clang']
         sanitizer: ['address']
 
-    env:
-      UBUNTU_VERSION: '22.04'
-      CC: ${{ matrix.compiler }}
-      BASE_CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
-      BUILD_CONTAINER: ${{ matrix.compiler }}-build-container
-      RUN_CMD: docker exec -t -w /src -e TEST_IN_CI -e ASAN_OPTIONS -e G_MESSAGES_DEBUG -e XDG_DATA_DIRS ${{ matrix.compiler }}-build-container
-      AS_USER: runuser -u tester --
-      BUILDDIR: builddir
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/xdg-desktop-portal-build:latest
+      env:
+        CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
+        CC: ${{ matrix.compiler }}
+        TEST_IN_CI: 1
+        G_MESSAGES_DEBUG: all
+      options: --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined
 
     steps:
-    - name: Prepare environment
-      id: env-setup
-      run: |
-        echo "cflags=$BASE_CFLAGS" >> $GITHUB_OUTPUT;
+      - name: Configure environment
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          echo XDG_DATA_DIRS=$GITHUB_WORKSPACE/tests/share:/usr/local/share:/usr/share | tee -a $GITHUB_ENV
 
-    - name: Prepare container
-      run: |
-        docker run --name $BUILD_CONTAINER \
-          --tty --device /dev/fuse --cap-add SYS_ADMIN \
-          --security-opt apparmor:unconfined \
-          -v $(pwd):/src \
-          -e DEBIAN_FRONTEND \
-          -e DEBCONF_NONINTERACTIVE_SEEN=true \
-          -e TERM=dumb \
-          -e MAKEFLAGS="-j $(getconf _NPROCESSORS_ONLN)" \
-          -e CC -e CFLAGS="${{ steps.env-setup.outputs.cflags }}" \
-          -d ubuntu:$UBUNTU_VERSION sleep infinity
+      - name: Check out xdg-desktop-portal
+        uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        $RUN_CMD apt-get update --quiet
-        $RUN_CMD apt-get upgrade --quiet -y
-        $RUN_CMD apt-get install --quiet -y --no-install-recommends \
-          ${{ matrix.compiler }} \
-          desktop-file-utils \
-          fuse3 \
-          gettext \
-          git \
-          gnome-desktop-testing \
-          gtk-doc-tools \
-          libcap2-bin \
-          libflatpak-dev \
-          libfontconfig1-dev \
-          libfuse3-dev \
-          libgdk-pixbuf-2.0-dev \
-          libgeoclue-2-dev \
-          libglib2.0-dev \
-          libjson-glib-dev \
-          libpipewire-0.3-dev \
-          libportal-dev \
-          libsystemd-dev \
-          libtool \
-          llvm \
-          python3-gi \
-          shared-mime-info
+      - name: Build xdg-desktop-portal
+        run: |
+          meson setup _build $MESON_OPTIONS
+          meson compile -C _build
+        env:
+          MESON_OPTIONS: -Dinstalled-tests=true -Dpytest=enabled -Db_sanitize=${{ matrix.sanitizer }}
 
-    - name: Install dependencies for meson
-      run: |
-        $RUN_CMD apt-get install --quiet -y --no-install-recommends \
-          meson
+      - name: Run xdg-desktop-portal tests
+        run: timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C _build
 
-    - name: Install dependencies for the pytest test suite
-      run: |
-        $RUN_CMD apt-get install --quiet -y --no-install-recommends \
-          python3-pytest python3-pytest-xdist python3-dbusmock python3-dbus
+      - name: Install xdg-desktop-portal
+        run: meson install -C _build
 
-    - name: Check out xdg-desktop-portal
-      uses: actions/checkout@v3
-
-    - name: Setup test user
-      run: |
-        $RUN_CMD adduser --disabled-password --gecos "" tester
-        $RUN_CMD chown tester:tester . -R
-
-    - name: Build xdg-desktop-portal
-      run: |
-        $RUN_CMD $AS_USER meson setup ${BUILDDIR} $MESON_OPTIONS
-        $RUN_CMD $AS_USER meson compile -C ${BUILDDIR}
-      env:
-        MESON_OPTIONS: -Dinstalled-tests=true -Dpytest=enabled -Db_sanitize=${{ matrix.sanitizer }}
-
-    - name: Run xdg-desktop-portal tests
-      run: $RUN_CMD $AS_USER timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR}
-      env:
-        TEST_IN_CI: 1
-        G_MESSAGES_DEBUG: all
-
-    - name: Install xdg-desktop-portal
-      run: $RUN_CMD meson install -C ${BUILDDIR}
-
-    - name: Run xdg-desktop-portal installed-tests
-      run: |
-        test -n "$($RUN_CMD $AS_USER gnome-desktop-testing-runner -l xdg-desktop-portal)"
-        $RUN_CMD $AS_USER \
-          env TEST_INSTALLED_IN_CI=1 XDG_DATA_DIRS=/src/tests/share/:$XDG_DATA_DIRS \
+      - name: Run xdg-desktop-portal installed-tests
+        run: |
+          test -n "$(gnome-desktop-testing-runner -l xdg-desktop-portal)"
           gnome-desktop-testing-runner --report-directory installed-test-logs/ \
             -t $((TESTS_TIMEOUT * 60)) xdg-desktop-portal
-      env:
-        G_MESSAGES_DEBUG: all
-        TEST_IN_CI: 1
-        XDG_DATA_DIRS: /usr/local/share:/usr/share
 
-    - name: Create dist tarball
-      run: |
-        $RUN_CMD $AS_USER ls -la
-        $RUN_CMD $AS_USER timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson dist -C ${BUILDDIR}
-      env:
-        TEST_IN_CI: 1
-        G_MESSAGES_DEBUG: all
+      - name: Create dist tarball
+        run: |
+          ls -la
+          timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson dist -C _build
 
-    - name: Upload test logs
-      uses: actions/upload-artifact@v3
-      if: success() || failure()
-      with:
-        name: test logs
-        path: |
-          tests/*.log
-          test-*.log
-          installed-test-logs/
-          builddir/meson-logs/testlog.txt
+      - name: Upload test logs
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: test logs
+          path: |
+            tests/*.log
+            test-*.log
+            installed-test-logs/
+            builddir/meson-logs/testlog.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (default: auto)"
+      preRelease:
+        description: "Is this a pre-release? (true/false, default: auto)"
+      dryRun:
+        description: Dry Run
+        default: false
+
+jobs:
+  release:
+    name: Build and publish a release
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/xdg-desktop-portal-build:latest
+    permissions:
+      contents: write
+    steps:
+      - name: Configure git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Update translation files
+        if: ${{ !fromJSON(github.event.inputs.dryRun) }}
+        run: |
+          meson setup . _build
+          meson compile -C _build/ xdg-desktop-portal-update-po
+          git add po/*po
+          git commit -m "Update po files"
+          git push
+          git clean -fxd
+
+      - name: Build xdg-desktop-portal
+        if: ${{ !fromJSON(github.event.inputs.dryRun) }}
+        run: |
+          meson setup . _build
+          meson dist -C _build
+
+      - name: Extract release information
+        env:
+          releaseVersion: ${{ github.event.inputs.version }}
+          preRelease: ${{ github.event.inputs.preRelease }}
+        run: |
+          # Extract the release version
+          if [ -z $releaseVersion ]; then
+            releaseVersion=`perl -0777nE 'print $& if /(?<=Changes in ).*/' NEWS`
+          fi
+          echo "releaseVersion=$releaseVersion" | tee -a $GITHUB_ENV
+
+          # Extract the changelog
+          {
+            echo "releaseChangelog<<EOF"
+            perl -0777nE 'print $& if /(?<=\n\n).*?(?=\n\n)/sg' NEWS
+            echo -e "\nEOF"
+          } | tee -a $GITHUB_ENV
+
+          # Check if version is a pre-release
+          if [ -z $preRelease ]; then
+            preRelease=$((`echo $releaseVersion | cut -d '.' -f2` % 2))
+          fi
+          {
+            echo -n "preRelease="
+            if [ $preRelease = 1 ]; then
+              echo "true";
+            else
+              echo "false";
+            fi
+          } | tee -a $GITHUB_ENV
+          
+      - name: Tag release
+        if: ${{ !fromJSON(github.event.inputs.dryRun) }}
+        run: |
+          git tag $releaseVersion
+          git push --tags
+
+      - name: Create release
+        if: ${{ !fromJSON(github.event.inputs.dryRun) }}
+        uses: ncipollo/release-action@v1.13.0
+        with:
+          tag: ${{ env.releaseVersion }}
+          body: ${{ env.releaseChangelog }}
+          prerelease: ${{ env.preRelease }}
+          artifacts: _build/meson-dist/*

--- a/RELEASE_HOWTO.md
+++ b/RELEASE_HOWTO.md
@@ -1,21 +1,9 @@
 # Steps for doing a xdg-desktop-portal release
 
- - git clean -fxd
- - meson setup . _build && meson compile -C _build/ xdg-desktop-portal-update-po
- - git add po/*po &&  git commit -m "Update po files"
- - git clean -fxd
- - add content to NEWS
- - git commit -m <version>
- - git push origin main
- - meson setup . _build -Ddocbook-docs=enabled 
- - meson dist -C _build
- - git tag <version>
- - git push origin refs/tags/<version>
- - upload tarball to github as release
- - edit release, copy NEWS section in
- - update portal api docs in the gh-pages branch
- - bump version in meson.build
- - git commit -m "Post-release version bump"
- - git push origin main
- - Update SECURITY.md if this is a new stable release
- - Update .github/ISSUE_TEMPLATE/bug-report.yml if this is a new stable release
+- Make sure the version in `meson.build` is correct
+- Add your changelog to the `NEWS` file
+- Run the "Release new version" GitHub Action
+  - The options are taken from the last `NEWS` entry by default, you may override them if needed
+- Bump version in `meson.build`
+- Update `SECURITY.md` if this is a new stable release
+- Update `.github/ISSUE_TEMPLATE/bug-report.yml` if this is a new stable release


### PR DESCRIPTION
- Automate releases using GitHub Actions (closes #1090)
- Manage CI dependencies in an automatically updating Docker image (closes #667)
- Completely rewrite the CI Tests action to make it much simpler

cc @GeorgesStavracas 