### PR TITLE
permissions-db: Fix GError double free

### DIFF
--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -838,7 +838,7 @@ save_content_callback (GObject      *source_object,
   if (ok)
     g_task_return_boolean (task, TRUE);
   else
-    g_task_return_error (task, error);
+    g_task_return_error (task, g_steal_pointer (&error));
 }
 
 void


### PR DESCRIPTION
```
May 02 22:08:23 linux xdg-permission-store[63750]: free(): double free detected in tcache 2
May 02 22:08:23 linux systemd[3051]: xdg-permission-store.service: Main process exited, code=dumped, status=6/ABRT
May 02 22:08:23 linux systemd[3051]: xdg-permission-store.service: Failed with result 'core-dump'.
```

```
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007fa6f83da1cf in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  0x00007fa6f838c472 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007fa6f83764b2 in __GI_abort () at ./stdlib/abort.c:79
#4  0x00007fa6f83771ed in __libc_message (fmt=fmt@entry=0x7fa6f84e978c "%s\n") at ../sysdeps/posix/libc_fatal.c:150
#5  0x00007fa6f83e3ae5 in malloc_printerr (str=str@entry=0x7fa6f84ec598 "free(): double free detected in tcache 2") at ./malloc/malloc.c:5658
#6  0x00007fa6f83e5d66 in _int_free (av=0x7fa6e4000030, p=0x7fa6e4008f50, have_lock=have_lock@entry=0) at ./malloc/malloc.c:4466
#7  0x00007fa6f83e81df in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3367
#8  0x00007fa6f88f4e59 in g_free (mem=<optimized out>) at ../../../glib/gmem.c:208
#9  0x00007fa6f88d4c24 in g_error_free (error=0x7fa6e4006e90) at ../../../glib/gerror.c:381
#10 0x000055e960269f1d in glib_autoptr_clear_GError (_ptr=<optimized out>) at /usr/include/glib-2.0/glib/glib-autocleanups.h:54
#11 glib_autoptr_cleanup_GError (_ptr=0x7ffc5e67aca0) at /usr/include/glib-2.0/glib/glib-autocleanups.h:54
#12 save_content_callback (source_object=<optimized out>, res=<optimized out>, user_data=0x55e9608d24f0) at ../document-portal/permission-db.c:833
#13 0x00007fa6f87596c3 in g_task_return_now (task=task@entry=0x55e9608dc5a0 [GTask]) at ../../../gio/gtask.c:1361
#14 0x00007fa6f875a363 in g_task_return (type=<optimized out>, task=0x55e9608dc5a0 [GTask]) at ../../../gio/gtask.c:1430
#15 g_task_return (task=0x55e9608dc5a0 [GTask], type=<optimized out>) at ../../../gio/gtask.c:1387
#16 0x00007fa6f870a37d in replace_contents_open_callback (obj=<optimized out>, open_res=<optimized out>, user_data=0x55e9608dc570) at ../../../gio/gfile.c:8528
#17 0x00007fa6f87596c3 in g_task_return_now (task=task@entry=0x55e9608dc680 [GTask]) at ../../../gio/gtask.c:1361
#18 0x00007fa6f87596fd in complete_in_idle_cb (task=0x55e9608dc680) at ../../../gio/gtask.c:1375
#19 0x00007fa6f88ebddf in g_main_dispatch (context=context@entry=0x55e9608c0090) at ../../../glib/gmain.c:3344
#20 0x00007fa6f88ede67 in g_main_context_dispatch_unlocked (context=0x55e9608c0090) at ../../../glib/gmain.c:4152
#21 g_main_context_iterate_unlocked (context=0x55e9608c0090, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../../../glib/gmain.c:4217
#22 0x00007fa6f88ee76f in g_main_loop_run (loop=0x55e9608ca6a0) at ../../../glib/gmain.c:4419
#23 0x000055e960260726 in main (argc=<optimized out>, argv=<optimized out>) at ../document-portal/permission-store.c:135
```