### PR TITLE
doc: fix typo in the portals.conf example

### DIFF
--- a/doc/portals.conf.rst.in
+++ b/doc/portals.conf.rst.in
@@ -126,8 +126,8 @@ EXAMPLE
   [preferred]
   # Use xdg-desktop-portal-gtk for every portal interface...
   default=gtk
-  # ... except for the Screencast interface
-  org.freedesktop.impl.portal.Screencast=gnome
+  # ... except for the ScreenCast interface
+  org.freedesktop.impl.portal.ScreenCast=gnome
 
 
 ENVIRONMENT


### PR DESCRIPTION
The ScreenCast interface name was misspelled and the typo has been already copied to various projects.