### PR TITLE
globalshorts: Do what the docs say

### DIFF
--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -186,7 +186,7 @@ session_created_cb (GObject *source_object,
     }
 
   g_variant_builder_add (&results_builder, "{sv}",
-                         "session_handle", g_variant_new ("s", session->id));
+                         "session_id", g_variant_new ("s", session->id));
 
 out:
   if (request->exported)


### PR DESCRIPTION
The docs say that the reponse brings the session handle with the 'session_id' key. But the code was using 'session_handle'.