### PR TITLE
open-uri: Basic globbing for detailed URI handlers

### DIFF
--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -498,8 +498,183 @@ should_use_default_app (const char *scheme,
   return FALSE;
 }
 
+// TODO: these will presumably be sourced from JSON or XML files
+typedef struct
+{
+  /* This probably requires generating some sort of matrix on-the-fly */
+  const char *app_id;
+  const char **schemes;
+  const char **hosts;
+  const char **paths;
+  const char **exclude_paths;
+
+  /* Alternative */
+  const char **patterns;
+  const char **exclude_patterns;
+} DomainHandler;
+
+static DomainHandler uri_handlers[] = {
+  // Maps
+  {
+    .app_id = "org.gnome.Maps",
+    .schemes = (const char *[]){
+      "http",
+      "https",
+      "maps",
+      NULL,
+    },
+    .hosts = (const char *[]){
+      "*.openstreetmap.org",
+      NULL,
+    },
+    .paths = (const char *[]){
+      "/#map=*",
+      NULL,
+    },
+    .exclude_paths = (const char *[]){
+      "https://www.openstreetmap.org/about",
+      NULL,
+
+    },
+
+    .patterns = (const char *[]){
+      "maps://*/#map=*",
+      "*://www.openstreetmap.org/#map=*",
+      "*://*openstreetmap.org/way/*",
+      NULL,
+    },
+    .exclude_patterns = (const char *[]){
+      NULL,
+    },
+  },
+
+  // Matrix
+  {
+    .app_id = "org.gnome.Fractal",
+
+    //
+    .schemes = (const char *[]){
+      "http",
+      "https",
+      "maps",
+      NULL,
+    },
+    .hosts = (const char *[]){
+      "*.openstreetmap.org",
+      NULL,
+    },
+    .paths = (const char *[]){
+      "/#map=*",
+      NULL,
+    },
+    .exclude_paths = (const char *[]){
+      "https://www.openstreetmap.org/about",
+      NULL,
+
+    },
+
+    //
+    .patterns = (const char *[]){
+      "https://matrix.to/#/#*:gnome.org",
+      "https://matrix.to/#/#*:*",
+      NULL,
+    },
+    .exclude_patterns = (const char *[]){
+      NULL,
+    },
+  },
+
+  // Software
+  {
+    .app_id = "org.gnome.Software",
+
+    //
+    .schemes = (const char *[]){
+      "http",
+      "https",
+      NULL,
+    },
+    .hosts = (const char *[]){
+      "flathub.org",
+      "*.flathub.org",
+      NULL,
+    },
+    .paths = (const char *[]){
+      "/apps/search?q=*",
+      "/apps/*",
+      NULL,
+    },
+    .exclude_paths = (const char *[]){
+      "/about",
+      NULL,
+    },
+
+    //
+    .patterns = (const char *[]){
+      "https://flathub.org/apps/search?q=*",
+      "https://flathub.org/apps/*",
+      NULL,
+    },
+    .exclude_patterns = (const char *[]){
+      "https://flathub.org/about",
+      NULL,
+    },
+  },
+};
+
+static gboolean
+domain_handler_should_exclude (DomainHandler handler,
+                               const char    *uri)
+{
+  g_assert (uri != NULL);
+
+  for (size_t p = 0; handler.exclude_patterns[p] != NULL; p++)
+    {
+       if (g_pattern_match_simple (handler.exclude_patterns[p], uri))
+        {
+          g_debug ("Excluding handler for %s (%s)", uri, handler.app_id);
+          return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
 static void
-find_recommended_choices (const char *scheme,
+find_patterned_choices (const char *uri,
+                        GStrv *choices,
+                        guint *choices_len)
+{
+  g_autoptr(GStrvBuilder) builder = NULL;
+  guint n_choices = 0;
+
+  g_assert (uri != NULL);
+
+  builder = g_strv_builder_new ();
+  for (size_t i = 0; i < G_N_ELEMENTS (uri_handlers); i++)
+    {
+      DomainHandler handler = uri_handlers[i];
+
+      for (size_t p = 0; handler.patterns[p] != NULL; p++)
+        {
+          if (g_pattern_match_simple (handler.patterns[p], uri) &&
+             !domain_handler_should_exclude (handler, uri))
+            {
+              g_debug ("Matching handler for %s (%s)", uri, handler.app_id);
+              g_strv_builder_add (builder, handler.app_id);
+              n_choices += 1;
+              break;
+            }
+        }
+    }
+
+  *choices = g_strv_builder_end (builder);
+  *choices_len = n_choices;
+}
+
+static void
+find_recommended_choices (const char *uri,
+                          const char *scheme,
                           const char *content_type,
                           char **default_app,
                           GStrv *choices,
@@ -511,6 +686,22 @@ find_recommended_choices (const char *scheme,
   guint n_choices = 0;
   GStrv result = NULL;
   int i;
+
+  /* TODO: we're pre-empting the default app, since there is are hard-coded
+   *       URI scheme overrides.
+   */
+  find_patterned_choices (uri, &result, &n_choices);
+  if (n_choices > 0)
+    {
+      *choices = g_steal_pointer (&result);
+      *choices_len = n_choices;
+      return;
+    }
+  else
+    {
+      n_choices = 0;
+      g_clear_pointer (&result, g_strfreev);
+    }
 
   info = g_app_info_get_default_for_type (content_type, FALSE);
 
@@ -553,13 +744,15 @@ app_info_changed (GAppInfoMonitor *monitor,
 {
   const char *scheme;
   const char *content_type;
+  const char *uri;
   g_autofree char *default_app = NULL;
   g_auto(GStrv) choices = NULL;
   guint n_choices;
 
   scheme = (const char *)g_object_get_data (G_OBJECT (request), "scheme");
   content_type = (const char *)g_object_get_data (G_OBJECT (request), "content-type");
-  find_recommended_choices (scheme, content_type, &default_app, &choices, &n_choices);
+  uri = (const char *)g_object_get_data (G_OBJECT (request), "uri");
+  find_recommended_choices (uri, scheme, content_type, &default_app, &choices, &n_choices);
 
   xdp_dbus_impl_app_chooser_call_update_choices (impl,
                                                  request->id,
@@ -787,7 +980,7 @@ handle_open_in_thread_func (GTask *task,
   g_object_set_data_full (G_OBJECT (request), "content-type", g_strdup (content_type), g_free);
 
   /* collect all the information */
-  find_recommended_choices (scheme, content_type, &default_app, &choices, &n_choices);
+  find_recommended_choices (uri, scheme, content_type, &default_app, &choices, &n_choices);
   /* it's never NULL, but might be empty (only contain the NULL terminator) */
   g_assert (choices != NULL);
   if (default_app != NULL && !app_exists (default_app))


### PR DESCRIPTION
Pre-empt the default URI scheme handlers, so that applications may specify scheme, host, and path patterns as well as exclusion patterns.