### PR TITLE
notification: Don't fail requests with unsupported properties

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,7 @@ jobs:
         docker run --name $BUILD_CONTAINER \
           --tty --device /dev/fuse --cap-add SYS_ADMIN \
           --security-opt apparmor:unconfined \
+          --privileged \
           -v $(pwd):/src \
           -e DEBIAN_FRONTEND \
           -e DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -60,6 +61,8 @@ jobs:
           libfontconfig1-dev \
           libfuse3-dev \
           libgdk-pixbuf-2.0-dev \
+          librsvg2-2 \
+          librsvg2-common \
           libgeoclue-2-dev \
           libglib2.0-dev \
           libjson-glib-dev \

--- a/src/meson.build
+++ b/src/meson.build
@@ -167,7 +167,8 @@ if bwrap.found()
   validate_icon_c_args += '-DHELPER="@0@"'.format(bwrap.full_path())
 endif
 
-executable(
+
+xdp_validate_icon = executable(
   'xdg-desktop-portal-validate-icon',
   'validate-icon.c',
   dependencies: [gdk_pixbuf_dep],

--- a/src/validate-icon.c
+++ b/src/validate-icon.c
@@ -237,11 +237,6 @@ rerun_in_sandbox (const char *arg_width,
   add_args (args, validate_icon, arg_width, arg_height, filename, NULL);
   g_ptr_array_add (args, NULL);
 
-  {
-    g_autofree char *cmdline = g_strjoinv (" ", (char **) args->pdata);
-    g_debug ("Icon validation: Spawning %s", cmdline);
-  }
-
   execvpe (flatpak_get_bwrap (), (char **) args->pdata, NULL);
   /* If we get here, then execvpe() failed. */
   g_printerr ("Icon validation: execvpe %s: %s\n", flatpak_get_bwrap (), g_strerror (errno));

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2346,6 +2346,9 @@ xdp_validate_serialized_icon (GVariant  *v,
       return FALSE;
     }
 
+  if (g_getenv ("XDP_VALIDATE_ICON"))
+    icon_validator = g_getenv ("XDP_VALIDATE_ICON");
+
   if (!g_file_test (icon_validator, G_FILE_TEST_EXISTS))
     {
       g_warning ("Icon validation: %s not found, rejecting icon by default.", icon_validator);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -2398,6 +2398,7 @@ xdp_validate_serialized_icon (GVariant  *v,
   if (!g_spawn_check_exit_status (status, &error))
     {
       g_warning ("Icon validation: %s", error->message);
+      g_warning ("stderr:\n%s\n", stderrlog);
       return FALSE;
     }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,7 @@
 env_tests = environment()
 env_tests.set('XDP_UNINSTALLED', '1')
 env_tests.set('XDG_DATA_DIRS', meson.current_build_dir() / 'share')
+env_tests.set('XDP_VALIDATE_ICON', xdp_validate_icon.full_path())
 env_tests.set('G_TEST_SRCDIR', meson.current_source_dir())
 env_tests.set('G_TEST_BUILDDIR', meson.current_build_dir())
 env_tests.set('G_DEBUG', 'gc-friendly')  # from glib-tap.mk

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -11,6 +11,20 @@ extern char outdir[];
 static int got_info;
 
 static void
+notification_succeed (GObject *source,
+                      GAsyncResult *result,
+                      gpointer data)
+{
+  XdpPortal *portal = XDP_PORTAL (source);
+  g_autoptr(GError) error = NULL;
+  gboolean res;
+
+  res = xdp_portal_add_notification_finish (portal, result, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+}
+
+static void
 notification_action_invoked (XdpPortal *portal,
                              const char *id,
                              const char *action,
@@ -66,7 +80,7 @@ test_notification_basic (void)
   id = g_signal_connect (portal, "notification-action-invoked", G_CALLBACK (notification_action_invoked), keyfile);
 
   got_info = 0;
-  xdp_portal_add_notification (portal, "test", notification, 0, NULL, NULL, NULL);
+  xdp_portal_add_notification (portal, "test", notification, 0, NULL, notification_succeed, NULL);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
@@ -114,7 +128,7 @@ test_notification_buttons (void)
   id = g_signal_connect (portal, "notification-action-invoked", G_CALLBACK (notification_action_invoked), keyfile);
 
   got_info = 0;
-  xdp_portal_add_notification (portal, "test2", notification, 0, NULL, NULL, NULL);
+  xdp_portal_add_notification (portal, "test2", notification, 0, NULL, notification_succeed, NULL);
 
   while (!got_info)
     g_main_context_iteration (NULL, TRUE);
@@ -140,7 +154,7 @@ notification_fail (GObject *source,
   got_info++;
   g_main_context_wakeup (NULL);
 }
-                
+
 void
 test_notification_bad_arg (void)
 {

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -4,7 +4,11 @@
 #include "account.h"
 
 #include <libportal/portal.h>
+#include <gio/gunixoutputstream.h>
 #include "xdp-utils.h"
+
+#define IMAGE_DATA "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" \
+                   "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"16px\" width=\"16px\"/>"
 
 extern char outdir[];
 
@@ -183,4 +187,73 @@ test_notification_bad_button (void)
                    "}";
 
   run_notification_test ("test5", notification_s, NULL, TRUE);
+}
+
+static void
+test_icon (const char *serialized_icon,
+           const char *exp_serialized_icon,
+           gboolean    exp_fail)
+{
+  g_autofree char *notification_s = NULL;
+  g_autofree char *exp_notification_s = NULL;
+
+  notification_s = g_strdup_printf ("{ 'title': <'test notification 7'>, "
+                                    "  'body': <'test notification body 7'>, "
+                                    "  'icon': <%s>, "
+                                    "  'default-action': <'test-action'> "
+                                    "}", serialized_icon);
+
+  if (exp_serialized_icon)
+    exp_notification_s = g_strdup_printf ("{ 'title': <'test notification 7'>, "
+                                          "  'body': <'test notification body 7'>, "
+                                          "  'icon': <%s>, "
+                                          "  'default-action': <'test-action'> "
+                                          "}", exp_serialized_icon);
+
+  run_notification_test ("test-icon", notification_s, exp_notification_s, exp_fail);
+}
+
+static void
+test_themed_icon ()
+{
+  g_autoptr(GIcon) icon = NULL;
+  g_autoptr(GVariant) serialized_icon = NULL;
+  g_autofree char *serialized_icon_s = NULL;
+
+  icon = g_themed_icon_new ("test-icon-symbolic");
+  serialized_icon = g_icon_serialize (icon);
+
+  serialized_icon_s = g_variant_print (serialized_icon, TRUE);
+  test_icon (serialized_icon_s, NULL, FALSE);
+}
+
+static void
+test_bytes_icon ()
+{
+  g_autoptr(GIcon) icon = NULL;
+  g_autoptr(GVariant) serialized_icon = NULL;
+  g_autofree char *serialized_icon_s = NULL;
+  g_autoptr(GBytes) bytes = NULL;
+
+  bytes = g_bytes_new_static (IMAGE_DATA, strlen (IMAGE_DATA));
+  icon = g_bytes_icon_new (bytes);
+  serialized_icon = g_icon_serialize (icon);
+
+  serialized_icon_s = g_variant_print (serialized_icon, TRUE);
+  test_icon (serialized_icon_s, NULL, FALSE);
+}
+
+void
+test_notification_icon (void)
+{
+  /* For historical reasons we also accept just an icon name but it's
+   * converted to a "normal" themed icon */
+  test_icon ("'test-icon'", "('themed', <['test-icon', 'test-icon-symbolic']>)", FALSE);
+
+  test_themed_icon ();
+  test_bytes_icon ();
+
+  /* Tests that should fail */
+  test_icon ("('themed', <'test-icon-symbolic'>)", NULL, TRUE);
+  test_icon ("('bytes', <['test-icon-symbolic', 'test-icon']>)", NULL, TRUE);
 }

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -66,6 +66,7 @@ notification_action_invoked (XdpPortal *portal,
 static void
 run_notification_test (const char *notification_id,
                        const char *notification_s,
+                       const char *exp_notification_s,
                        gboolean    exp_fail)
 {
   g_autoptr(XdpPortal) portal = NULL;
@@ -79,7 +80,7 @@ run_notification_test (const char *notification_id,
 
   keyfile = g_key_file_new ();
 
-  g_key_file_set_string (keyfile, "notification", "data", notification_s);
+  g_key_file_set_string (keyfile, "notification", "data", exp_notification_s ? exp_notification_s : notification_s);
   g_key_file_set_string (keyfile, "notification", "id", notification_id);
   g_key_file_set_string (keyfile, "notification", "action", "test-action");
 
@@ -123,7 +124,7 @@ test_notification_basic (void)
                    "  'priority': <'normal'>, "
                    "  'default-action': <'test-action'> }";
 
-  run_notification_test ("test1", notification_s, FALSE);
+  run_notification_test ("test1", notification_s, NULL, FALSE);
 }
 
 void
@@ -139,19 +140,22 @@ test_notification_buttons (void)
                    "               {'label': <'button2'>, 'action': <'action2'>}]> "
                    "}";
 
-  run_notification_test ("test2", notification_s, FALSE);
+  run_notification_test ("test2", notification_s, NULL, FALSE);
 }
 
 void
 test_notification_bad_arg (void)
 {
   const char *notification_s;
+  const char *exp_notification_s;
 
   notification_s = "{ 'title': <'test notification 3'>, "
                    "  'bodx': <'test notification body 3'> "
                    "}";
 
-  run_notification_test ("test3", notification_s, TRUE);
+  exp_notification_s = "{ 'title': <'test notification 3'> }";
+
+  run_notification_test ("test3", notification_s, exp_notification_s, FALSE);
 }
 
 void
@@ -164,7 +168,7 @@ test_notification_bad_priority (void)
                    "  'priority': <'invalid'> "
                    "}";
 
-  run_notification_test ("test4", notification_s, TRUE);
+  run_notification_test ("test4", notification_s, NULL, TRUE);
 }
 
 void
@@ -178,5 +182,5 @@ test_notification_bad_button (void)
                    "               {'label': <'button2'>, 'action': <'action2'>}]> "
                    "}";
 
-  run_notification_test ("test5", notification_s, TRUE);
+  run_notification_test ("test5", notification_s, NULL, TRUE);
 }

--- a/tests/notification.h
+++ b/tests/notification.h
@@ -6,3 +6,4 @@ void test_notification_buttons (void);
 void test_notification_bad_arg (void);
 void test_notification_bad_priority (void);
 void test_notification_bad_button (void);
+void test_notification_icon (void);

--- a/tests/test-portals.c
+++ b/tests/test-portals.c
@@ -605,6 +605,7 @@ main (int argc, char **argv)
   g_test_add_func ("/portal/notification/bad-arg", test_notification_bad_arg);
   g_test_add_func ("/portal/notification/bad-priority", test_notification_bad_priority);
   g_test_add_func ("/portal/notification/bad-button", test_notification_bad_button);
+  g_test_add_func ("/portal/notification/icon", test_notification_icon);
 #endif
 
   global_setup ();


### PR DESCRIPTION
This filters unsupported properties from a notification request without
failing it. This allows backwards compatibility after adding new
properties. This should had been the case from the beginning so that we
don't have to break API when extending the notification interface. See
[1].

[1] https://dbus.freedesktop.org/doc/dbus-api-design.html#extensibility


Also improve tests and add icon tests to make sure that this doesn't break icons.