### PR TITLE
background: Improve validation of commandline option

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -854,7 +854,7 @@ validate_commandline (const char *key,
                       GError **error)
 {
   gsize length;
-  const char **strv = g_variant_get_strv (value, &length);
+  g_autofree const char **strv = g_variant_get_strv (value, &length);
 
   if (strv[0] == NULL)
     {
@@ -867,6 +867,13 @@ validate_commandline (const char *key,
     {
       g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
                    "Not accepting overly long commandlines");
+      return FALSE;
+    }
+
+  if (*strv[0] == ' ' || *strv[0] == '-')
+    {
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "First commandline item can't start with whitespace nor hyphens");
       return FALSE;
     }
 


### PR DESCRIPTION
Check that the first commandline item doesn't start with whitespaces or
a hyphen.

Also sneakily plug a memory leak, g_variant_get_strv() is transfer-
container. Switch to g_autofree on the variable.

Mitigates: CVE-2024-32462