### PR TITLE
docs: clarify guarantees of the File Chooser API

### DIFF
--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -28,8 +28,8 @@
       backend will present the user with a file chooser dialog.
 
       The selected files will be made accessible to the application
-      via the document portal, and the returned URI will point
-      into the document portal fuse filesystem in ``/run/user/$UID/doc/``.
+      (which may involve adding it to the :ref:`Documents
+      portal<org.freedesktop.portal.Documents>`).
 
       This documentation describes version 4 of this interface.
   -->


### PR DESCRIPTION
The application should not depend on where the URL points, or how access to the file is granted, just that access has been granted at that URL.

@matthiasclasen, I've set you as the commit author since I used the wording you suggested on Matrix.