### PR TITLE
device: Do not set permission=no on errors

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -175,6 +175,10 @@ device_query_permission_sync (const char *app_id,
                                                          &error))
         {
           g_warning ("A backend call failed: %s", error->message);
+          /* We do not want to set the permission if there was an error and the
+           * permission was UNSET. Setting a permission should only be done from
+           * user input. */
+          return FALSE;
         }
 
       allowed = response == 0;


### PR DESCRIPTION
The permission should be set to NO or YES only if the choice came from the user.

Fixes: https://github.com/flatpak/xdg-desktop-portal/issues/1338

(cherry picked from commit 8049324038cd9fd63bf6c13aca004f85f4bf0255)