### PR TITLE
portal-impl: Check for default_portal before derefing it

### DIFF
--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -508,7 +508,8 @@ find_matching_iface_config (const char *interface)
 static gboolean
 portal_default_prefers_none (void)
 {
-  if (config != NULL && g_strv_contains ((const char * const *) config->default_portal->portals, "none"))
+  if (config && config->default_portal &&
+      g_strv_contains ((const char * const *) config->default_portal->portals, "none"))
     {
       g_debug ("Found 'none' in configuration for default");
       return TRUE;


### PR DESCRIPTION
The default_portal pointer can be NULL if there is no default portal set in the configuration. In that case the default portal is not explicitly set to "none" and we return FALSE in portal_default_prefers_none.

Fixes: 1394bb2 ("portal-impl: fallback implementation is used if preferred value is none")
Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1330