### PR TITLE
portal-impl: Use fallback portals for Settings as well

### DIFF
--- a/src/portal-impl.c
+++ b/src/portal-impl.c
@@ -653,8 +653,6 @@ PortalImplementation *
 find_portal_implementation (const char *interface)
 {
   const char **desktops;
-  GList *l;
-  int i;
 
   if (portal_interface_prefers_none (interface))
     return NULL;
@@ -677,9 +675,9 @@ find_portal_implementation (const char *interface)
   desktops = get_current_lowercase_desktops ();
 
   /* Fallback to the old UseIn key */
-  for (i = 0; desktops[i] != NULL; i++)
+  for (size_t i = 0; desktops[i] != NULL; i++)
     {
-      for (l = implementations; l != NULL; l = l->next)
+      for (GList *l = implementations; l != NULL; l = l->next)
         {
           PortalImplementation *impl = l->data;
 
@@ -703,7 +701,7 @@ find_portal_implementation (const char *interface)
    * try to fall back to x-d-p-gtk, which has historically been the portal
    * UI backend used by desktop environments with no backend of their own.
    * If it isn't installed, that is not an error: we just don't use it. */
-  for (l = implementations; l != NULL; l = l->next)
+  for (GList *l = implementations; l != NULL; l = l->next)
     {
       PortalImplementation *impl = l->data;
 
@@ -727,8 +725,6 @@ find_all_portal_implementations (const char *interface)
 {
   const char **desktops;
   GPtrArray *impls;
-  GList *l;
-  int i;
 
   impls = g_ptr_array_new ();
 
@@ -756,9 +752,9 @@ find_all_portal_implementations (const char *interface)
   desktops = get_current_lowercase_desktops ();
 
   /* Fallback to the old UseIn key */
-  for (i = 0; desktops[i] != NULL; i++)
+  for (size_t i = 0; desktops[i] != NULL; i++)
     {
-      for (l = implementations; l != NULL; l = l->next)
+      for (GList *l = implementations; l != NULL; l = l->next)
         {
           PortalImplementation *impl = l->data;
 
@@ -785,7 +781,7 @@ find_all_portal_implementations (const char *interface)
    * try to fall back to x-d-p-gtk, which has historically been the portal
    * UI backend used by desktop environments with no backend of their own.
    * If it isn't installed, that is not an error: we just don't use it. */
-  for (l = implementations; l != NULL; l = l->next)
+  for (GList *l = implementations; l != NULL; l = l->next)
     {
       PortalImplementation *impl = l->data;
 


### PR DESCRIPTION
Since 1.18.2, we have a hardcoded fallback to xdg-desktop-portal-gtk as a last resort if no other portal is defined by a configuration file. This fallback mechanism, however, isn't implemented for the org.freedesktop.impl.portal.Settings interface.

The consequence is that everything seems to work just fine, but user preferences like color scheme are ignored in applications that use the portal API to retrieve them (not just flatpak apps, also libadwaita apps). That comes as a surprise to users; and since the portal stuff otherwise works fine, it's not entirely straightforward to figure out that configuring portal.conf would fix it.

I believe that if [`find_portal_implementation`](https://github.com/flatpak/xdg-desktop-portal/blob/ef1e96b51be6313f524279cd77c8261d1e5186ba/src/portal-impl.c#L598) implements fallbacks, so should [`find_all_portal_implementations`](https://github.com/flatpak/xdg-desktop-portal/blob/ef1e96b51be6313f524279cd77c8261d1e5186ba/src/portal-impl.c#L670), for consistency and to avoid surprises.

The fallback logic this commit implements closely resembles [the logic in `find_portal_implementation`](https://github.com/flatpak/xdg-desktop-portal/blob/ef1e96b51be6313f524279cd77c8261d1e5186ba/src/portal-impl.c#L621-L664): we don't look for fallbacks if there is a portal configured in portals.conf (or if portals.conf explicitly says there should be none), and we only use the x-d-p-gtk as a last resort if we haven't found any impl(s) using the legacy UseIn key.

(The above should be a self-contained description but there's some additional thoughts at https://github.com/flatpak/xdg-desktop-portal/pull/1199#issuecomment-2093902804)

Fixes: d18c563b6a34 ("portal-impl: Hard-code x-d-p-gtk as a last-resort fallback")
Related: https://github.com/flatpak/xdg-desktop-portal/issues/1102
