### PR TITLE
camera: Do not set permission=no on errors

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -136,6 +136,10 @@ query_permission_sync (Request *request)
                                                          &error))
         {
           g_warning ("A backend call failed: %s", error->message);
+          /* We do not want to set the permission if there was an error and the
+           * permission was UNSET. Setting a permission should only be done from
+           * user input. */
+          return FALSE;
         }
 
       allowed = response == 0;


### PR DESCRIPTION
The permission should be set to NO or YES only if the choice came from the user.

Fixes: https://github.com/flatpak/xdg-desktop-portal/issues/1338