### PR TITLE
doc: Add ScreenCast source type meaning

### DIFF
--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -239,9 +239,9 @@
 
         A bitmask of available source types. Currently defined types are:
 
-        - ``1``: MONITOR
-        - ``2``: WINDOW
-        - ``4``: VIRTUAL
+        - ``1``: MONITOR: Share existing monitors
+        - ``2``: WINDOW: Share application windows
+        - ``4``: VIRTUAL: Extend with new virtual monitor
     -->
     <property name="AvailableSourceTypes" type="u" access="read"/>
     <!--

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -266,9 +266,9 @@
 
         A bitmask of available source types. Currently defined types are:
 
-        - ``1``: MONITOR
-        - ``2``: WINDOW
-        - ``4``: VIRTUAL
+        - ``1``: MONITOR: Share existing monitors
+        - ``2``: WINDOW: Share application windows
+        - ``4``: VIRTUAL: Extend with new virtual monitor
     -->
     <property name="AvailableSourceTypes" type="u" access="read"/>
     <!--


### PR DESCRIPTION
The name "virtual" is too ambiguous by itself so a blurb is added for each type.