### PR TITLE
docs: clarify guarantees of the Screenshot API

### DIFF
--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -25,9 +25,9 @@
 
       This simple portal lets sandboxed applications request a screenshot.
 
-      The screenshot will be made accessible to the application
-      via the document portal, and the returned URI will point
-      into the document portal fuse filesystem in /run/user/$UID/doc/.
+      The screenshot will be made accessible to the application (which
+      may involve adding it to the :ref:`Documents
+      portal<org.freedesktop.portal.Documents>`).
 
       This documentation describes **version 2** of this interface.
   -->


### PR DESCRIPTION
Same as c7dce4e ("docs: clarify guarantees of the File Chooser API").

(I've checked, and no other portal documentation mentions /run/user apart from the document portal, so this should be the last of these fixes.)