### PR TITLE
launch-context: Return a copy of the token string

### DIFF
--- a/src/launch-context.c
+++ b/src/launch-context.c
@@ -46,7 +46,7 @@ xdp_app_launch_context_get_startup_notify_id (GAppLaunchContext *context,
 {
   XdpAppLaunchContext *self = XDP_APP_LAUNCH_CONTEXT (context);
 
-  return self->token;
+  return g_strdup (self->token);
 }
 
 static void


### PR DESCRIPTION
GAppLaunchContext.get_startup_notify_id() expects a string copy, not a const string. Call g_strdup() to copy the string.