### PR TITLE
README: Describe the activation environment requirements for x-d-p

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,58 @@ When it comes to processes, passing PIDs around is not useful in a sandboxed
 world where apps are likely in their own PID namespace. And passing PIDs from
 inside the sandbox is problematic, since the app can just lie.
 
+## System Integration
+
+### D-Bus Activation Environment
+
+xdg-desktop-portal and its portal backends are activatable D-Bus services.
+This means that they inherit environment variables from the
+"activation environment" maintained by either `systemd --user`
+(on systems that use systemd) or `dbus-daemon` (on systems that do not).
+They do not inherit environment variables from the GUI environment or
+from the shell, unless some component of the overall system takes
+responsibility for taking the necessary environment variables from the
+GUI environment and sending them to `systemd` or `dbus-daemon` to be
+added to the activation environment.
+
+In integrated desktop environments such as GNOME and KDE Plasma, and in
+OS distributions with a high level of integration, this should be done
+automatically by desktop environment or OS infrastructure.
+
+Variables that might need to be propagated in this way include, but are
+not limited to:
+
+- `DISPLAY`
+- `PATH`
+- `WAYLAND_DISPLAY`
+- `XAUTHORITY`
+- `XDG_CURRENT_DESKTOP`
+- `XDG_DATA_DIRS`
+
+In environments that are assembled out of individual components by
+the user, it is the user's responsibility to ensure that this system
+integration has been done, for example by using
+[dbus-update-activation-environment(1)][dbus-update-activation-environment]
+or [`systemctl --user import-environment VAR…`][systemctl].
+
+### Desktop Environment Requirements
+
+The display manager or GUI environment is responsible for setting
+`XDG_CURRENT_DESKTOP` to an appropriate value.
+
+The GUI environment should provide a
+[portal configuration file][portals.conf] with a name based on its
+`XDG_CURRENT_DESKTOP`, to select appropriate portal backends.
+
+The GUI environment should arrange for its required portal backend or
+backends to be installed as dependencies (possibly as optional
+dependencies, if it is packaged in a loosely-coupled operating system).
+
+In environments that are assembled out of individual components by
+the user, it is the user's responsibility to ensure that this system
+integration has been done.
+
 [contributing]: https://github.com/flatpak/xdg-desktop-portal/blob/main/CONTRIBUTING.md
+[dbus-update-activation-environment]: https://dbus.freedesktop.org/doc/dbus-update-activation-environment.1.html
+[portals.conf]: https://flatpak.github.io/xdg-desktop-portal/docs/portals.conf.html
+[systemctl]: https://www.freedesktop.org/software/systemd/man/latest/systemctl.html


### PR DESCRIPTION
Inspired by https://github.com/flatpak/xdg-desktop-portal-gtk/issues/440 and various other issue reports that can be summarized as "I use (some minimal window manager or compositor), and it didn't propagate an environment variable to the activation environment".