### PR TITLE
pipewire: Destroy registry object with remote

### DIFF
--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -51,6 +51,7 @@ struct _PipeWireRemote
 
   int sync_seq;
 
+  struct pw_proxy *registry;
   struct spa_hook registry_listener;
 
   GHashTable *globals;


### PR DESCRIPTION
This practically reintroduces commit fbe26534e14 which got reverted in ff8a8de6aedb5, which I only discovered after coming up with this solution on its own. The only difference is that
`discover_node_factory_sync()` gets removed as it doesn't really make much sense to keep around.

The commit message of fbe26534e14 (by msizanoen1
<qtmlabs@protonmail.com>)>
```
Currently, the PipeWire registry object is destroyed when
discover_node_factory_sync finishes its functionality. This causes
registry events to not be delivered to the global_removed_cb and
global_added_cb callbacks after discover_node_factory_sync, breaking
the functionality of the
org.freedesktop.portal.Camera.IsCameraPresent property in case of
camera device hot(un)plug.

This changes the discover_node_factory_sync function to store the
registry in the PipeWireRemote structure and destroy it in
pipewire_remote_destroy.
```

This holds true to this day and causes issues for the camera portal. Whatever crashes it caused at some point I can't reproduce - and Gnome-Shell, which has a very similar implementation for its camera monitor doesn't seem to suffer from crashes as well.

P.S.: the originally described issue:
> breaking the functionality of the org.freedesktop.portal.Camera.IsCameraPresent property in case of camera device hot(un)plug.

does not describe the main problem that many people are facing: if Pipewire initializes cameras a little too late, the portal won't see them.

---

cc: @GeorgesStavracas, @msizanoen1 