### PR TITLE
Some follow-ups to the icon validator

### DIFF
--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -161,7 +161,11 @@ validate_serialized_icon (GVariant  *arg_icon_v,
   bytes = g_bytes_icon_get_bytes (G_BYTES_ICON (icon));
   sealed_icon = xdp_sealed_fd_new_from_bytes (bytes, NULL);
 
-  return sealed_icon && xdp_validate_icon (sealed_icon, icon_format, icon_size);
+  return sealed_icon &&
+         xdp_validate_icon (sealed_icon,
+                            XDP_ICON_TYPE_DESKTOP,
+                            icon_format,
+                            icon_size);
 }
 
 static gboolean

--- a/src/notification.c
+++ b/src/notification.c
@@ -430,7 +430,7 @@ parse_serialized_icon (GVariantBuilder  *builder,
 
       if (!sealed_icon)
         g_warning ("Failed to read icon: %s", local_error->message);
-      else if (xdp_validate_icon (sealed_icon, NULL, NULL))
+      else if (xdp_validate_icon (sealed_icon, XDP_ICON_TYPE_NOTIFICATION, NULL, NULL))
         g_variant_builder_add (builder, "{sv}", "icon", icon);
     }
   else

--- a/src/validate-icon.c
+++ b/src/validate-icon.c
@@ -43,6 +43,17 @@
 #define BUFFER_SIZE 4096
 #define MAX_FILE_SIZE (1024 * 1024 * 4) /* Max file size of 4MiB */
 
+static gboolean opt_sandbox;
+static char *opt_path = NULL;
+static int opt_fd = -1;
+
+static GOptionEntry entries[] = {
+  { "sandbox", 0, 0, G_OPTION_ARG_NONE, &opt_sandbox, "Run in a sandbox", NULL },
+  { "path", 0, 0, G_OPTION_ARG_FILENAME, &opt_path, "Read icon data from given file path. Required to be from a trusted source.", "PATH" },
+  { "fd", 0, 0, G_OPTION_ARG_INT, &opt_fd, "Read icon data from given file descriptor. Required to be from a trusted source or to be sealed", "FD" },
+  { NULL }
+};
+
 static int
 validate_icon (int input_fd)
 {
@@ -272,17 +283,6 @@ rerun_in_sandbox (int input_fd)
   return 1;
 }
 #endif
-
-static gboolean opt_sandbox;
-static char *opt_path = NULL;
-static int opt_fd = -1;
-
-static GOptionEntry entries[] = {
-  { "sandbox", 0, 0, G_OPTION_ARG_NONE, &opt_sandbox, "Run in a sandbox", NULL },
-  { "path", 0, 0, G_OPTION_ARG_FILENAME, &opt_path, "Read icon data from given file path. Required to be from a trusted source.", "PATH" },
-  { "fd", 0, 0, G_OPTION_ARG_INT, &opt_fd, "Read icon data from given file descriptor. Required to be from a trusted source or to be sealed", "FD" },
-  { NULL }
-};
 
 int
 main (int argc, char *argv[])

--- a/src/validate-icon.c
+++ b/src/validate-icon.c
@@ -199,11 +199,10 @@ static int
 rerun_in_sandbox (int input_fd)
 {
   const char * const usrmerged_dirs[] = { "bin", "lib32", "lib64", "lib", "sbin" };
-  int i;
   g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func (g_free);
+  g_autofree char* arg_input_fd = NULL;
   char validate_icon[PATH_MAX + 1];
   ssize_t symlink_size;
-  g_autofree char* arg_input_fd = NULL;
 
   symlink_size = readlink ("/proc/self/exe", validate_icon, sizeof (validate_icon) - 1);
   if (symlink_size < 0 || (size_t) symlink_size >= sizeof (validate_icon))
@@ -225,7 +224,7 @@ rerun_in_sandbox (int input_fd)
             NULL);
 
   /* These directories might be symlinks into /usr/... */
-  for (i = 0; i < G_N_ELEMENTS (usrmerged_dirs); i++)
+  for (size_t i = 0; i < G_N_ELEMENTS (usrmerged_dirs); i++)
     {
       g_autofree char *absolute_dir = g_strdup_printf ("/%s", usrmerged_dirs[i]);
 
@@ -274,9 +273,9 @@ rerun_in_sandbox (int input_fd)
 }
 #endif
 
-static gboolean  opt_sandbox;
-static char     *opt_path = NULL;
-static int       opt_fd = -1;
+static gboolean opt_sandbox;
+static char *opt_path = NULL;
+static int opt_fd = -1;
 
 static GOptionEntry entries[] = {
   { "sandbox", 0, 0, G_OPTION_ARG_NONE, &opt_sandbox, "Run in a sandbox", NULL },

--- a/src/xdp-sealed-fd.c
+++ b/src/xdp-sealed-fd.c
@@ -32,7 +32,8 @@
 
 static const int required_seals = F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_SHRINK;
 
-struct _XdpSealedFd {
+struct _XdpSealedFd
+{
   GObject parent_instance;
 
   int fd;
@@ -68,9 +69,9 @@ XdpSealedFd *
 xdp_sealed_fd_new_take_memfd (int      memfd,
                               GError **error)
 {
-  int saved_errno = -1;
   g_autoptr(XdpSealedFd) sealed_fd = NULL;
   xdp_autofd int fd = g_steal_fd (&memfd);
+  int saved_errno = -1;
   int seals;
 
   g_return_val_if_fail (fd != -1, NULL);
@@ -112,13 +113,13 @@ XdpSealedFd *
 xdp_sealed_fd_new_from_bytes (GBytes  *bytes,
                               GError **error)
 {
-  gconstpointer bytes_data;
-  gsize bytes_len;
-  xdp_autofd int fd = -1;
-  int saved_errno = -1;
-  g_autoptr(XdpSealedFd) sealed_fd = NULL;
-  gpointer shm;
   g_autoptr(GOutputStream) stream = NULL;
+  g_autoptr(XdpSealedFd) sealed_fd = NULL;
+  xdp_autofd int fd = -1;
+  gconstpointer bytes_data;
+  gpointer shm;
+  gsize bytes_len;
+  int saved_errno = -1;
 
   g_return_val_if_fail (bytes != NULL, NULL);
 
@@ -197,8 +198,8 @@ xdp_sealed_fd_new_from_handle (GVariant     *handle,
                                GUnixFDList  *fd_list,
                                GError      **error)
 {
-  int fd_id;
   xdp_autofd int fd = -1;
+  int fd_id;
 
   g_return_val_if_fail (g_variant_is_of_type (handle, G_VARIANT_TYPE_HANDLE), NULL);
   g_return_val_if_fail (G_IS_UNIX_FD_LIST (fd_list), NULL);

--- a/src/xdp-sealed-fd.c
+++ b/src/xdp-sealed-fd.c
@@ -30,7 +30,7 @@
 #include "xdp-utils.h"
 #include "xdp-sealed-fd.h"
 
-static const int required_seals = F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_SHRINK;
+#define REQUIRED_SEALS (F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_SHRINK)
 
 struct _XdpSealedFd
 {
@@ -89,9 +89,9 @@ xdp_sealed_fd_new_take_memfd (int      memfd,
     }
 
   /* If the seal seal is set and some required seal is missing report EPERM error directly */
-  if ((seals & F_SEAL_SEAL) && (seals & required_seals) != required_seals)
+  if ((seals & F_SEAL_SEAL) && (seals & REQUIRED_SEALS) != REQUIRED_SEALS)
     saved_errno = EPERM;
-  else if (fcntl (fd, F_ADD_SEALS, required_seals) == -1)
+  else if (fcntl (fd, F_ADD_SEALS, REQUIRED_SEALS) == -1)
     saved_errno = errno;
 
   if (saved_errno != -1)
@@ -177,7 +177,7 @@ xdp_sealed_fd_new_from_bytes (GBytes  *bytes,
       return NULL;
     }
 
-  if (fcntl (fd, F_ADD_SEALS, required_seals) == -1)
+  if (fcntl (fd, F_ADD_SEALS, REQUIRED_SEALS) == -1)
     {
       saved_errno = errno;
       g_set_error (error,

--- a/src/xdp-sealed-fd.h
+++ b/src/xdp-sealed-fd.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <glib-object.h>
+#include <gio/gio.h>
 
 #define XDP_TYPE_SEALED_FD (xdp_sealed_fd_get_type())
 G_DECLARE_FINAL_TYPE (XdpSealedFd,

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -552,15 +552,32 @@ xdp_has_path_prefix (const char *str,
 #define VALIDATOR_INPUT_FD 3
 #define ICON_VALIDATOR_GROUP "Icon Validator"
 
+static const char *
+icon_type_to_string (XdpIconType icon_type)
+{
+  switch (icon_type)
+    {
+    case XDP_ICON_TYPE_DESKTOP:
+      return "desktop";
+
+    case XDP_ICON_TYPE_NOTIFICATION:
+      return "notification";
+
+    default:
+      g_assert_not_reached ();
+    }
+}
+
 gboolean
 xdp_validate_icon (XdpSealedFd  *icon,
+                   XdpIconType   icon_type,
                    char        **out_format,
                    char        **out_size)
 {
   g_autofree char *format = NULL;
   g_autoptr(GError) error = NULL;
   const char *icon_validator = LIBEXECDIR "/xdg-desktop-portal-validate-icon";
-  const char *args[5];
+  const char *args[7];
   int size;
   g_autofree char *output = NULL;
   g_autoptr(GKeyFile) key_file = NULL;
@@ -578,7 +595,9 @@ xdp_validate_icon (XdpSealedFd  *icon,
   args[1] = "--sandbox";
   args[2] = "--fd";
   args[3] = G_STRINGIFY (VALIDATOR_INPUT_FD);
-  args[4] = NULL;
+  args[4] = "--ruleset";
+  args[5] = icon_type_to_string (icon_type);
+  args[6] = NULL;
 
   output = xdp_spawn_full (args, xdp_sealed_fd_dup_fd (icon), VALIDATOR_INPUT_FD, &error);
   if (!output)

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -43,7 +43,14 @@ gboolean xdp_is_valid_app_id (const char *string);
 
 char *xdp_get_app_id_from_desktop_id (const char *desktop_id);
 
+typedef enum
+{
+  XDP_ICON_TYPE_DESKTOP,
+  XDP_ICON_TYPE_NOTIFICATION,
+} XdpIconType;
+
 gboolean xdp_validate_icon (XdpSealedFd  *icon,
+                            XdpIconType   icon_type,
                             char        **out_format,
                             char        **out_size);
 


### PR DESCRIPTION
See commits. The most important change is that the icon validator now requires a `--ruleset` argument