### PR TITLE
build: Generate autocleanup functions where possible

### DIFF
--- a/document-portal/meson.build
+++ b/document-portal/meson.build
@@ -3,7 +3,6 @@ permission_store_built_sources = gnome.gdbus_codegen(
   sources: '../data/org.freedesktop.impl.portal.PermissionStore.xml',
   interface_prefix: 'org.freedesktop.impl.portal',
   namespace: 'Xdg',
-  autocleanup: 'none',
 )
 
 db_sources = files(
@@ -46,7 +45,6 @@ document_portal_built_sources = gnome.gdbus_codegen(
   ],
   interface_prefix: 'org.freedesktop.portal',
   namespace: 'XdpDbus',
-  autocleanup: 'none',
 )
 
 xdg_document_portal_sources = [

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,7 +6,6 @@ portal_built_sources = gnome.gdbus_codegen(
   interface_prefix: 'org.freedesktop.portal',
   namespace: 'XdpDbus',
   docbook: 'portal',
-  autocleanup: 'none',
 )
 impl_built_sources = gnome.gdbus_codegen(
   'xdp-impl-dbus',
@@ -22,7 +21,6 @@ background_monitor_built_sources = gnome.gdbus_codegen(
   interface_prefix: 'org.freedesktop.background',
   namespace: 'XdpDbusBackground',
   docbook: 'portal',
-  autocleanup: 'all',
 )
 if have_geoclue
   geoclue_built_sources = gnome.gdbus_codegen(
@@ -30,7 +28,6 @@ if have_geoclue
     sources: 'org.freedesktop.GeoClue2.Client.xml',
     interface_prefix: 'org.freedesktop.GeoClue2',
     namespace: 'Geoclue',
-    autocleanup: 'none',
   )
 else
   geoclue_built_sources = []


### PR DESCRIPTION
The autocleanup helpers are very useful and there is no reason to turn them off, if the code still compiles.

Unfortunately the autocleanup for portal impl interfaces do generate code that doesn't compile, so leave it turned off for now.