### PR TITLE
Add cast and type-check functions for Session and Request

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -773,7 +773,7 @@ handle_request_background_in_thread_func (GTask *task,
                                           gpointer task_data,
                                           GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   GVariant *options;
   const char *id;
   Permission permission;

--- a/src/camera.c
+++ b/src/camera.c
@@ -162,7 +162,7 @@ handle_access_camera_in_thread_func (GTask *task,
                                      gpointer task_data,
                                      GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   gboolean allowed;
 
   allowed = query_permission_sync (request);

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -78,7 +78,7 @@ handle_request_clipboard (XdpDbusClipboard *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_remote_desktop_session (session))
+  if (!IS_REMOTE_DESKTOP_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -86,7 +86,7 @@ handle_request_clipboard (XdpDbusClipboard *object,
                                              "Invalid session type");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
-  remote_desktop_session = (RemoteDesktopSession *)session;
+  remote_desktop_session = REMOTE_DESKTOP_SESSION (session);
 
   if (!remote_desktop_session_can_request_clipboard (remote_desktop_session))
     {
@@ -128,7 +128,7 @@ handle_set_selection (XdpDbusClipboard *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_remote_desktop_session (session))
+  if (!IS_REMOTE_DESKTOP_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -137,7 +137,7 @@ handle_set_selection (XdpDbusClipboard *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
   else if (!remote_desktop_session_is_clipboard_enabled (
-             (RemoteDesktopSession *)session))
+             REMOTE_DESKTOP_SESSION (session)))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -238,7 +238,7 @@ handle_selection_write (XdpDbusClipboard *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_remote_desktop_session (session))
+  if (!IS_REMOTE_DESKTOP_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -247,7 +247,7 @@ handle_selection_write (XdpDbusClipboard *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
   else if (!remote_desktop_session_is_clipboard_enabled (
-             (RemoteDesktopSession *)session))
+             REMOTE_DESKTOP_SESSION (session)))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -289,7 +289,7 @@ handle_selection_write_done (XdpDbusClipboard *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_remote_desktop_session (session))
+  if (!IS_REMOTE_DESKTOP_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -298,7 +298,7 @@ handle_selection_write_done (XdpDbusClipboard *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
   else if (!remote_desktop_session_is_clipboard_enabled (
-             (RemoteDesktopSession *)session))
+             REMOTE_DESKTOP_SESSION (session)))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -379,7 +379,7 @@ handle_selection_read (XdpDbusClipboard *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_remote_desktop_session (session))
+  if (!IS_REMOTE_DESKTOP_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -388,7 +388,7 @@ handle_selection_read (XdpDbusClipboard *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
   else if (!remote_desktop_session_is_clipboard_enabled (
-             (RemoteDesktopSession *)session))
+              REMOTE_DESKTOP_SESSION (session)))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -450,8 +450,7 @@ selection_transfer_cb (XdpDbusImplClipboard *impl,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  RemoteDesktopSession *remote_desktop_session =
-    (RemoteDesktopSession *)session;
+  RemoteDesktopSession *remote_desktop_session = REMOTE_DESKTOP_SESSION (session);
 
   if (remote_desktop_session &&
       remote_desktop_session_is_clipboard_enabled (remote_desktop_session) &&
@@ -487,8 +486,7 @@ selection_owner_changed_cb (XdpDbusImplClipboard *impl,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  RemoteDesktopSession *remote_desktop_session =
-    (RemoteDesktopSession *)session;
+  RemoteDesktopSession *remote_desktop_session = REMOTE_DESKTOP_SESSION (session);
 
   if (remote_desktop_session &&
       remote_desktop_session_is_clipboard_enabled (remote_desktop_session) &&

--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -71,10 +71,23 @@ GType global_shortcuts_session_get_type (void);
 
 G_DEFINE_TYPE (GlobalShortcutsSession, global_shortcuts_session, session_get_type ())
 
+G_GNUC_UNUSED static inline GlobalShortcutsSession *
+GLOBAL_SHORTCUTS_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_CAST (ptr, global_shortcuts_session_get_type (), GlobalShortcutsSession);
+}
+
+G_GNUC_UNUSED static inline gboolean
+IS_GLOBAL_SHORTCUTS_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, global_shortcuts_session_get_type ());
+}
+
 static void
 global_shortcuts_session_close (Session *session)
 {
-  GlobalShortcutsSession *global_shortcuts_session = (GlobalShortcutsSession *)session;
+  GlobalShortcutsSession *global_shortcuts_session =
+    GLOBAL_SHORTCUTS_SESSION (session);
 
   global_shortcuts_session->closed = TRUE;
 }
@@ -131,7 +144,7 @@ global_shortcuts_session_new (GVariant *options,
   if (session)
     g_debug ("global shortcuts session owned by '%s' created", session->sender);
 
-  return (GlobalShortcutsSession *) session;
+  return GLOBAL_SHORTCUTS_SESSION (session);
 }
 
 static void
@@ -251,7 +264,7 @@ handle_create_session (XdpDbusGlobalShortcuts *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  session = (Session *)global_shortcuts_session_new (options, request, &error);
+  session = SESSION (global_shortcuts_session_new (options, request, &error));
   if (!session)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -591,7 +604,8 @@ activated_cb (XdpDbusImplGlobalShortcuts *impl,
 {
   GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   g_autoptr(Session) session = lookup_session (session_id);
-  GlobalShortcutsSession *global_shortcuts_session = (GlobalShortcutsSession *)session;
+  GlobalShortcutsSession *global_shortcuts_session =
+    GLOBAL_SHORTCUTS_SESSION (session);
 
   g_debug ("Received activated %s for %s", session_id, shortcut_id);
 
@@ -617,7 +631,8 @@ deactivated_cb (XdpDbusImplGlobalShortcuts *impl,
 {
   GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   g_autoptr(Session) session = lookup_session (session_id);
-  GlobalShortcutsSession *global_shortcuts_session = (GlobalShortcutsSession *)session;
+  GlobalShortcutsSession *global_shortcuts_session =
+    GLOBAL_SHORTCUTS_SESSION (session);
 
   g_debug ("Received deactivated %s for %s", session_id, shortcut_id);
 
@@ -641,7 +656,8 @@ shortcuts_changed_cb (XdpDbusImplGlobalShortcuts *impl,
 {
   GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   g_autoptr(Session) session = lookup_session (session_id);
-  GlobalShortcutsSession *global_shortcuts_session = (GlobalShortcutsSession *)session;
+  GlobalShortcutsSession *global_shortcuts_session =
+    GLOBAL_SHORTCUTS_SESSION (session);
 
   g_debug ("Received ShortcutsChanged %s", session_id);
 

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -136,7 +136,7 @@ handle_inhibit_in_thread_func (GTask *task,
                                gpointer task_data,
                                GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   const char *window;
   guint32 flags;
   GVariant *options;
@@ -263,10 +263,22 @@ GType inhibit_session_get_type (void);
 
 G_DEFINE_TYPE (InhibitSession, inhibit_session, session_get_type ())
 
+G_GNUC_UNUSED static inline InhibitSession *
+INHIBIT_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_CAST (ptr, inhibit_session_get_type (), InhibitSession);
+}
+
+G_GNUC_UNUSED static inline gboolean
+IS_INHIBIT_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, inhibit_session_get_type ());
+}
+
 static void
 inhibit_session_close (Session *session)
 {
-  InhibitSession *inhibit_session = (InhibitSession *)session;
+  InhibitSession *inhibit_session = INHIBIT_SESSION (session);
 
   inhibit_session->closed = TRUE;
 
@@ -419,7 +431,7 @@ handle_create_monitor (XdpDbusInhibit *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  session = (Session *)inhibit_session_new (arg_options, request, &error);
+  session = SESSION (inhibit_session_new (arg_options, request, &error));
   if (!session)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -493,7 +505,7 @@ state_changed_cb (XdpDbusImplInhibit *impl,
 {
   GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (impl));
   g_autoptr(Session) session = lookup_session (session_id);
-  InhibitSession *inhibit_session = (InhibitSession *)session;
+  InhibitSession *inhibit_session = INHIBIT_SESSION (session);
   gboolean active = FALSE;
   guint32 session_state = 0;
 

--- a/src/input-capture.c
+++ b/src/input-capture.c
@@ -82,10 +82,16 @@ GType input_capture_session_get_type (void);
 
 G_DEFINE_TYPE (InputCaptureSession, input_capture_session, session_get_type ())
 
-static gboolean
-is_input_capture_session (Session *session)
+G_GNUC_UNUSED static inline InputCaptureSession *
+INPUT_CAPTURE_SESSION (gpointer ptr)
 {
-  return G_TYPE_CHECK_INSTANCE_TYPE (session, input_capture_session_get_type ());
+  return G_TYPE_CHECK_INSTANCE_CAST (ptr, input_capture_session_get_type (), InputCaptureSession);
+}
+
+G_GNUC_UNUSED static inline gboolean
+IS_INPUT_CAPTURE_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, input_capture_session_get_type ());
 }
 
 static InputCaptureSession *
@@ -253,7 +259,7 @@ handle_create_session (XdpDbusInputCapture   *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  session = (Session *)input_capture_session_new (arg_options, request, &error);
+  session = SESSION (input_capture_session_new (arg_options, request, &error));
   if (!session)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -303,7 +309,7 @@ get_zones_done (GObject      *source_object,
   gboolean should_close_session;
   uint32_t response = 2;
 
-  request = (Request *)data;
+  request = REQUEST (data);
 
   REQUEST_AUTOLOCK (request);
 
@@ -374,7 +380,7 @@ handle_get_zones (XdpDbusInputCapture   *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -383,7 +389,7 @@ handle_get_zones (XdpDbusInputCapture   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  input_capture_session = (InputCaptureSession *)session;
+  input_capture_session = INPUT_CAPTURE_SESSION (session);
 
   switch (input_capture_session->state)
     {
@@ -458,7 +464,7 @@ set_pointer_barriers_done (GObject      *source_object,
   Session *session;
   uint32_t response = 2;
 
-  request = (Request *)data;
+  request = REQUEST (data);
 
   REQUEST_AUTOLOCK (request);
 
@@ -529,7 +535,7 @@ handle_set_pointer_barriers (XdpDbusInputCapture   *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -538,7 +544,7 @@ handle_set_pointer_barriers (XdpDbusInputCapture   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  input_capture_session = (InputCaptureSession *)session;
+  input_capture_session = INPUT_CAPTURE_SESSION (session);
 
   switch (input_capture_session->state)
     {
@@ -630,7 +636,7 @@ handle_enable (XdpDbusInputCapture   *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -639,7 +645,7 @@ handle_enable (XdpDbusInputCapture   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-   input_capture_session = (InputCaptureSession *)session;
+   input_capture_session = INPUT_CAPTURE_SESSION (session);
 
    switch (input_capture_session->state)
      {
@@ -731,7 +737,7 @@ handle_disable (XdpDbusInputCapture   *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -740,7 +746,7 @@ handle_disable (XdpDbusInputCapture   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-   input_capture_session = (InputCaptureSession *)session;
+   input_capture_session = INPUT_CAPTURE_SESSION (session);
 
    switch (input_capture_session->state)
      {
@@ -832,7 +838,7 @@ handle_release (XdpDbusInputCapture   *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -841,7 +847,7 @@ handle_release (XdpDbusInputCapture   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  input_capture_session = (InputCaptureSession *)session;
+  input_capture_session = INPUT_CAPTURE_SESSION (session);
 
   switch (input_capture_session->state)
     {
@@ -932,7 +938,7 @@ handle_connect_to_eis (XdpDbusInputCapture   *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              G_DBUS_ERROR,
@@ -941,7 +947,7 @@ handle_connect_to_eis (XdpDbusInputCapture   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  input_capture_session = (InputCaptureSession *)session;
+  input_capture_session = INPUT_CAPTURE_SESSION (session);
 
   switch (input_capture_session->state)
     {
@@ -1025,7 +1031,7 @@ on_disabled_cb (XdpDbusImplInputCapture *impl,
   g_autoptr(Session) session = lookup_session (session_id);
   InputCaptureSession *input_capture_session;
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_critical ("Invalid session type for signal");
       return;
@@ -1058,7 +1064,7 @@ on_activated_cb (XdpDbusImplInputCapture *impl,
   g_autoptr(Session) session = lookup_session (session_id);
   InputCaptureSession *input_capture_session;
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_critical ("Invalid session type for signal");
       return;
@@ -1090,7 +1096,7 @@ on_deactivated_cb (XdpDbusImplInputCapture *impl,
   g_autoptr(Session) session = lookup_session (session_id);
   InputCaptureSession *input_capture_session;
 
-  if (!is_input_capture_session (session))
+  if (!IS_INPUT_CAPTURE_SESSION (session))
     {
       g_critical ("Invalid session type for signal");
       return;
@@ -1140,7 +1146,7 @@ input_capture_class_init (InputCaptureClass *klass)
 static void
 input_capture_session_close (Session *session)
 {
-  InputCaptureSession *input_capture_session = (InputCaptureSession *)session;
+  InputCaptureSession *input_capture_session = INPUT_CAPTURE_SESSION (session);
 
   input_capture_session->state = INPUT_CAPTURE_SESSION_STATE_CLOSED;
 

--- a/src/location.c
+++ b/src/location.c
@@ -71,6 +71,18 @@ GType location_session_get_type (void);
 
 G_DEFINE_TYPE (LocationSession, location_session, session_get_type ())
 
+G_GNUC_UNUSED static inline LocationSession *
+LOCATION_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_CAST (ptr, location_session_get_type (), LocationSession);
+}
+
+G_GNUC_UNUSED static inline gboolean
+IS_LOCATION_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, location_session_get_type ());
+}
+
 static void
 location_session_init (LocationSession *session)
 {
@@ -82,7 +94,7 @@ location_session_init (LocationSession *session)
 static void
 location_session_close (Session *session)
 {
-  LocationSession *loc_session = (LocationSession *)session;
+  LocationSession *loc_session = LOCATION_SESSION (session);
 
   loc_session->state = LOCATION_SESSION_STATE_CLOSED;
 
@@ -95,7 +107,7 @@ location_session_close (Session *session)
 static void
 location_session_finalize (GObject *object)
 {
-  LocationSession *loc_session = (LocationSession *)object;
+  LocationSession *loc_session = LOCATION_SESSION (object);
 
   g_clear_object (&loc_session->client);
 
@@ -231,7 +243,7 @@ location_session_start (LocationSession *loc_session)
 
   g_debug ("location session '%s', GeoClue client '%s'", ((Session*)loc_session)->id, client_id);
   g_debug ("location session '%s', distance-threshold %d, time-threshold %d, accuracy %s",
-           ((Session *)loc_session)->id,
+           SESSION (loc_session)->id,
            loc_session->distance_threshold,
            loc_session->time_threshold,
            gclue_accuracy_level_to_string (loc_session->accuracy));
@@ -409,7 +421,8 @@ handle_create_session (XdpDbusLocation *object,
                        GVariant *arg_options)
 {
   g_autoptr(GError) error = NULL;
-  LocationSession *session;
+  LocationSession *loc_session;
+  Session *session;
   guint threshold;
   guint accuracy;
 
@@ -423,31 +436,33 @@ handle_create_session (XdpDbusLocation *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  session = location_session_new (arg_options, invocation, &error);
-  if (!session)
+  loc_session = location_session_new (arg_options, invocation, &error);
+  if (!loc_session)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
+  session = SESSION (loc_session);
+
   if (g_variant_lookup (arg_options, "distance-threshold", "u", &threshold))
-    session->distance_threshold = threshold;
+    loc_session->distance_threshold = threshold;
   if (g_variant_lookup (arg_options, "time-threshold", "u", &threshold))
-    session->time_threshold = threshold;
+    loc_session->time_threshold = threshold;
   if (g_variant_lookup (arg_options, "accuracy", "u", &accuracy))
     {
       if (accuracy == 0)
-        session->accuracy = GCLUE_ACCURACY_LEVEL_NONE;
+        loc_session->accuracy = GCLUE_ACCURACY_LEVEL_NONE;
       else if (accuracy == 1)
-        session->accuracy = GCLUE_ACCURACY_LEVEL_COUNTRY;
+        loc_session->accuracy = GCLUE_ACCURACY_LEVEL_COUNTRY;
       else if (accuracy == 2)
-        session->accuracy = GCLUE_ACCURACY_LEVEL_CITY;
+        loc_session->accuracy = GCLUE_ACCURACY_LEVEL_CITY;
       else if (accuracy == 3)
-        session->accuracy = GCLUE_ACCURACY_LEVEL_NEIGHBORHOOD;
+        loc_session->accuracy = GCLUE_ACCURACY_LEVEL_NEIGHBORHOOD;
       else if (accuracy == 4)
-        session->accuracy = GCLUE_ACCURACY_LEVEL_STREET;
+        loc_session->accuracy = GCLUE_ACCURACY_LEVEL_STREET;
       else if (accuracy == 5)
-        session->accuracy = GCLUE_ACCURACY_LEVEL_EXACT;
+        loc_session->accuracy = GCLUE_ACCURACY_LEVEL_EXACT;
       else
         {
           g_dbus_method_invocation_return_error (invocation,
@@ -458,18 +473,18 @@ handle_create_session (XdpDbusLocation *object,
         }
     }
 
-  if (!session_export ((Session *)session, &error))
+  if (!session_export (session, &error))
     {
        g_warning ("Failed to export session: %s", error->message);
-       session_close ((Session *)session, FALSE);
+       session_close (session, FALSE);
     }
   else
     {
-      g_debug ("CreateSession new session '%s'",  ((Session *)session)->id);
-      session_register ((Session *)session);
+      g_debug ("CreateSession new session '%s'",  (session)->id);
+      session_register (session);
     }
 
-  xdp_dbus_location_complete_create_session (object, invocation, ((Session *)session)->id);
+  xdp_dbus_location_complete_create_session (object, invocation, (session)->id);
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
@@ -482,7 +497,7 @@ handle_start_in_thread_func (GTask *task,
                              gpointer task_data,
                              GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   const char *parent_window;
   const char *id;
   gint64 last_used = 0;
@@ -497,7 +512,7 @@ handle_start_in_thread_func (GTask *task,
   session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
-  loc_session = (LocationSession *)session;
+  loc_session = LOCATION_SESSION (session);
 
   parent_window = (const char *)g_object_get_data (G_OBJECT (request), "parent-window");
 
@@ -607,7 +622,7 @@ handle_start_in_thread_func (GTask *task,
       loc_session->accuracy = accuracy;
     }
 
-  if (location_session_start ((LocationSession*)session))
+  if (location_session_start (loc_session))
     response = 0;
   else
     response = 2;
@@ -628,7 +643,7 @@ out:
   if (response != 0)
     {
        g_debug ("closing session");
-       session_close ((Session *)session, FALSE);
+       session_close (session, FALSE);
     }
 }
 
@@ -668,7 +683,7 @@ handle_start (XdpDbusLocation *object,
 
   SESSION_AUTOLOCK_UNREF (session);
 
-  loc_session = (LocationSession *)session;
+  loc_session = LOCATION_SESSION (session);
   switch (loc_session->state)
     {
     case LOCATION_SESSION_STATE_INIT:

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -348,7 +348,7 @@ send_response_in_thread_func (GTask *task,
                               gpointer task_data,
                               GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   guint response;
   GVariant *options;
   const char *choice;
@@ -589,7 +589,7 @@ handle_open_in_thread_func (GTask *task,
                             gpointer task_data,
                             GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   const char *parent_window;
   const char *app_id = xdp_app_info_get_id (request->app_info);
   const char *activation_token;

--- a/src/remote-desktop.h
+++ b/src/remote-desktop.h
@@ -25,7 +25,19 @@
 
 typedef struct _RemoteDesktopSession RemoteDesktopSession;
 
-gboolean is_remote_desktop_session (Session *session);
+GType remote_desktop_session_get_type (void);
+
+G_GNUC_UNUSED static inline RemoteDesktopSession *
+REMOTE_DESKTOP_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_CAST (ptr, remote_desktop_session_get_type (), RemoteDesktopSession);
+}
+
+G_GNUC_UNUSED static inline gboolean
+IS_REMOTE_DESKTOP_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, remote_desktop_session_get_type ());
+}
 
 GList * remote_desktop_session_get_streams (RemoteDesktopSession *session);
 

--- a/src/request.c
+++ b/src/request.c
@@ -36,7 +36,7 @@ request_on_signal_response (XdpDbusRequest *object,
                             guint arg_response,
                             GVariant *arg_results)
 {
-  Request *request = (Request *)object;
+  Request *request = REQUEST (object);
   XdpDbusRequestSkeleton *skeleton = XDP_DBUS_REQUEST_SKELETON (object);
   GList      *connections, *l;
   GVariant   *signal_variant;
@@ -65,7 +65,7 @@ static gboolean
 handle_close (XdpDbusRequest *object,
               GDBusMethodInvocation *invocation)
 {
-  Request *request = (Request *)object;
+  Request *request = REQUEST (object);
   g_autoptr(GError) error = NULL;
 
   g_debug ("Handling Close");
@@ -110,7 +110,7 @@ request_init (Request *request)
 static void
 request_finalize (GObject *object)
 {
-  Request *request = (Request *)object;
+  Request *request = REQUEST (object);
 
   G_LOCK (requests);
   g_hash_table_remove (requests, request->id);

--- a/src/request.h
+++ b/src/request.h
@@ -55,6 +55,18 @@ struct _RequestClass
 
 GType request_get_type (void) G_GNUC_CONST;
 
+G_GNUC_UNUSED static inline Request *
+REQUEST (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_CAST (ptr, request_get_type (), Request);
+}
+
+G_GNUC_UNUSED static inline gboolean
+IS_REQUEST (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, request_get_type ());
+}
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (Request, g_object_unref)
 
 void request_init_invocation (GDBusMethodInvocation  *invocation, XdpAppInfo *app_info);

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -189,7 +189,7 @@ handle_screenshot_in_thread_func (GTask *task,
                                   gpointer task_data,
                                   GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   GVariantBuilder opt_builder;

--- a/src/session.c
+++ b/src/session.c
@@ -215,7 +215,7 @@ static gboolean
 handle_close (XdpDbusSession *object,
               GDBusMethodInvocation *invocation)
 {
-  Session *session = (Session *)object;
+  Session *session = SESSION (object);
 
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
 
@@ -281,7 +281,7 @@ close_sessions_for_sender (const char *sender)
 static void
 on_closed (XdpDbusImplSession *object, GObject *data)
 {
-  Session *session = (Session *)data;
+  Session *session = SESSION (data);
 
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
 
@@ -314,7 +314,7 @@ session_initable_init (GInitable *initable,
                        GCancellable *cancellable,
                        GError **error)
 {
-  Session *session = (Session *)initable;
+  Session *session = SESSION (initable);
   g_autofree char *sender_escaped = NULL;
   g_autofree char *id = NULL;
   g_autoptr(XdpDbusImplSession) impl_session = NULL;
@@ -375,7 +375,7 @@ session_set_property (GObject *object,
                       const GValue *value,
                       GParamSpec *pspec)
 {
-  Session *session = (Session *)object;
+  Session *session = SESSION (object);
 
   switch (prop_id)
     {
@@ -414,7 +414,7 @@ session_get_property (GObject *object,
                       GValue *value,
                       GParamSpec *pspec)
 {
-  Session *session = (Session *)object;
+  Session *session = SESSION (object);
 
   switch (prop_id)
     {
@@ -450,7 +450,7 @@ session_get_property (GObject *object,
 static void
 session_finalize (GObject *object)
 {
-  Session *session = (Session *)object;
+  Session *session = SESSION (object);
 
   g_assert (!session->id || !g_hash_table_lookup (sessions, session->id));
 

--- a/src/session.h
+++ b/src/session.h
@@ -56,6 +56,18 @@ struct _SessionClass
 
 GType session_get_type (void);
 
+G_GNUC_UNUSED static inline Session *
+SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_CAST (ptr, session_get_type (), Session);
+}
+
+G_GNUC_UNUSED static inline gboolean
+IS_SESSION (gpointer ptr)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, session_get_type ());
+}
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (Session, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpDbusImplSession, g_object_unref)
 

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -123,7 +123,7 @@ handle_set_wallpaper_in_thread_func (GTask *task,
                                      gpointer task_data,
                                      GCancellable *cancellable)
 {
-  Request *request = (Request *)task_data;
+  Request *request = REQUEST (task_data);
   const char *parent_window;
   const char *id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;


### PR DESCRIPTION
We would usually get them from the G_DECLARE_TYPE macro family but we cannot use them right now because they have no namespace and the derivable classes would need private data and our data is public.

For now, just define the functions manually where it makes sense. In the longer term, we should switch towards the G_DECLARE_TYPE macros.