### PR TITLE
Uniformize application as app

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -751,7 +751,7 @@ handle_request_background_in_thread_func (GTask *task,
         subtitle = g_strdup_printf (_("%s requests to be started automatically and run in the background."), info ? g_app_info_get_display_name (info) : id);
       else
         subtitle = g_strdup_printf (_("%s requests to run in the background."), info ? g_app_info_get_display_name (info) : id);
-      body = g_strdup (_("The ‘run in background’ permission can be changed at any time from the application settings."));
+      body = g_strdup (_("The ‘run in background’ permission can be changed at any time from the app settings."));
 
       g_debug ("Calling backend for background access for: %s", id);
 

--- a/src/location.c
+++ b/src/location.c
@@ -563,7 +563,7 @@ handle_start_in_thread_func (GTask *task,
           g_assert (xdp_app_info_is_host (request->app_info));
           app_id = g_strdup ("");
           title = g_strdup (_("Grant Access to Your Location?"));
-          subtitle = g_strdup (_("An application wants to use your location."));
+          subtitle = g_strdup (_("An app wants to use your location."));
         }
 
       body = _("Location access can be changed at any time from the privacy settings.");

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -262,8 +262,8 @@ handle_screenshot_in_thread_func (GTask *task,
            * apps for which an app ID can't be determined.
            */
           g_assert (xdp_app_info_is_host (request->app_info));
-          title = g_strdup (_("Allow Applications to Take Screenshots?"));
-          subtitle = g_strdup (_("An application wants to be able to take screenshots at any time."));
+          title = g_strdup (_("Allow Apps to Take Screenshots?"));
+          subtitle = g_strdup (_("An app wants to be able to take screenshots at any time."));
         }
 
       body = _("This permission can be changed at any time from the privacy settings.");

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -212,8 +212,8 @@ handle_set_wallpaper_in_thread_func (GTask *task,
            */
           g_assert (xdp_app_info_is_host (request->app_info));
           app_id = g_strdup ("");
-          title = g_strdup (_("Allow Applications to Set Backgrounds?"));
-          subtitle = g_strdup (_("An application is requesting to be able to change the background image."));
+          title = g_strdup (_("Allow Apps to Set Backgrounds?"));
+          subtitle = g_strdup (_("An app is requesting to be able to change the background image."));
         }
       body = _("This permission can be changed at any time from the privacy settings.");
 


### PR DESCRIPTION
Uniformize occurrences of "application"(s) and "app"(s) as the latter.

#### Occurrences of application(s):

* src/background.c, line 754
The ‘run in background’ permission can be changed at any time from the application settings.

* src/location.c, line 566
An application wants to use your location.

* src/screenshot.c, line 265
Allow Applications to Take Screenshots?

* src/screenshot.c, line 266
An application wants to be able to take screenshots at any time.

* src/wallpaper.c, lines 215 and 216
Allow Applications to Set Backgrounds?
An application is requesting to be able to change the background image.

#### Occurrences of app(s):

* src/device.c, line 122 and 123, 137 and 138
Allow app to Use the Microphone?
An app wants to access recording devices.
Allow app to Use the Speakers?
An app wants to access audio devices.

* src/device.c, lines 152 and 153
Allow app to Use the Camera?
An app wants to access camera devices.

* src/dynamic-launcher.c, lines 131 and 719
Desktop file id missing app id prefix '%s.': %s
RequestInstallToken() not allowed for app id %s