### PR TITLE
doc: Fix Background Monitor Apps ref link

### DIFF
--- a/doc/for-desktop-developers.rst
+++ b/doc/for-desktop-developers.rst
@@ -99,4 +99,4 @@ manage background running applications.
       :target: doc-org.freedesktop.background.Monitor.html
       :class: only-dark
 
-   :doc:`Background Apps Monitor </doc-org.freedesktop.background.Monitor.rst>`
+   :doc:`Background Apps Monitor </doc-org.freedesktop.background.Monitor>`


### PR DESCRIPTION
Fix the ref link which is linked to this warning while generating docs:
```
../doc/for-desktop-developers.rst:102: WARNING: unknown document: '/doc-org.freedesktop.background.Monitor.rst' [ref.doc]
```