### PR TITLE
globalshortcuts: Remove session_id option from CreateSession impl

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -42,11 +42,7 @@
 
         Create a global shortcuts session.
 
-        The following results get returned in the @results vardict:
-
-        * ``session_id`` (``s``)
-
-          The session id. A string representing the created global shortcuts session.
+        There are currently no supported keys in the @results vardict.
     -->
     <method name="CreateSession">
       <arg type="o" name="handle" direction="in"/>


### PR DESCRIPTION
It is not used in the frontend and not in the backends. This is most likely a mistake from copying things from another portal.