### PR TITLE
Make contribution link in README.md direct instead of requiring more clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ production.
 
 xdg-desktop-portal depends on GLib and Flatpak.
 To build the documentation, you will need xmlto and the docbook stylesheets.
-For more instructions, please read [CONTRIBUTING.md][contributing].
+For more instructions, please read [the contribution guidelines](https://flatpak.github.io/xdg-desktop-portal/docs/contributing.html).
 
 ## Using Portals
 


### PR DESCRIPTION
This is just a tiny thing but it was one more hurdle - `CONTRIBUTING.md` doesn't contain anything except a link to the "real" docs, so there's not much point for the README to point there.