### PR TITLE
Use sealded memfd for icon validator

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,7 @@ xdp_utils_includes = include_directories('.')
 xdp_utils_sources = files(
   'xdp-utils.c',
   'xdp-app-info.c',
+  'xdp-sealed-fd.c',
 )
 
 if have_libsystemd

--- a/src/meson.build
+++ b/src/meson.build
@@ -174,7 +174,7 @@ endif
 xdp_validate_icon = executable(
   'xdg-desktop-portal-validate-icon',
   'validate-icon.c',
-  dependencies: [gdk_pixbuf_dep],
+  dependencies: [gdk_pixbuf_dep, gio_unix_dep],
   c_args: validate_icon_c_args,
   install: true,
   install_dir: libexecdir,

--- a/src/validate-icon.c
+++ b/src/validate-icon.c
@@ -41,6 +41,7 @@
 #define MAX_ICON_SIZE 512
 #define MAX_SVG_ICON_SIZE 4096
 #define BUFFER_SIZE 4096
+#define MAX_FILE_SIZE (1024 * 1024 * 4) /* Max file size of 4MiB */
 
 static int
 validate_icon (int input_fd)
@@ -72,6 +73,12 @@ validate_icon (int input_fd)
   if (g_bytes_get_size (bytes) == 0)
     {
       g_printerr ("Image is 0 bytes\n");
+      return 1;
+    }
+
+  if (g_bytes_get_size (bytes) > MAX_FILE_SIZE)
+    {
+      g_printerr ("Image is bigger then the allowed size\n");
       return 1;
     }
 

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -1765,7 +1765,6 @@ xdp_app_info_from_snap (int          pid,
 {
   g_autoptr(GError) local_error = NULL;
   g_autofree char *pid_str = NULL;
-  const char *argv[] = { "snap", "routine", "portal-info", NULL, NULL };
   g_autofree char *output = NULL;
   g_autoptr(GKeyFile) metadata = NULL;
   g_autoptr(XdpAppInfo) app_info = NULL;
@@ -1779,8 +1778,8 @@ xdp_app_info_from_snap (int          pid,
     }
 
   pid_str = g_strdup_printf ("%u", (guint) pid);
-  argv[3] = pid_str;
-  if (!xdp_spawnv (NULL, &output, 0, error, argv))
+  output = xdp_spawn (error, "snap", "routine", "portal-info", pid_str, NULL);
+  if (output == NULL)
     {
       return FALSE;
     }

--- a/src/xdp-sealed-fd.c
+++ b/src/xdp-sealed-fd.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2024 GNOME Foundation Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Julian Sparber <jsparber@gnome.org>
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <gio/gunixfdlist.h>
+#include <sys/mman.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "xdp-utils.h"
+#include "xdp-sealed-fd.h"
+
+static const int required_seals = F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_SHRINK;
+
+struct _XdpSealedFd {
+  GObject parent_instance;
+
+  int fd;
+};
+
+G_DEFINE_FINAL_TYPE (XdpSealedFd, xdp_sealed_fd, G_TYPE_OBJECT)
+
+static void
+xdp_sealed_fd_finalize (GObject *object)
+{
+  XdpSealedFd *sealed_fd = XDP_SEALED_FD (object);
+
+  xdp_close_fd (&sealed_fd->fd);
+
+  G_OBJECT_CLASS (xdp_sealed_fd_parent_class)->finalize (object);
+}
+
+static void
+xdp_sealed_fd_class_init (XdpSealedFdClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = xdp_sealed_fd_finalize;
+}
+
+static void
+xdp_sealed_fd_init (XdpSealedFd *sealed_fd)
+{
+  sealed_fd->fd = -1;
+}
+
+XdpSealedFd *
+xdp_sealed_fd_new_take_memfd (int      memfd,
+                              GError **error)
+{
+  int saved_errno = -1;
+  g_autoptr(XdpSealedFd) sealed_fd = NULL;
+  xdp_autofd int fd = g_steal_fd (&memfd);
+  int seals;
+
+  g_return_val_if_fail (fd != -1, NULL);
+
+  seals = fcntl (fd, F_GET_SEALS);
+  if (seals == -1)
+   {
+      saved_errno = errno;
+
+      g_set_error (error,
+                   G_IO_ERROR,
+                   g_io_error_from_errno (saved_errno),
+                   "fcntl F_GET_SEALS: %s", g_strerror (saved_errno));
+      return NULL;
+    }
+
+  /* If the seal seal is set and some required seal is missing report EPERM error directly */
+  if ((seals & F_SEAL_SEAL) && (seals & required_seals) != required_seals)
+    saved_errno = EPERM;
+  else if (fcntl (fd, F_ADD_SEALS, required_seals) == -1)
+    saved_errno = errno;
+
+  if (saved_errno != -1)
+    {
+      g_set_error (error,
+                   G_IO_ERROR,
+                   g_io_error_from_errno (saved_errno),
+                   "fcntl F_ADD_SEALS: %s", g_strerror (saved_errno));
+      return NULL;
+    }
+
+  sealed_fd = g_object_new (XDP_TYPE_SEALED_FD, NULL);
+  sealed_fd->fd = xdp_steal_fd (&fd);
+
+  return g_steal_pointer (&sealed_fd);
+}
+
+XdpSealedFd *
+xdp_sealed_fd_new_from_bytes (GBytes  *bytes,
+                              GError **error)
+{
+  gconstpointer bytes_data;
+  gsize bytes_len;
+  xdp_autofd int fd = -1;
+  int saved_errno = -1;
+  g_autoptr(XdpSealedFd) sealed_fd = NULL;
+  gpointer shm;
+  g_autoptr(GOutputStream) stream = NULL;
+
+  g_return_val_if_fail (bytes != NULL, NULL);
+
+  fd = memfd_create ("xdp-sealed-fd", MFD_ALLOW_SEALING);
+  if (fd == -1)
+    {
+      int saved_errno;
+
+      saved_errno = errno;
+      g_set_error (error,
+                   G_IO_ERROR,
+                   g_io_error_from_errno (saved_errno),
+                   "memfd_create: %s", g_strerror (saved_errno));
+      return NULL;
+    }
+
+  bytes_data = g_bytes_get_data (bytes, &bytes_len);
+
+  if (ftruncate (fd, bytes_len) == -1)
+    {
+      int saved_errno;
+
+      saved_errno = errno;
+      g_set_error (error,
+                   G_IO_ERROR,
+                   g_io_error_from_errno (saved_errno),
+                   "ftruncate: %s", g_strerror (saved_errno));
+      return NULL;
+    }
+
+  shm = mmap (NULL, bytes_len, PROT_WRITE, MAP_SHARED, fd, 0);
+  if (shm == MAP_FAILED)
+    {
+      int saved_errno;
+
+      saved_errno = errno;
+      g_set_error (error,
+                   G_IO_ERROR,
+                   g_io_error_from_errno (saved_errno),
+                   "mmap: %s", g_strerror (saved_errno));
+      return NULL;
+    }
+
+  memcpy (shm, bytes_data, bytes_len);
+
+  if (munmap (shm, bytes_len) == -1)
+    {
+      int saved_errno;
+
+      saved_errno = errno;
+      g_set_error (error,
+                   G_IO_ERROR,
+                   g_io_error_from_errno (saved_errno),
+                   "munmap: %s", g_strerror (saved_errno));
+      return NULL;
+    }
+
+  if (fcntl (fd, F_ADD_SEALS, required_seals) == -1)
+    {
+      saved_errno = errno;
+      g_set_error (error,
+                   G_IO_ERROR,
+                   g_io_error_from_errno (saved_errno),
+                   "fcntl F_ADD_SEALS: %s", g_strerror (saved_errno));
+      return NULL;
+    }
+
+  sealed_fd = g_object_new (XDP_TYPE_SEALED_FD, NULL);
+  sealed_fd->fd = xdp_steal_fd (&fd);
+
+  return g_steal_pointer (&sealed_fd);
+}
+
+XdpSealedFd *
+xdp_sealed_fd_new_from_handle (GVariant     *handle,
+                               GUnixFDList  *fd_list,
+                               GError      **error)
+{
+  int fd_id;
+  xdp_autofd int fd = -1;
+
+  g_return_val_if_fail (g_variant_is_of_type (handle, G_VARIANT_TYPE_HANDLE), NULL);
+  g_return_val_if_fail (G_IS_UNIX_FD_LIST (fd_list), NULL);
+  g_return_val_if_fail (g_unix_fd_list_get_length (fd_list) > 0, NULL);
+
+  fd_id = g_variant_get_handle (handle);
+  fd = g_unix_fd_list_get (fd_list, fd_id, error);
+  if (fd == -1)
+    return NULL;
+
+  return xdp_sealed_fd_new_take_memfd (xdp_steal_fd (&fd), error);
+}
+
+int
+xdp_sealed_fd_get_fd (XdpSealedFd *sealed_fd)
+{
+  g_return_val_if_fail (XDP_IS_SEALED_FD (sealed_fd), -1);
+
+  return sealed_fd->fd;
+}
+
+int
+xdp_sealed_fd_dup_fd (XdpSealedFd *sealed_fd)
+{
+  g_return_val_if_fail (XDP_IS_SEALED_FD (sealed_fd), -1);
+
+  return dup (sealed_fd->fd);
+}

--- a/src/xdp-sealed-fd.h
+++ b/src/xdp-sealed-fd.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2024 GNOME Foundation Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#define XDP_TYPE_SEALED_FD (xdp_sealed_fd_get_type())
+G_DECLARE_FINAL_TYPE (XdpSealedFd,
+                      xdp_sealed_fd,
+                      XDP, SEALED_FD,
+                      GObject)
+
+XdpSealedFd * xdp_sealed_fd_new_take_memfd (int           memfd,
+                                            GError      **error);
+XdpSealedFd * xdp_sealed_fd_new_from_bytes (GBytes       *bytes,
+                                            GError      **error);
+XdpSealedFd * xdp_sealed_fd_new_from_handle (GVariant     *handle,
+                                             GUnixFDList  *fd_list,
+                                             GError      **error);
+int xdp_sealed_fd_get_fd (XdpSealedFd  *sealed_fd);
+int xdp_sealed_fd_dup_fd (XdpSealedFd  *sealed_fd);
+

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -432,7 +432,7 @@ xdp_spawn (GError     **error,
   g_ptr_array_add (args, NULL);
   va_end (ap);
 
-  output = xdp_spawnv ((const char * const *) args->pdata, error);
+  output = xdp_spawn_full ((const char * const *) args->pdata, -1, -1, error);
 
   g_ptr_array_free (args, TRUE);
 
@@ -440,8 +440,10 @@ xdp_spawn (GError     **error,
 }
 
 char *
-xdp_spawnv (const char * const  *argv,
-            GError             **error)
+xdp_spawn_full (const char * const  *argv,
+                int                  source_fd,
+                int                  target_fd,
+                GError             **error)
 {
   g_autoptr(GSubprocessLauncher) launcher = NULL;
   g_autoptr(GSubprocess) subp = NULL;
@@ -452,6 +454,9 @@ xdp_spawnv (const char * const  *argv,
   g_autofree char *commandline = NULL;
 
   launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+
+  if (source_fd != -1)
+    g_subprocess_launcher_take_fd (launcher, source_fd, target_fd);
 
   commandline = xdp_quote_argv ((const char **)argv);
   g_debug ("Running: %s", commandline);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -591,11 +591,8 @@ xdp_validate_serialized_icon (GVariant  *v,
   g_autofree char *stderrlog = NULL;
   g_autoptr(GError) error = NULL;
   const char *icon_validator = LIBEXECDIR "/xdg-desktop-portal-validate-icon";
-  const char *args[6];
-  /* same allowed formats as Flatpak */
-  const char *allowed_icon_formats[] = { "png", "jpeg", "svg", NULL };
+  const char *args[4];
   int size;
-  const char *MAX_ICON_SIZE = "512";
   gconstpointer bytes_data;
   gsize bytes_len;
   g_autoptr(GKeyFile) key_file = NULL;
@@ -657,10 +654,8 @@ xdp_validate_serialized_icon (GVariant  *v,
 
   args[0] = icon_validator;
   args[1] = "--sandbox";
-  args[2] = MAX_ICON_SIZE;
-  args[3] = MAX_ICON_SIZE;
-  args[4] = name;
-  args[5] = NULL;
+  args[2] = name;
+  args[3] = NULL;
 
   if (!g_spawn_sync (NULL, (char **)args, NULL, 0, NULL, NULL, &stdoutlog, &stderrlog, &status, &error))
     {
@@ -682,10 +677,9 @@ xdp_validate_serialized_icon (GVariant  *v,
       g_warning ("Icon validation: %s", error->message);
       return FALSE;
     }
-  if (!(format = g_key_file_get_string (key_file, ICON_VALIDATOR_GROUP, "format", &error)) ||
-      !g_strv_contains (allowed_icon_formats, format))
+  if (!(format = g_key_file_get_string (key_file, ICON_VALIDATOR_GROUP, "format", &error)))
     {
-      g_warning ("Icon validation: %s", error ? error->message : "not allowed format");
+      g_warning ("Icon validation: %s", error->message);
       return FALSE;
     }
   if (!(size = g_key_file_get_integer (key_file, ICON_VALIDATOR_GROUP, "width", &error)))

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -125,8 +125,10 @@ char *   xdp_quote_argv (const char           *argv[]);
 char * xdp_spawn (GError             **error,
                   const char          *argv0,
                   ...) G_GNUC_NULL_TERMINATED;
-char * xdp_spawnv (const char * const  *argv,
-                   GError              **error);
+char * xdp_spawn_full (const char * const  *argv,
+                       int                  source_fd,
+                       int                  target_fd,
+                       GError             **error);
 
 char * xdp_canonicalize_filename (const char *path);
 gboolean  xdp_has_path_prefix (const char *str,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -122,17 +122,11 @@ xdp_close_fd (int *fdp)
 
 
 char *   xdp_quote_argv (const char           *argv[]);
-gboolean xdp_spawn      (GFile                *dir,
-                         char                **output,
-                         GSubprocessFlags      flags,
-                         GError              **error,
-                         const gchar          *argv0,
-                         va_list               ap);
-gboolean xdp_spawnv     (GFile                *dir,
-                         char                **output,
-                         GSubprocessFlags      flags,
-                         GError              **error,
-                         const gchar * const  *argv);
+char * xdp_spawn (GError             **error,
+                  const char          *argv0,
+                  ...) G_GNUC_NULL_TERMINATED;
+char * xdp_spawnv (const char * const  *argv,
+                   GError              **error);
 
 char * xdp_canonicalize_filename (const char *path);
 gboolean  xdp_has_path_prefix (const char *str,

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -30,6 +30,7 @@
 #include <errno.h>
 
 #include "glib-backports.h"
+#include "xdp-sealed-fd.h"
 
 #define DESKTOP_PORTAL_OBJECT_PATH "/org/freedesktop/portal/desktop"
 
@@ -42,10 +43,9 @@ gboolean xdp_is_valid_app_id (const char *string);
 
 char *xdp_get_app_id_from_desktop_id (const char *desktop_id);
 
-gboolean xdp_validate_serialized_icon (GVariant  *v,
-                                       gboolean   bytes_only,
-                                       char     **out_format,
-                                       char     **out_size);
+gboolean xdp_validate_icon (XdpSealedFd  *icon,
+                            char        **out_format,
+                            char        **out_size);
 
 typedef void (*XdpPeerDiedCallback) (const char *name);
 


### PR DESCRIPTION
I split out the first few commits from https://github.com/flatpak/xdg-desktop-portal/pull/1298/ that rework how the validator works and that introduce the `XdpSealdFd`.

CC: @hfiguiere and @GeorgesStavracas 