### PR TITLE
Order portal startup after graphical-session.target

### DIFF
--- a/document-portal/xdg-document-portal.service.in
+++ b/document-portal/xdg-document-portal.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=flatpak document portal service
 PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 BusName=org.freedesktop.portal.Documents

--- a/document-portal/xdg-permission-store.service.in
+++ b/document-portal/xdg-permission-store.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=sandboxed app permission store
 PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 BusName=org.freedesktop.impl.portal.PermissionStore

--- a/src/xdg-desktop-portal.service.in
+++ b/src/xdg-desktop-portal.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Portal service
 PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Otherwise portal units might try to start before compositor exported `WAYLAND_DISPLAY` to activation environments.
[Reference](https://github.com/Vladimir-csp/uwsm/issues/37#issuecomment-2307818022)