### PR TITLE
globalshortcuts: Specify the shortcuts result of BindShortcuts

### DIFF
--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -121,8 +121,11 @@
 
         * ``shortcuts`` (``a(sa{sv})``)
 
-          A list of shortcuts. The list of keys it may contain is described
-          below, and is different from the @shortcuts variable of this method.
+          The list of shortcuts which were bound. This is a subset of the
+          shortcuts which were passed in from the @shortcuts variable of this
+          method (this includes the set of all shortcuts and the empty set).
+          The keys they may contain are described below, and are different from
+          the keys in the @shortcuts variable of this method.
 
         Each element of the @shortcuts array returned by the
         :ref:`org.freedesktop.portal.Request::Response` signal is a tuple composed of


### PR DESCRIPTION
The method result's shortcuts list is the list of shortcuts which were actually bound. It's valid to send any subset of shortcuts that were passed in by the caller.

See: https://github.com/flatpak/xdg-desktop-portal/issues/1350

@dcz-self @davidedmundson 