### PR TITLE
tests: install files required for `installed_tests`

### DIFF
--- a/tests/share/applications/meson.build
+++ b/tests/share/applications/meson.build
@@ -1,3 +1,3 @@
-configure_file(input: 'furrfix.desktop', output: '@PLAINNAME@', copy: true)
-configure_file(input: 'mimeinfo.cache', output: '@PLAINNAME@', copy: true)
-configure_file(input: 'defaults.list', output: '@PLAINNAME@', copy: true)
+configure_file(input: 'furrfix.desktop', output: '@PLAINNAME@', copy: true, install: enable_installed_tests, install_dir: installed_tests_data_dir / 'share' / 'applications')
+configure_file(input: 'mimeinfo.cache', output: '@PLAINNAME@', copy: true, install: enable_installed_tests, install_dir: installed_tests_data_dir / 'share' / 'applications')
+configure_file(input: 'defaults.list', output: '@PLAINNAME@', copy: true, install: enable_installed_tests, install_dir: installed_tests_data_dir / 'share' / 'applications')


### PR DESCRIPTION
These are required to be in `XDG_DATA_DIR` when the installed tests are run