### PR TITLE
Add Qt annotations

### DIFF
--- a/data/org.freedesktop.background.Monitor.xml
+++ b/data/org.freedesktop.background.Monitor.xml
@@ -48,7 +48,9 @@
 
         Status message reported by the application. Optional.
     -->
-    <property name="BackgroundApps" type="aa{sv}" access="read"/>
+    <property name="BackgroundApps" type="aa{sv}" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;QVariantMap&gt;"/>
+    </property>
 
     <property name="version" type="u" access="read"/>
   </interface>

--- a/data/org.freedesktop.impl.portal.Access.xml
+++ b/data/org.freedesktop.impl.portal.Access.xml
@@ -79,8 +79,10 @@
       <arg type="s" name="title" direction="in"/>
       <arg type="s" name="subtitle" direction="in"/>
       <arg type="s" name="body" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In6" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
   </interface>

--- a/data/org.freedesktop.impl.portal.Account.xml
+++ b/data/org.freedesktop.impl.portal.Account.xml
@@ -67,8 +67,10 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
       <arg type="s" name="window" direction="in"/>
+       <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
+       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
   </interface>

--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -41,6 +41,7 @@
       - ``2``: Active (in the foreground)
     -->
     <method name='GetAppState'>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
       <arg type="a{sv}" name="apps" direction="out"/>
     </method>
 
@@ -70,6 +71,7 @@
       <arg type="s" name="app_id" direction="in"/>
       <arg type="s" name="name" direction="in"/>
       <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
 

--- a/data/org.freedesktop.impl.portal.Clipboard.xml
+++ b/data/org.freedesktop.impl.portal.Clipboard.xml
@@ -41,6 +41,7 @@
     -->
     <method name="RequestClipboard">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
     <!-- 
@@ -64,6 +65,7 @@
      -->
     <method name="SetSelection">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
     <!--
@@ -140,6 +142,7 @@
      -->
     <signal name="SelectionOwnerChanged">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
     <!-- 

--- a/data/org.freedesktop.impl.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.impl.portal.DynamicLauncher.xml
@@ -85,6 +85,7 @@
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="name" direction="in"/>
       <arg type="v" name="icon_v" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In5" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -110,6 +111,7 @@
     -->
     <method name="RequestInstallToken">
       <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
     </method>

--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -50,8 +50,8 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <arg type="a{sv}" name="options" direction="in"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
@@ -76,14 +76,14 @@
     <method name="BindShortcuts">
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
       <arg type="a(sa{sv})" name="shortcuts" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
-      <arg type="a{sv}" name="results" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
     </method>
 
     <!--
@@ -108,8 +108,8 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="u" name="response" direction="out"/>
-      <arg type="a{sv}" name="results" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
     </method>
 
     <!--
@@ -125,8 +125,8 @@
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="s" name="shortcut_id" direction="out"/>
       <arg type="t" name="timestamp" direction="out"/>
-      <arg type="a{sv}" name="options" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
     <!--
@@ -142,8 +142,8 @@
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="s" name="shortcut_id" direction="out"/>
       <arg type="t" name="timestamp" direction="out"/>
-      <arg type="a{sv}" name="options" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
     <!--
@@ -159,8 +159,8 @@
     -->
     <signal name="ShortcutsChanged">
       <arg type="o" name="session_handle" direction="out"/>
-      <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
+      <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
     </signal>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.impl.portal.Inhibit.xml
+++ b/data/org.freedesktop.impl.portal.Inhibit.xml
@@ -111,6 +111,7 @@
     -->
     <signal name="StateChanged">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="state" direction="out"/>
     </signal>
 

--- a/data/org.freedesktop.impl.portal.InputCapture.xml
+++ b/data/org.freedesktop.impl.portal.InputCapture.xml
@@ -64,7 +64,7 @@
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -96,7 +96,7 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -141,8 +141,9 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QList&lt;QVariantMap&gt;"/>
       <arg type="aa{sv}" name="barriers" direction="in"/>
       <arg type="u" name="zone_set" direction="in"/>
       <arg type="u" name="response" direction="out"/>
@@ -161,7 +162,7 @@
     <method name="Enable">
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -179,7 +180,7 @@
     <method name="Disable">
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -213,7 +214,7 @@
     <method name="Release">
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -239,7 +240,7 @@
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>
@@ -255,6 +256,7 @@
     -->
     <signal name="Disabled">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
@@ -317,6 +319,7 @@
     -->
     <signal name="Activated">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
@@ -350,6 +353,7 @@
     -->
     <signal name="Deactivated">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
@@ -364,6 +368,7 @@
     -->
     <signal name="ZonesChanged">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 

--- a/data/org.freedesktop.impl.portal.PermissionStore.xml
+++ b/data/org.freedesktop.impl.portal.PermissionStore.xml
@@ -43,7 +43,7 @@
 
       This document describes version 2 of the permission store interface.
   -->
-  <interface name='org.freedesktop.impl.portal.PermissionStore'>
+  <interface name="org.freedesktop.impl.portal.PermissionStore">
     <property name="version" type="u" access="read"/>
 
     <!--
@@ -57,10 +57,11 @@
         all associated application permissions and data.
     -->
     <method name="Lookup">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='id' type='s' direction='in'/>
-      <arg name='permissions' type='a{sas}' direction='out'/>
-      <arg name='data' type='v' direction='out'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QMap&lt;QString,QStringList&gt;"/>
+      <arg name="permissions" type="a{sas}" direction="out"/>
+      <arg name="data" type="v" direction="out"/>
     </method>
 
     <!--
@@ -74,11 +75,12 @@
         Writes the entry for a resource in the given table.
     -->
     <method name="Set">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='create' type='b' direction='in'/>
-      <arg name='id' type='s' direction='in'/>
-      <arg name='app_permissions' type='a{sas}' direction='in'/>
-      <arg name='data' type='v' direction='in'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="create" type="b" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QMap&lt;QString,QStringList&gt;"/>
+      <arg name="app_permissions" type="a{sas}" direction="in"/>
+      <arg name="data" type="v" direction="in"/>
     </method>
 
     <!--
@@ -89,8 +91,8 @@
         Removes the entry for a resource in the given table.
     -->
     <method name="Delete">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='id' type='s' direction='in'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
     </method>
 
     <!--
@@ -103,10 +105,10 @@
         Sets just the data for a resource in the given table.
     -->
     <method name="SetValue">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='create' type='b' direction='in'/>
-      <arg name='id' type='s' direction='in'/>
-      <arg name='data' type='v' direction='in'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="create" type="b" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
+      <arg name="data" type="v" direction="in"/>
     </method>
 
     <!--
@@ -121,11 +123,11 @@
         in the given table.
     -->
     <method name="SetPermission">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='create' type='b' direction='in'/>
-      <arg name='id' type='s' direction='in'/>
-      <arg name='app' type='s' direction='in'/>
-      <arg name='permissions' type='as' direction='in'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="create" type="b" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
+      <arg name="app" type="s" direction="in"/>
+      <arg name="permissions" type="as" direction="in"/>
     </method>
 
     <!--
@@ -140,9 +142,9 @@
         This method was added in version 2.
     -->
     <method name="DeletePermission">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='id' type='s' direction='in'/>
-      <arg name='app' type='s' direction='in'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
+      <arg name="app" type="s" direction="in"/>
     </method>
 
     <!--
@@ -156,10 +158,10 @@
         in the given table.
     -->
     <method name="GetPermission">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='id' type='s' direction='in'/>
-      <arg name='app' type='s' direction='in'/>
-      <arg name='permissions' type='as' direction='out'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
+      <arg name="app" type="s" direction="in"/>
+      <arg name="permissions" type="as" direction="out"/>
     </method>
 
     <!--
@@ -170,8 +172,8 @@
         Returns all the resources that are present in the table.
     -->
     <method name="List">
-      <arg name='table' type='s' direction='in'/>
-      <arg name='ids' type='as' direction='out'/>
+      <arg name="table" type="s" direction="in"/>
+      <arg name="ids" type="as" direction="out"/>
     </method>
 
     <!--
@@ -188,11 +190,12 @@
         database. If the entry was modified, they contain the new values.
     -->
     <signal name="Changed">
-      <arg name='table' type='s' direction='out'/>
-      <arg name='id' type='s' direction='out'/>
-      <arg name='deleted' type='b' direction='out'/>
-      <arg name='data' type='v' direction='out'/>
-      <arg name='permissions' type='a{sas}' direction='out'/>
+      <arg name="table" type="s" direction="out"/>
+      <arg name="id" type="s" direction="out"/>
+      <arg name="deleted" type="b" direction="out"/>
+      <arg name="data" type="v" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out4" value="QMap&lt;QString,QStringList&gt;"/>
+      <arg name="permissions" type="a{sas}" direction="out"/>
     </signal>
   </interface>
 

--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -110,6 +110,7 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -165,7 +166,7 @@
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
@@ -184,6 +185,7 @@
     -->
     <method name="NotifyPointerMotion">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="d" name="dx" direction="in"/>
       <arg type="d" name="dy" direction="in"/>
@@ -203,6 +205,7 @@
     -->
     <method name="NotifyPointerMotionAbsolute">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="stream" direction="in"/>
       <arg type="d" name="x" direction="in"/>
@@ -227,6 +230,7 @@
     -->
     <method name="NotifyPointerButton">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="i" name="button" direction="in"/>
       <arg type="u" name="state" direction="in"/>
@@ -255,6 +259,7 @@
     -->
     <method name="NotifyPointerAxis">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="d" name="dx" direction="in"/>
       <arg type="d" name="dy" direction="in"/>
@@ -276,6 +281,7 @@
     -->
     <method name="NotifyPointerAxisDiscrete">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="axis" direction="in"/>
       <arg type="i" name="steps" direction="in"/>
@@ -297,6 +303,7 @@
     -->
     <method name="NotifyKeyboardKeycode">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="i" name="keycode" direction="in"/>
       <arg type="u" name="state" direction="in"/>
@@ -318,6 +325,7 @@
     -->
     <method name="NotifyKeyboardKeysym">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="i" name="keysym" direction="in"/>
       <arg type="u" name="state" direction="in"/>
@@ -341,6 +349,7 @@
     -->
     <method name="NotifyTouchDown">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="stream" direction="in"/>
       <arg type="u" name="slot" direction="in"/>
@@ -366,6 +375,7 @@
     -->
     <method name="NotifyTouchMotion">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="stream" direction="in"/>
       <arg type="u" name="slot" direction="in"/>
@@ -385,6 +395,7 @@
     -->
     <method name="NotifyTouchUp">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="slot" direction="in"/>
     </method>
@@ -404,7 +415,7 @@
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="app_id" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>

--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -73,9 +73,10 @@
       If @namespaces is an empty array or contains an empty string it matches all. Globbing is supported but only for
       trailing sections, e.g. "org.example.*".
     -->
-    <method name='ReadAll'>
-      <arg name='namespaces' type='as'/>
-      <arg name='value' direction='out' type='a{sa{sv}}'/>
+    <method name="ReadAll">
+      <arg type="as" name="namespaces" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QMap&lt;QString,QVariantMap&gt;"/>
+      <arg type="a{sa{sv}}" name="value" direction="out"/>
     </method>
 
     <!--
@@ -86,10 +87,10 @@
 
       Reads a single value. Returns an error on any unknown namespace or key.
     -->
-    <method name='Read'>
-      <arg name='namespace' type='s'/>
-      <arg name='key' type='s'/>
-      <arg name='value' direction='out' type='v'/>
+    <method name="Read">
+      <arg type="s" name="namespace" direction="in"/>
+      <arg type="s" name="key" direction="in"/>
+      <arg type="v" name="value" direction="out"/>
     </method>
 
     <!--
@@ -100,10 +101,10 @@
 
       Emitted when a setting changes.
     -->
-    <signal name='SettingChanged'>
-      <arg name='namespace' direction='out' type='s'/>
-      <arg name='key' direction='out' type='s'/>
-      <arg name='value' direction='out' type='v'/>
+    <signal name="SettingChanged">
+      <arg type="s" name="namespace" direction="out"/>
+      <arg type="s" name="key" direction="out"/>
+      <arg type="v" name="value" direction="out"/>
     </signal>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.impl.portal.Wallpaper.xml
+++ b/data/org.freedesktop.impl.portal.Wallpaper.xml
@@ -55,6 +55,7 @@
       <arg type="s" name="app_id" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="uri" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Account.xml
+++ b/data/org.freedesktop.portal.Account.xml
@@ -69,6 +69,7 @@
     -->
     <method name="GetUserInformation">
       <arg type="s" name="window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -77,6 +77,7 @@
     -->
     <method name="RequestBackground">
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -99,6 +100,7 @@
         characters.
     -->
     <method name="SetStatus">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
 

--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -44,6 +44,7 @@
         open a PipeWire remote.
     -->
     <method name="AccessCamera">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -64,6 +65,7 @@
     <method name="OpenPipeWireRemote">
       <annotation name="org.gtk.GDBus.C.Name" value="open_pipewire_remote"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Clipboard.xml
+++ b/data/org.freedesktop.portal.Clipboard.xml
@@ -43,6 +43,7 @@
     -->
     <method name="RequestClipboard">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
     <!-- 
@@ -66,6 +67,7 @@
      -->
     <method name="SetSelection">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
     <!--
@@ -142,6 +144,7 @@
      -->
     <signal name="SelectionOwnerChanged">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
     <!-- 

--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -50,7 +50,7 @@
 
       This documentation describes version 4 of this interface.
   -->
-  <interface name='org.freedesktop.portal.Documents'>
+  <interface name="org.freedesktop.portal.Documents">
     <property name="version" type="u" access="read"/>
 
     <!--
@@ -61,7 +61,7 @@
         is mounted. This will typically be ``/run/user/$UID/doc/``.
     -->
     <method name="GetMountPoint">
-      <arg type='ay' name='path' direction='out'/>
+      <arg type="ay" name="path" direction="out"/>
     </method>
 
     <!--
@@ -77,10 +77,10 @@
     -->
     <method name="Add">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
-      <arg type='h' name='o_path_fd' direction='in'/>
-      <arg type='b' name='reuse_existing' direction='in'/>
-      <arg type='b' name='persistent' direction='in'/>
-      <arg type='s' name='doc_id' direction='out'/>
+      <arg type="h" name="o_path_fd" direction="in"/>
+      <arg type="b" name="reuse_existing" direction="in"/>
+      <arg type="b" name="persistent" direction="in"/>
+      <arg type="s" name="doc_id" direction="out"/>
     </method>
 
     <!--
@@ -95,11 +95,12 @@
     -->
     <method name="AddNamed">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
-      <arg type='h' name='o_path_parent_fd' direction='in'/>
-      <arg type='ay' name='filename' direction='in'/>
-      <arg type='b' name='reuse_existing' direction='in'/>
-      <arg type='b' name='persistent' direction='in'/>
-      <arg type='s' name='doc_id' direction='out'/>
+      <arg type="h" name="o_path_parent_fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QByteArray"/>
+      <arg type="ay" name="filename" direction="in"/>
+      <arg type="b" name="reuse_existing" direction="in"/>
+      <arg type="b" name="persistent" direction="in"/>
+      <arg type="s" name="doc_id" direction="out"/>
     </method>
 
     <!--
@@ -133,12 +134,14 @@
     -->
     <method name="AddFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
-      <arg type='ah' name='o_path_fds' direction='in'/>
-      <arg type='u' name='flags' direction='in'/>
-      <arg type='s' name='app_id' direction='in'/>
-      <arg type='as' name='permissions' direction='in'/>
-      <arg type='as' name='doc_ids' direction='out'/>
-      <arg type='a{sv}' name='extra_out' direction='out'/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QList&lt;QDBusUnixFileDescriptor&gt;"/>
+      <arg type="ah" name="o_path_fds" direction="in"/>
+      <arg type="u" name="flags" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="as" name="permissions" direction="in"/>
+      <arg type="as" name="doc_ids" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="extra_out" direction="out"/>
     </method>
 
     <!--
@@ -169,13 +172,14 @@
     -->
     <method name="AddNamedFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
-      <arg type='h' name='o_path_fd' direction='in'/>
-      <arg type='ay' name='filename' direction='in'/>
-      <arg type='u' name='flags' direction='in'/>
-      <arg type='s' name='app_id' direction='in'/>
-      <arg type='as' name='permissions' direction='in'/>
-      <arg type='s' name='doc_id' direction='out'/>
-      <arg type='a{sv}' name='extra_out' direction='out'/>
+      <arg type="h" name="o_path_fd" direction="in"/>
+      <arg type="ay" name="filename" direction="in"/>
+      <arg type="u" name="flags" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="as" name="permissions" direction="in"/>
+      <arg type="s" name="doc_id" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="extra_out" direction="out"/>
     </method>
 
     <!--
@@ -191,9 +195,9 @@
         has the ``grant-permissions`` permission for the document.
     -->
     <method name="GrantPermissions">
-      <arg type='s' name='doc_id' direction='in'/>
-      <arg type='s' name='app_id' direction='in'/>
-      <arg type='as' name='permissions' direction='in'/>
+      <arg type="s" name="doc_id" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="as" name="permissions" direction="in"/>
     </method>
 
     <!--
@@ -209,9 +213,9 @@
         has the ``grant-permissions`` permission for the document.
     -->
     <method name="RevokePermissions">
-      <arg type='s' name='doc_id' direction='in'/>
-      <arg type='s' name='app_id' direction='in'/>
-      <arg type='as' name='permissions' direction='in'/>
+      <arg type="s" name="doc_id" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="as" name="permissions" direction="in"/>
     </method>
 
     <!--
@@ -225,7 +229,7 @@
         has the ``delete`` permission for the document.
     -->
     <method name="Delete">
-      <arg type='s' name='doc_id' direction='in'/>
+      <arg type="s" name="doc_id" direction="in"/>
     </method>
 
     <!--
@@ -238,8 +242,8 @@
         This call is not available inside the sandbox.
     -->
     <method name="Lookup">
-      <arg type='ay' name='filename' direction='in'/>
-      <arg type='s' name='doc_id' direction='out'/>
+      <arg type="ay" name="filename" direction="in"/>
+      <arg type="s" name="doc_id" direction="out"/>
     </method>
 
     <!--
@@ -254,9 +258,10 @@
         This call is not available inside the sandbox.
     -->
     <method name="Info">
-      <arg type='s' name='doc_id' direction='in'/>
-      <arg type='ay' name='path' direction='out'/>
-      <arg type='a{sas}' name='apps' direction='out'/>
+      <arg type="s" name="doc_id" direction="in"/>
+      <arg type="ay" name="path" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QMap&lt;QString,QStringList&gt;"/>
+      <arg type="a{sas}" name="apps" direction="out"/>
     </method>
 
     <!--
@@ -270,8 +275,9 @@
         This call is not available inside the sandbox.
     -->
     <method name="List">
-      <arg type='s' name='app_id' direction='in'/>
-      <arg type='a{say}' name='docs' direction='out'/>
+      <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QMap&lt;QString,QByteArray&gt;"/>
+      <arg type="a{say}" name="docs" direction="out"/>
     </method>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.portal.DynamicLauncher.xml
@@ -91,6 +91,7 @@
       <arg type="s" name="token" direction="in"/>
       <arg type="s" name="desktop_file_id" direction="in"/>
       <arg type="s" name="desktop_entry" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
     <!--
@@ -153,6 +154,7 @@
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="name" direction="in"/>
       <arg type="v" name="icon_v" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -176,6 +178,7 @@
     <method name="RequestInstallToken">
       <arg type="s" name="name" direction="in"/>
       <arg type="v" name="icon_v" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="s" name="token" direction="out"/>
     </method>
@@ -217,6 +220,7 @@
     -->
     <method name="Uninstall">
       <arg type="s" name="desktop_file_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
     <!--
@@ -289,6 +293,7 @@
     -->
     <method name="Launch">
       <arg type="s" name="desktop_file_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
     <!--

--- a/data/org.freedesktop.portal.Email.xml
+++ b/data/org.freedesktop.portal.Email.xml
@@ -111,6 +111,7 @@
     <method name="ComposeEmail">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -151,6 +151,7 @@
     <method name="OpenFile">
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="title" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -240,6 +241,7 @@
     <method name="SaveFile">
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="title" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -318,6 +320,7 @@
     <method name="SaveFiles">
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="title" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.FileTransfer.xml
+++ b/data/org.freedesktop.portal.FileTransfer.xml
@@ -80,6 +80,7 @@
           Default: True
     -->
     <method name="StartTransfer">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="s" name="key" direction="out"/>
     </method>
@@ -103,7 +104,9 @@
     <method name="AddFiles">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="s" name="key" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QList&lt;QDBusUnixFileDescriptor&gt;"/>
       <arg type="ah" name="fds" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
 
@@ -125,6 +128,7 @@
     -->
     <method name="RetrieveFiles">
       <arg type="s" name="key" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="as" name="files" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -72,9 +72,9 @@
           session.
     -->
     <method name="CreateSession">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
     </method>
 
     <!--
@@ -132,13 +132,12 @@
     -->
     <method name="BindShortcuts">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
       <arg type="a(sa{sv})" name="shortcuts" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="request_handle" direction="out"/>
-
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
     </method>
 
     <!--
@@ -169,9 +168,9 @@
     -->
     <method name="ListShortcuts">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="request_handle" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
 
     <!--
@@ -187,8 +186,8 @@
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="s" name="shortcut_id" direction="out"/>
       <arg type="t" name="timestamp" direction="out"/>
-      <arg type="a{sv}" name="options" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
     <!--
@@ -204,8 +203,8 @@
       <arg type="o" name="session_handle" direction="out"/>
       <arg type="s" name="shortcut_id" direction="out"/>
       <arg type="t" name="timestamp" direction="out"/>
-      <arg type="a{sv}" name="options" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
     <!--
@@ -221,8 +220,8 @@
     -->
     <signal name="ShortcutsChanged">
       <arg type="o" name="session_handle" direction="out"/>
-      <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QList&lt;QPair&lt;QString,QVariantMap&gt;&gt;"/>
+      <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
     </signal>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -62,6 +62,7 @@
     <method name="Inhibit">
       <arg type="s" name="window" direction="in"/>
       <arg type="u" name="flags" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -107,6 +108,7 @@
     -->
     <method name="CreateMonitor">
       <arg type="s" name="window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -142,6 +144,7 @@
     -->
     <signal name="StateChanged">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="state" direction="out"/>
     </signal>
 

--- a/data/org.freedesktop.portal.InputCapture.xml
+++ b/data/org.freedesktop.portal.InputCapture.xml
@@ -107,6 +107,7 @@
     -->
     <method name="CreateSession">
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -165,6 +166,7 @@
     -->
     <method name="GetZones">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -248,7 +250,9 @@
     -->
     <method name="SetPointerBarriers">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QList&lt;QVariantMap&gt;"/>
       <arg type="aa{sv}" name="barriers" direction="in"/>
       <arg type="u" name="zone_set" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
@@ -266,6 +270,7 @@
     -->
     <method name="Enable">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
 
@@ -292,6 +297,7 @@
     -->
     <method name="Disable">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
 
@@ -337,6 +343,7 @@
     -->
     <method name="Release">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
 
@@ -358,6 +365,7 @@
       <annotation name="org.gtk.GDBus.C.Name" value="connect_to_eis"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>
@@ -377,6 +385,7 @@
     -->
     <signal name="Disabled">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
@@ -440,6 +449,7 @@
     -->
     <signal name="Activated">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
@@ -461,6 +471,7 @@
     -->
     <signal name="Deactivated">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 
@@ -494,6 +505,7 @@
     -->
     <signal name="ZonesChanged">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="out"/>
     </signal>
 

--- a/data/org.freedesktop.portal.Location.xml
+++ b/data/org.freedesktop.portal.Location.xml
@@ -67,6 +67,7 @@
           - ``EXACT``: 5
     -->
     <method name="CreateSession">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -92,6 +93,7 @@
     <method name="Start">
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -136,6 +138,7 @@
       -->
     <signal name="LocationUpdated">
       <arg type="o" name="session_handle" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="location" direction="out"/>
     </signal>
 

--- a/data/org.freedesktop.portal.NetworkMonitor.xml
+++ b/data/org.freedesktop.portal.NetworkMonitor.xml
@@ -49,7 +49,7 @@
         the available property.
     -->
     <method name="GetAvailable">
-      <arg type='b' name='available' direction='out'/>
+      <arg type="b" name="available" direction="out"/>
     </method>
     <!--
         GetMetered:
@@ -64,7 +64,7 @@
         the metered property.
     -->
     <method name="GetMetered">
-      <arg type='b' name='metered' direction='out'/>
+      <arg type="b" name="metered" direction="out"/>
     </method>
     <!--
         GetConnectivity:
@@ -82,7 +82,7 @@
         the connectivity property.
     -->
     <method name="GetConnectivity">
-      <arg type='u' name='connectivity' direction='out'/>
+      <arg type="u" name="connectivity" direction="out"/>
     </method>
     <!--
         GetStatus:
@@ -107,7 +107,8 @@
         This method was added in version 3 to avoid multiple round-trips.
     -->
     <method name="GetStatus">
-      <arg type='a{sv}' name='status' direction='out'/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+      <arg type="a{sv}" name="status" direction="out"/>
     </method>
 
     <!--
@@ -120,9 +121,9 @@
         This method was added in version 3.
     -->
     <method name="CanReach">
-      <arg type='s' name='hostname' direction='in'/>
-      <arg type='u' name='port' direction='in'/>
-      <arg type='b' name='reachable' direction='out'/>
+      <arg type="s" name="hostname" direction="in"/>
+      <arg type="u" name="port" direction="in"/>
+      <arg type="b" name="reachable" direction="out"/>
     </method>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -119,6 +119,7 @@
       -->
     <method name="AddNotification">
       <arg type="s" name="id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="notification" direction="in"/>
     </method>
     <!--

--- a/data/org.freedesktop.portal.OpenURI.xml
+++ b/data/org.freedesktop.portal.OpenURI.xml
@@ -74,6 +74,7 @@
     <method name="OpenURI">
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="uri" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -122,6 +123,7 @@
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="h" name="fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -157,6 +159,7 @@
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="h" name="fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -250,8 +250,11 @@
     <method name="PreparePrint">
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="title" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="settings" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="page_setup" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -305,6 +308,7 @@
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="title" direction="in"/>
       <arg type="h" name="fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -72,6 +72,7 @@
           session.
     -->
     <method name="CreateSession">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -129,6 +130,7 @@
     -->
     <method name="SelectDevices">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -180,6 +182,7 @@
     <method name="Start">
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -196,6 +199,7 @@
     -->
     <method name="NotifyPointerMotion">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="d" name="dx" direction="in"/>
       <arg type="d" name="dy" direction="in"/>
@@ -215,6 +219,7 @@
     -->
     <method name="NotifyPointerMotionAbsolute">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="stream" direction="in"/>
       <arg type="d" name="x" direction="in"/>
@@ -239,6 +244,7 @@
     -->
     <method name="NotifyPointerButton">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="i" name="button" direction="in"/>
       <arg type="u" name="state" direction="in"/>
@@ -267,6 +273,7 @@
     -->
     <method name="NotifyPointerAxis">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="d" name="dx" direction="in"/>
       <arg type="d" name="dy" direction="in"/>
@@ -289,6 +296,7 @@
     -->
     <method name="NotifyPointerAxisDiscrete">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="axis" direction="in"/>
       <arg type="i" name="steps" direction="in"/>
@@ -310,6 +318,7 @@
     -->
     <method name="NotifyKeyboardKeycode">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="i" name="keycode" direction="in"/>
       <arg type="u" name="state" direction="in"/>
@@ -331,6 +340,7 @@
     -->
     <method name="NotifyKeyboardKeysym">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="i" name="keysym" direction="in"/>
       <arg type="u" name="state" direction="in"/>
@@ -354,6 +364,7 @@
     -->
     <method name="NotifyTouchDown">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="stream" direction="in"/>
       <arg type="u" name="slot" direction="in"/>
@@ -379,6 +390,7 @@
     -->
     <method name="NotifyTouchMotion">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="stream" direction="in"/>
       <arg type="u" name="slot" direction="in"/>
@@ -398,6 +410,7 @@
     -->
     <method name="NotifyTouchUp">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="slot" direction="in"/>
     </method>
@@ -432,6 +445,7 @@
       <annotation name="org.gtk.GDBus.C.Name" value="connect_to_eis"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Request.xml
+++ b/data/org.freedesktop.portal.Request.xml
@@ -84,8 +84,8 @@
     -->
     <signal name="Response">
       <arg type="u" name="response"/>
-      <arg type="a{sv}" name="results"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results"/>
     </signal>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -59,6 +59,7 @@
           session.
     -->
     <method name="CreateSession">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -142,6 +143,7 @@
     -->
     <method name="SelectSources">
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -237,6 +239,7 @@
     <method name="Start">
       <arg type="o" name="session_handle" direction="in"/>
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -256,6 +259,7 @@
       <annotation name="org.gtk.GDBus.C.Name" value="open_pipewire_remote"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="o" name="session_handle" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="h" name="fd" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -66,6 +66,7 @@
     -->
     <method name="Screenshot">
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -93,6 +94,7 @@
       -->
     <method name="PickColor">
       <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Secret.xml
+++ b/data/org.freedesktop.portal.Secret.xml
@@ -74,6 +74,7 @@
       <annotation name="org.gtk.GDBus.C.Name" value="retrieve_secret"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="h" name="fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>

--- a/data/org.freedesktop.portal.Session.xml
+++ b/data/org.freedesktop.portal.Session.xml
@@ -68,6 +68,7 @@
         The content of @details is specified by the interface creating the session.
     -->
     <signal name="Closed">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
       <arg type="a{sv}" name="details"/>
     </signal>
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -72,9 +72,10 @@
       If @namespaces is an empty array or contains an empty string it matches all. Globbing is supported but only for
       trailing sections, e.g. "org.example.*".
     -->
-    <method name='ReadAll'>
-      <arg name='namespaces' type='as'/>
-      <arg name='value' direction='out' type='a{sa{sv}}'/>
+    <method name="ReadAll">
+      <arg type="as" name="namespaces"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QMap&lt;QString,QVariantMap&gt;"/>
+      <arg type="a{sa{sv}}" name="value" direction="out"/>
     </method>
 
     <!--
@@ -91,11 +92,11 @@
       returned inside two layers of variant, for example
       `&lt;&lt;string "hello"&gt;&gt;`.
     -->
-    <method name='Read'>
+    <method name="Read">
       <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
-      <arg name='namespace' type='s'/>
-      <arg name='key' type='s'/>
-      <arg name='value' direction='out' type='v'/>
+      <arg type="s" name="namespace"/>
+      <arg type="s" name="key"/>
+      <arg type="v" name="value" direction="out"/>
     </method>
 
     <!--
@@ -108,10 +109,10 @@
 
       This method was added in version 2.
     -->
-    <method name='ReadOne'>
-      <arg name='namespace' type='s'/>
-      <arg name='key' type='s'/>
-      <arg name='value' direction='out' type='v'/>
+    <method name="ReadOne">
+      <arg type="s" name="namespace" direction="in"/>
+      <arg type="s" name="key" direction="in"/>
+      <arg type="v" name="value" direction="out"/>
     </method>
 
     <!--
@@ -122,10 +123,10 @@
 
       Emitted when a setting changes.
     -->
-    <signal name='SettingChanged'>
-      <arg name='namespace' direction='out' type='s'/>
-      <arg name='key' direction='out' type='s'/>
-      <arg name='value' direction='out' type='v'/>
+    <signal name="SettingChanged">
+      <arg type="s" name="namespace" direction="out"/>
+      <arg type="s" name="key" direction="out"/>
+      <arg type="v" name="value" direction="out"/>
     </signal>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.portal.Wallpaper.xml
+++ b/data/org.freedesktop.portal.Wallpaper.xml
@@ -56,6 +56,7 @@
     <method name="SetWallpaperURI">
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="s" name="uri" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
@@ -85,6 +86,7 @@
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type="s" name="parent_window" direction="in"/>
       <arg type="h" name="fd" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>


### PR DESCRIPTION
Tested both by adding all `.xml` interface files to a Qt project via `qt_add_dbus_interface`, and through `meson test -C _build`.

Two tests are failing, attached for posterity:
[testlog.txt](https://github.com/flatpak/xdg-desktop-portal/files/15142973/testlog.txt)
They don't seem to be introduced by this PR though, as I can still reproduce them on the previous commit, even after a clean rebuild.

Note that [`Lockdown.xml`](https://github.com/flatpak/xdg-desktop-portal/blob/0cad9ea9d8aec9c8c504f83a0201a56b55e7cd44/data/org.freedesktop.impl.portal.Lockdown.xml#L34) still errors as its property names are `kebab-cased` instead of `snake_cased`, which Qt considers as invalid.

- Add missing Qt type annotations for complex types
- Reorder Qt type annotations to the line above their corresponding parameters for consistency
- Fix incorrect argument names

Also does minor formatting changes for consistency:
- Prefer double quotes over single quotes
- Prefer `type=` before `name=`