### PR TITLE
Fix segfault when opening non-existant file

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -684,12 +684,15 @@ handle_open_in_thread_func (GTask *task,
 
       path = xdp_app_info_get_path_for_fd (request->app_info, fd, 0, NULL, &fd_is_writable, &local_error);
 
-      host_path = get_real_path_for_doc_path (path, request->app_info);
-      if (host_path)
+      if (path != NULL)
         {
-          g_debug ("OpenFile: translating path value '%s' to host path '%s'", path, host_path);
-          g_clear_pointer (&path, g_free);
-          path = g_steal_pointer (&host_path);
+          host_path = get_real_path_for_doc_path (path, request->app_info);
+          if (host_path)
+            {
+              g_debug ("OpenFile: translating path value '%s' to host path '%s'", path, host_path);
+              g_clear_pointer (&path, g_free);
+              path = g_steal_pointer (&host_path);
+            }
         }
 
       if (path == NULL ||


### PR DESCRIPTION
When OpenURI was called with a file-descriptor to a file whose path was not available (whether due to sandboxing or race conditions) this caused an obscure crash, which is resolved by this commit.

This fixes https://retrace.fedoraproject.org/faf/problems/603686/