### PR TITLE
screen-cast: Add textual context hint

### DIFF
--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -138,6 +138,16 @@
         Start the screen cast session. This will typically result the portal presenting
         a dialog letting the user do the selection set up by SelectSources.
 
+        Supported keys in the @options vardict include:
+
+        * ``context_hint`` (``s``)
+
+          Textual hint that can be shown on the presented dialog. This allow the user to
+          know the context behind the selection dialog if the application happens use
+          multiple sessions.
+
+          The string is localized by the application.
+
         The following results get returned in the @results vardict:
 
         * ``streams`` (``a(ua{sv})``)

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -168,6 +168,14 @@
           object path element. See the :ref:`org.freedesktop.portal.Request` documentation for
           more information about the @handle.
 
+        * ``context_hint`` (``s``)
+
+          Textual hint that can be shown on the presented dialog. This allow the user to
+          know the context behind the selection dialog if the application happens use
+          multiple sessions.
+
+          The string is localized by the application.
+
         The following results get returned via the
         :ref:`org.freedesktop.portal.Request::Response` signal:
 

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -831,6 +831,10 @@ start_done (GObject *source_object,
     }
 }
 
+static XdpOptionKey start_options[] = {
+  { "context_hint", G_VARIANT_TYPE_STRING, NULL },
+};
+
 static gboolean
 handle_start (XdpDbusScreenCast *object,
               GDBusMethodInvocation *invocation,
@@ -906,6 +910,9 @@ handle_start (XdpDbusScreenCast *object,
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
   g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_filter_options (arg_options, &options_builder,
+                      start_options, G_N_ELEMENTS (start_options),
+                      NULL);
   options = g_variant_builder_end (&options_builder);
 
   g_object_set_qdata_full (G_OBJECT (request),


### PR DESCRIPTION
Adds an optional argument to display a textual hint on the Screen Cast selection dialog.

When a software like OBS Studio has multiple Screen Cast session, the user has no way to know from which session the dialog comes from when prompted at start.
This new argument allows to mitigate that if used by the implementation.

- [OBS Studio branch with context hint support](https://github.com/tytan652/obs-studio/tree/screen_cast_context_hint)
- [xdg-desktop-portal-gnome branch with context hint support](https://gitlab.gnome.org/tytan652/xdg-desktop-portal-gnome/-/tree/tytan652/dirty_screen_cast_context_hint), the design is a patchwork not meant to be upstream