### PR TITLE
document-portal: fix crash on auto-cleanup of path we don't own

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1492,7 +1492,7 @@ portal_get_host_paths (GDBusMethodInvocation *invocation,
   for (size_t i = 0; id_list[i] != NULL; i++)
     {
       g_autoptr(GError) error = NULL;
-      g_autofree const char *path = NULL;
+      const char *path = NULL;
 
       path = get_host_path_internal (invocation, app_info, id_list[i], &error);
       if (path == NULL)


### PR DESCRIPTION
Do not automatically free a path we get from document_entry_get_path().

From ASAN:
```
==541366==ERROR: AddressSanitizer: SEGV on unknown address 0x7f24a6f99170 (pc 0x7f24a7ea31c5 bp 0x7f24a6f99170 sp 0x7ffd9c12d570 T0)
==541366==The signal is caused by a WRITE memory access.
    #0 0x7f24a7ea31c5 in __asan::Allocator::Deallocate(void*, unsigned long, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType) (/lib64/libasan.so.8+0x441c5) (BuildId: 388cbb99455c2e2eaec79bd8db6d9a78eb39f80d)
    #1 0x7f24a7f5452e in free.part.0 (/lib64/libasan.so.8+0xf552e) (BuildId: 388cbb99455c2e2eaec79bd8db6d9a78eb39f80d)
    #2 0x7f24a7d6f294 in g_free (/lib64/libglib-2.0.so.0+0x5d294) (BuildId: 795136df3faa85587229ddc59d709f81d6f697df)
    #3 0x4225ed in g_autoptr_cleanup_generic_gfree /usr/include/glib-2.0/glib/glib-autocleanups.h:32
    #4 0x42d945 in portal_get_host_paths ../document-portal/document-portal.c:1495
    #5 0x42b5f5 in handle_method ../document-portal/document-portal.c:1201
    #6 0x40dadb in _g_dbus_codegen_marshal_BOOLEAN__OBJECT_BOXED document-portal/document-portal-dbus.c:586
    #7 0x40e516 in xdp_dbus_documents_method_marshal_get_host_paths document-portal/document-portal-dbus.c:1710
```