### PR TITLE
settings: Make the text about non-standardized keys prominent

### DIFF
--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -25,11 +25,15 @@
     org.freedesktop.portal.Settings:
     @short_description: Settings interface
 
-    This interface provides read-only access to a small number
-    of host settings required for toolkits similar to XSettings.
-    It is not for general purpose settings.
+    This interface provides read-only access to a small number of standardized
+    host settings required for toolkits similar to XSettings. It is not for
+    general purpose settings.
 
-    Currently the interface provides the following keys:
+    Implementations can provide keys not listed below; they are entirely
+    implementation details that are undocumented. If you are a toolkit and want
+    to use this please open an issue.
+
+    Currently the interface provides the following standardized keys:
 
     * ``org.freedesktop.appearance`` ``color-scheme`` (``u``)
 
@@ -57,10 +61,6 @@
         * ``1``: Higher contrast
 
       Unknown values should be treated as ``0`` (no preference).
-
-    Implementations can provide other keys; they are entirely
-    implementation details that are undocumented. If you are a
-    toolkit and want to use this please open an issue.
 
     This documentation describes version 2 of this interface.
   -->


### PR DESCRIPTION
Explicitly calls the keys which we document "standardized keys" and moves the text about non-standardized keys closer to that and before the list of keys so it's harder to miss.