### PR TITLE
Fix potential segfault in permissions.c

### DIFF
--- a/src/permissions.c
+++ b/src/permissions.c
@@ -44,8 +44,16 @@ get_permissions_sync (const char *app_id,
                                                         NULL,
                                                         &error))
     {
-      g_dbus_error_strip_remote_error (error);
-      g_debug ("No '%s' permissions found: %s", table, error->message);
+      if (error != NULL)
+        {
+          g_dbus_error_strip_remote_error (error);
+          g_debug ("No '%s' permissions found: %s", table, error->message);
+        }
+      else
+        {
+          g_debug ("No '%s' permissions found", table);
+        }
+
       return NULL;
     }
 


### PR DESCRIPTION
Under specific circumstances, xdp could segfault due to `error` variable being NULL. This patch adds a check that prevents us from referencing `error` if it's not initialised. 

```
[174025.661871] pool-/usr/lib/x[621481]: segfault at 8 ip 000055e10b83d484 sp 00007fc411fff7c0 error 4 in xdg-desktop-portal[55e10b7d5000+86000] likely on CPU 0 (core 0, socket 0)
[174025.661899] Code: 5d c3 0f 1f 40 00 48 8b 7d d0 ff 15 6e fc 06 00 48 8b 45 d0 4c 89 f1 48 8d 15 a8 0d 02 00 be 80 00 00 00 48 8d 3d 2d 16 02 00 <4c> 8b 40 08 31 c0 ff 15 90 0a 07 00 31 db e9 6f ff ff ff 66 0f 1f
```
[xdp-bt.txt](https://github.com/user-attachments/files/16325136/xdp-bt.txt)
