### PR TITLE
tests: Fix mistake in notification tests

### DIFF
--- a/tests/notification.c
+++ b/tests/notification.c
@@ -29,10 +29,6 @@ notification_succeed (GObject      *source,
   res = xdp_portal_add_notification_finish (portal, result, &error);
   g_assert_no_error (error);
   g_assert_true (res);
-
-  got_info++;
-
-  g_main_context_wakeup (NULL);
 }
 
 static void
@@ -225,7 +221,7 @@ test_icon (const char *serialized_icon,
                                                "}",
                                                expected_serialized_icon);
 
-  run_notification_test ("test-icon", notification_s, expected_serialized_icon, expect_failure);
+  run_notification_test ("test-icon", notification_s, expected_notification_s, expect_failure);
 }
 
 static void

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -124,7 +124,7 @@ run_notification_test (const char *notification_id,
   if (!expect_failure)
     g_signal_handler_disconnect (portal, id);
 
-  xdp_portal_remove_notification (portal, "test");
+  xdp_portal_remove_notification (portal, notification_id);
 }
 
 void


### PR DESCRIPTION
The commit [1] introduced an issue that the test would terminate before
it actually run, which was probably done because the expected
notification string was set to the serialized icon instead of the
actual expected notification string.

[1] https://github.com/flatpak/xdg-desktop-portal/commit/412b3ea4bb4e1425352cc1c836030d086a037dd1