### PR TITLE
camera: Stop forcing a remote roundtrip when creating PW FD

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -166,8 +166,6 @@ open_pipewire_camera_remote (const char *app_id,
                                 G_N_ELEMENTS (permission_items),
                                 permission_items);
 
-  pipewire_remote_roundtrip (remote);
-
   return remote;
 }
 


### PR DESCRIPTION
For not yet understood reason it causes camera globals to be send twice to clients, resulting in duplicated camera entries. To be investigated before this should be merged.

This only happens since the commit mentioned below, thus: Fixes: 24d29bf (pipewire: Destroy registry object with remote)

---

See https://github.com/flatpak/xdg-desktop-portal/pull/1319