### PR TITLE
Regression fixes

### DIFF
--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -300,7 +300,7 @@ initable_init (GInitable    *initable,
         }
       else
         {
-          g_propagate_error (error, my_error);
+          g_propagate_error (error, g_steal_pointer (&my_error));
           return FALSE;
         }
     }

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -267,7 +267,7 @@ launch_application_with_uri (const char *choice_id,
       if (ruri == NULL)
         {
           g_warning ("Error registering %s for %s: %s", uri, choice_id, local_error->message);
-          g_propagate_error (error, local_error);
+          g_propagate_error (error, g_steal_pointer (&local_error));
           return FALSE;
         }
     }

--- a/src/xdp-app-info-flatpak.c
+++ b/src/xdp-app-info-flatpak.c
@@ -443,7 +443,7 @@ get_bwrap_pidfd (const char  *instance,
   fd = open_pid_fd (dirfd (proc), pid, error);
   closedir (proc);
 
-  return fd;
+  return xdp_steal_fd (&fd);
 }
 
 XdpAppInfo *

--- a/src/xdp-app-info-flatpak.c
+++ b/src/xdp-app-info-flatpak.c
@@ -299,7 +299,7 @@ xdp_app_info_flatpak_dispose (GObject *object)
 {
   XdpAppInfoFlatpak *app_info = XDP_APP_INFO_FLATPAK (object);
 
-  g_clear_object (&app_info->flatpak_info);
+  g_clear_pointer (&app_info->flatpak_info, g_key_file_free);
 
   G_OBJECT_CLASS (xdp_app_info_flatpak_parent_class)->dispose (object);
 }
@@ -593,7 +593,7 @@ xdp_app_info_flatpak_new (int      pid,
                            FLATPAK_ENGINE_ID, id, instance,
                            bwrap_pidfd, gappinfo,
                            TRUE, has_network, TRUE);
-  g_set_object (&app_info_flatpak->flatpak_info, metadata);
+  app_info_flatpak->flatpak_info = g_steal_pointer (&metadata);
 
   return XDP_APP_INFO (g_steal_pointer (&app_info_flatpak));
 }

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -606,7 +606,7 @@ xdp_connection_get_pidfd (GDBusConnection  *connection,
                                                 error);
         }
 
-      g_propagate_error (error, local_error);
+      g_propagate_error (error, g_steal_pointer (&local_error));
       return FALSE;
     }
 
@@ -729,7 +729,7 @@ xdp_connection_lookup_app_info_sync (GDBusConnection  *connection,
   if (!app_info && !g_error_matches (local_error, XDP_APP_INFO_ERROR,
                                      XDP_APP_INFO_ERROR_WRONG_APP_KIND))
     {
-      g_propagate_error (error, local_error);
+      g_propagate_error (error, g_steal_pointer (&local_error));
       return NULL;
     }
   g_clear_error (&local_error);
@@ -740,7 +740,7 @@ xdp_connection_lookup_app_info_sync (GDBusConnection  *connection,
   if (!app_info && !g_error_matches (local_error, XDP_APP_INFO_ERROR,
                                      XDP_APP_INFO_ERROR_WRONG_APP_KIND))
     {
-      g_propagate_error (error, local_error);
+      g_propagate_error (error, g_steal_pointer (&local_error));
       return NULL;
     }
   g_clear_error (&local_error);

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -202,8 +202,7 @@ xdp_filter_options (GVariant *options,
                   ret = FALSE;
                   if (error && *error == NULL)
                     {
-                      g_propagate_error (error, local_error);
-                      local_error = NULL;
+                      g_propagate_error (error, g_steal_pointer (&local_error));
                     }
                 }
 
@@ -498,7 +497,7 @@ xdp_spawn_full (const char * const  *argv,
 
   if (data.error)
     {
-      g_propagate_error (error, data.error);
+      g_propagate_error (error, g_steal_pointer (&data.error));
       g_clear_error (&data.splice_error);
       return NULL;
     }
@@ -507,7 +506,7 @@ xdp_spawn_full (const char * const  *argv,
     {
       if (data.splice_error)
         {
-          g_propagate_error (error, data.splice_error);
+          g_propagate_error (error, g_steal_pointer (&data.splice_error));
           return NULL;
         }
 

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -826,7 +826,7 @@ rm_rf_dir (GFile         *dir,
 
   if (temp_error != NULL)
     {
-      g_propagate_error (error, temp_error);
+      g_propagate_error (error, g_steal_pointer (&temp_error));
       return FALSE;
     }
 

--- a/tests/test-permission-store.c
+++ b/tests/test-permission-store.c
@@ -626,7 +626,7 @@ rm_rf_dir (GFile         *dir,
 
   if (temp_error != NULL)
     {
-      g_propagate_error (error, temp_error);
+      g_propagate_error (error, g_steal_pointer (&temp_error));
       return FALSE;
     }
 


### PR DESCRIPTION
3 independent patches.

# Fix 1

Use g_steal_pointer to make sure there is no double free


I hit this testing my USB portal changes:

```
=================================================================
==2042089==ERROR: AddressSanitizer: heap-use-after-free on address 0x502000109898 at pc 0x0000005ba818 bp 0x7fbc501ff420 sp 0x7fbc501ff418
READ of size 8 at 0x502000109898 thread T14
    #0 0x5ba817 in authorize_callback ../src/xdg-desktop-portal.c:141
    #1 0x7fbc672a7dcf in _g_cclosure_marshal_BOOLEAN__OBJECT.part.0 (/lib64/libgio-2.0.so.0+0x76dcf) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #2 0x7fbc671e3649 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x11649) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #3 0x7fbc672135f2 in signal_emit_unlocked_R.isra.0 (/lib64/libgobject-2.0.so.0+0x415f2) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #4 0x7fbc67203968 in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x31968) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #5 0x7fbc67204360 in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x32360) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #6 0x7fbc67204422 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x32422) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #7 0x7fbc67355d25 in dispatch_in_thread_func (/lib64/libgio-2.0.so.0+0x124d25) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #8 0x7fbc672e0ab1 in g_task_thread_pool_thread (/lib64/libgio-2.0.so.0+0xafab1) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #9 0x7fbc67b82541 in g_thread_pool_thread_proxy.lto_priv.0 (/lib64/libglib-2.0.so.0+0x8f541) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #10 0x7fbc67b80812 in g_thread_proxy (/lib64/libglib-2.0.so.0+0x8d812) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #11 0x7fbc6745df95 in asan_thread_start(void*) (/lib64/libasan.so.8+0x5df95) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)
    #12 0x7fbc66eb56d6 in start_thread (/lib64/libc.so.6+0x976d6) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #13 0x7fbc66f3960b in __clone3 (/lib64/libc.so.6+0x11b60b) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)

0x502000109898 is located 8 bytes inside of 16-byte region [0x502000109890,0x5020001098a0)
freed by thread T14 here:
    #0 0x7fbc674f6638 in free.part.0 (/lib64/libasan.so.8+0xf6638) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)
    #1 0x7fbc67b50d04 in g_free_sized (/lib64/libglib-2.0.so.0+0x5dd04) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #2 0x7fbc67b737fd in g_slice_free1 (/lib64/libglib-2.0.so.0+0x807fd) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #3 0x7fbc67b38974 in g_error_free (/lib64/libglib-2.0.so.0+0x45974) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #4 0x5c2840 in glib_autoptr_clear_GError /usr/include/glib-2.0/glib/glib-autocleanups.h:56
    #5 0x5c287e in glib_autoptr_cleanup_GError /usr/include/glib-2.0/glib/glib-autocleanups.h:56
    #6 0x5c64ff in xdp_connection_lookup_app_info_sync ../src/xdp-app-info.c:737
    #7 0x5c65d7 in xdp_invocation_lookup_app_info_sync ../src/xdp-app-info.c:792
    #8 0x5ba7a3 in authorize_callback ../src/xdg-desktop-portal.c:138
    #9 0x7fbc672a7dcf in _g_cclosure_marshal_BOOLEAN__OBJECT.part.0 (/lib64/libgio-2.0.so.0+0x76dcf) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #10 0x7fbc671e3649 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x11649) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #11 0x7fbc672135f2 in signal_emit_unlocked_R.isra.0 (/lib64/libgobject-2.0.so.0+0x415f2) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #12 0x7fbc67203968 in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x31968) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #13 0x7fbc67204360 in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x32360) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #14 0x7fbc67204422 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x32422) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #15 0x7fbc67355d25 in dispatch_in_thread_func (/lib64/libgio-2.0.so.0+0x124d25) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #16 0x7fbc672e0ab1 in g_task_thread_pool_thread (/lib64/libgio-2.0.so.0+0xafab1) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #17 0x7fbc67b82541 in g_thread_pool_thread_proxy.lto_priv.0 (/lib64/libglib-2.0.so.0+0x8f541) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #18 0x7fbc67b80812 in g_thread_proxy (/lib64/libglib-2.0.so.0+0x8d812) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #19 0x7fbc6745df95 in asan_thread_start(void*) (/lib64/libasan.so.8+0x5df95) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)

previously allocated by thread T14 here:
    #0 0x7fbc674f7997 in malloc (/lib64/libasan.so.8+0xf7997) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)
    #1 0x7fbc67b56879 in g_malloc (/lib64/libglib-2.0.so.0+0x63879) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #2 0x7fbc67b6fe14 in g_slice_alloc (/lib64/libglib-2.0.so.0+0x7ce14) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #3 0x7fbc67b6ff04 in g_slice_alloc0 (/lib64/libglib-2.0.so.0+0x7cf04) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #4 0x7fbc67b38450 in g_error_allocate (/lib64/libglib-2.0.so.0+0x45450) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #5 0x7fbc67b38be4 in g_error_new_valist (/lib64/libglib-2.0.so.0+0x45be4) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #6 0x7fbc67b38e20 in g_set_error (/lib64/libglib-2.0.so.0+0x45e20) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #7 0x5cda8b in xdp_app_info_flatpak_new ../src/xdp-app-info-flatpak.c:557
    #8 0x5c6150 in xdp_connection_lookup_app_info_sync ../src/xdp-app-info.c:746
    #9 0x5c65d7 in xdp_invocation_lookup_app_info_sync ../src/xdp-app-info.c:792
    #10 0x5ba7a3 in authorize_callback ../src/xdg-desktop-portal.c:138
    #11 0x7fbc672a7dcf in _g_cclosure_marshal_BOOLEAN__OBJECT.part.0 (/lib64/libgio-2.0.so.0+0x76dcf) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #12 0x7fbc671e3649 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x11649) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #13 0x7fbc672135f2 in signal_emit_unlocked_R.isra.0 (/lib64/libgobject-2.0.so.0+0x415f2) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #14 0x7fbc67203968 in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x31968) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #15 0x7fbc67204360 in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x32360) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #16 0x7fbc67204422 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x32422) (BuildId: 327e1dbd4b402ab1171d32553c27b5a07e36af7d)
    #17 0x7fbc67355d25 in dispatch_in_thread_func (/lib64/libgio-2.0.so.0+0x124d25) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #18 0x7fbc672e0ab1 in g_task_thread_pool_thread (/lib64/libgio-2.0.so.0+0xafab1) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #19 0x7fbc67b82541 in g_thread_pool_thread_proxy.lto_priv.0 (/lib64/libglib-2.0.so.0+0x8f541) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #20 0x7fbc67b80812 in g_thread_proxy (/lib64/libglib-2.0.so.0+0x8d812) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #21 0x7fbc6745df95 in asan_thread_start(void*) (/lib64/libasan.so.8+0x5df95) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)

Thread T14 created by T2 here:
    #0 0x7fbc674ef871 in pthread_create (/lib64/libasan.so.8+0xef871) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)
    #1 0x7fbc67b816df in g_thread_new_internal (/lib64/libglib-2.0.so.0+0x8e6df) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #2 0x7fbc67b81a16 in g_thread_pool_spawn_thread (/lib64/libglib-2.0.so.0+0x8ea16) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #3 0x7fbc67b80812 in g_thread_proxy (/lib64/libglib-2.0.so.0+0x8d812) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #4 0x7fbc6745df95 in asan_thread_start(void*) (/lib64/libasan.so.8+0x5df95) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)

Thread T2 created by T0 here:
    #0 0x7fbc674ef871 in pthread_create (/lib64/libasan.so.8+0xef871) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)
    #1 0x7fbc67b816df in g_thread_new_internal (/lib64/libglib-2.0.so.0+0x8e6df) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #2 0x7fbc67b818ed in g_thread_new (/lib64/libglib-2.0.so.0+0x8e8ed) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #3 0x7fbc67b81e26 in g_thread_pool_new_full (/lib64/libglib-2.0.so.0+0x8ee26) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #4 0x7fbc672df4f9 in g_task_get_type_once (/lib64/libgio-2.0.so.0+0xae4f9) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #5 0x7fbc672df644 in g_task_get_type (/lib64/libgio-2.0.so.0+0xae644) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #6 0x7fbc6734dbd8 in _g_dbus_initialize.part.0 (/lib64/libgio-2.0.so.0+0x11cbd8) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #7 0x7fbc673409a4 in g_bus_get_sync (/lib64/libgio-2.0.so.0+0x10f9a4) (BuildId: 1a20350aab8ff50007bb0131898dc24973f8b164)
    #8 0x5bbe10 in main ../src/xdg-desktop-portal.c:454
    #9 0x7fbc66e48087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #10 0x7fbc66e4814a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #11 0x40d534 in _start (/var/home/hub/source/xdg-desktop-portal/_build/src/xdg-desktop-portal+0x40d534) (BuildId: 71198a45640515db52e0f1e7a14cfebb398b943b)

SUMMARY: AddressSanitizer: heap-use-after-free ../src/xdg-desktop-portal.c:141 in authorize_callback
Shadow bytes around the buggy address:
  0x502000109600: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fd
  0x502000109680: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fd
  0x502000109700: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x502000109780: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fd
  0x502000109800: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
=>0x502000109880: fa fa fd[fd]fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000109900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000109980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000109a00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000109a80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000109b00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==2042089==ABORTING
```

# Fix 2

flatpak_info is not a GObject.
This cause a glib critical.

# Fix 3

We returned an autoclosed fd... instead. steal it instead.