### PR TITLE
Unassorted cleanups

### DIFF
--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -26,52 +26,6 @@
   -->
   <interface name="org.freedesktop.impl.portal.Print">
     <!--
-        Print:
-        @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
-        @app_id: App id of the application
-        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
-        @title: Title for the print dialog
-        @fd: File descriptor from which to read the content to print
-        @options: Vardict with optional further information
-        @response: Numeric response
-        @results: Vardict with the results of the call
-
-        Prints a file.
-
-        The file is given in the form of a file descriptor open for reading.
-
-        If a valid token is present in the @options, then this call will print
-        with the settings from the Print call that the token refers to. If
-        no token is present, then a print dialog will be presented to the user.
-
-        Note that it is up to the portal implementation to determine how long
-        it considers tokens valid.
-
-        Supported keys in the @options vardict:
-
-        * ``modal`` (``b``)
-
-          Whether to make the dialog modal. Defaults to yes.
-
-        * ``token`` (``u``)
-
-          Token that was returned by a previous org.freedesktop.impl.portal.Print.PreparePrint() call.
-    -->
-    <method name="Print">
-      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
-      <arg type="o" name="handle" direction="in"/>
-      <arg type="s" name="app_id" direction="in"/>
-      <arg type="s" name="parent_window" direction="in"/>
-      <arg type="s" name="title" direction="in"/>
-      <arg type="h" name="fd" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In5" value="QVariantMap"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <arg type="u" name="response" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
-      <arg type="a{sv}" name="results" direction="out"/>
-    </method>
-
-    <!--
         PreparePrint:
         @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
         @app_id: App id of the application
@@ -124,6 +78,52 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.In5" value="QVariantMap"/>
       <arg type="a{sv}" name="page_setup" direction="in"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In6" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+
+    <!--
+        Print:
+        @handle: Object path for the :ref:`org.freedesktop.impl.portal.Request` object representing this call
+        @app_id: App id of the application
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
+        @title: Title for the print dialog
+        @fd: File descriptor from which to read the content to print
+        @options: Vardict with optional further information
+        @response: Numeric response
+        @results: Vardict with the results of the call
+
+        Prints a file.
+
+        The file is given in the form of a file descriptor open for reading.
+
+        If a valid token is present in the @options, then this call will print
+        with the settings from the Print call that the token refers to. If
+        no token is present, then a print dialog will be presented to the user.
+
+        Note that it is up to the portal implementation to determine how long
+        it considers tokens valid.
+
+        Supported keys in the @options vardict:
+
+        * ``modal`` (``b``)
+
+          Whether to make the dialog modal. Defaults to yes.
+
+        * ``token`` (``u``)
+
+          Token that was returned by a previous org.freedesktop.impl.portal.Print.PreparePrint() call.
+    -->
+    <method name="Print">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="s" name="title" direction="in"/>
+      <arg type="h" name="fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In5" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -140,7 +140,7 @@
 
           * ``default-source`` (``s``)
 
-             The default paper source.
+            The default paper source.
 
           * ``quality`` (``s``)
 

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -36,51 +36,6 @@
   -->
   <interface name="org.freedesktop.portal.Print">
     <!--
-        Print:
-        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
-        @title: Title for the print dialog
-        @fd: File descriptor for reading the content to print
-        @options: Vardict with optional further information
-        @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
-
-        Asks to print a file.
-
-        The file must be passed in the form of a file descriptor open for reading.
-        This ensures that sandboxed applications only print files that they have
-        access to.
-
-        If a valid token is present in the @options, then this call will print
-        with the settings from the Print call that the token refers to. If
-        no token is present, then a print dialog will be presented to the user.
-
-        Note that it is up to the portal implementation to determine how long
-        it considers tokens valid.
-
-        Supported keys in the @options vardict:
-
-        * ``handle_token`` (``s``)
-
-          A string that will be used as the last element of the @handle. Must be a valid
-          object path element. See the :ref:`org.freedesktop.portal.Request` documentation for
-          more information about the @handle.
-
-        * ``modal`` (``b``)
-
-          Whether to make the dialog modal. Defaults to yes.
-
-        * ``token`` (``u``)
-
-          Token that was returned by a previous org.freedesktop.portal.Print.PreparePrint() call.
-    -->
-    <method name="Print">
-      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
-      <arg type="s" name="parent_window" direction="in"/>
-      <arg type="s" name="title" direction="in"/>
-      <arg type="h" name="fd" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
-      <arg type="o" name="handle" direction="out"/>
-    </method>
-    <!--
         PreparePrint:
         @parent_window: Identifier for the application window, see :doc:`window-identifiers`
         @title: Title for the print dialog
@@ -293,6 +248,53 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+
+    <!--
+        Print:
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
+        @title: Title for the print dialog
+        @fd: File descriptor for reading the content to print
+        @options: Vardict with optional further information
+        @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
+
+        Asks to print a file.
+
+        The file must be passed in the form of a file descriptor open for reading.
+        This ensures that sandboxed applications only print files that they have
+        access to.
+
+        If a valid token is present in the @options, then this call will print
+        with the settings from the Print call that the token refers to. If
+        no token is present, then a print dialog will be presented to the user.
+
+        Note that it is up to the portal implementation to determine how long
+        it considers tokens valid.
+
+        Supported keys in the @options vardict:
+
+        * ``handle_token`` (``s``)
+
+          A string that will be used as the last element of the @handle. Must be a valid
+          object path element. See the :ref:`org.freedesktop.portal.Request` documentation for
+          more information about the @handle.
+
+        * ``modal`` (``b``)
+
+          Whether to make the dialog modal. Defaults to yes.
+
+        * ``token`` (``u``)
+
+          Token that was returned by a previous org.freedesktop.portal.Print.PreparePrint() call.
+    -->
+    <method name="Print">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="s" name="title" direction="in"/>
+      <arg type="h" name="fd" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/camera.c
+++ b/src/camera.c
@@ -92,8 +92,7 @@ query_permission_sync (Request *request)
 
       if (app_id[0] != 0)
         {
-          g_autofree char *desktop_id;
-          desktop_id = g_strconcat (app_id, ".desktop", NULL);
+          g_autofree char *desktop_id = g_strconcat (app_id, ".desktop", NULL);
           info = (GAppInfo*)g_desktop_app_info_new (desktop_id);
         }
 

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -131,7 +131,6 @@ authorize_callback (GDBusInterfaceSkeleton *interface,
                     gpointer                user_data)
 {
   g_autoptr(XdpAppInfo) app_info = NULL;
-
   g_autoptr(GError) error = NULL;
 
   app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, &error);
@@ -363,7 +362,7 @@ main (int argc, char *argv[])
   guint owner_id;
   g_autoptr(GError) error = NULL;
   g_autoptr(GDBusConnection) session_bus = NULL;
-  g_autoptr(GOptionContext) context;
+  g_autoptr(GOptionContext) context = NULL;
 
   setlocale (LC_ALL, "");
   bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);

--- a/tests/testdb.c
+++ b/tests/testdb.c
@@ -67,7 +67,7 @@ create_test_db (gboolean serialized)
 static void
 verify_test_db (PermissionDb *db)
 {
-  g_auto(GStrv) ids;
+  g_auto(GStrv) ids = NULL;
   g_autofree const char **apps1 = NULL;
   g_autofree const char **apps2 = NULL;
   g_auto(GStrv) all_apps = NULL;


### PR DESCRIPTION
Addresses some (apparently harmless) compiler warnings, and shuffles some stuff around.

No functional changes.