### PR TITLE
Avoid forwarding all notification file desciptors to backend

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -361,7 +361,7 @@ parse_markup_body (GVariantBuilder  *builder,
   gsize text_length = 0;
 
   if (!check_value_type ("markup-body", body, G_VARIANT_TYPE_STRING, error))
-      return FALSE;
+    return FALSE;
 
   text = g_variant_get_string (body, &text_length);
   composed = g_string_sized_new (text_length);
@@ -797,13 +797,13 @@ parse_display_hint (GVariantBuilder  *builder,
   g_autofree const char **display_hints = NULL;
   gsize display_hints_length;
   const char *supported_display_hints[] = {
-      "transient",
-      "tray",
-      "persistent",
-      "hide-on-lock-screen",
-      "hide-content-on-lock-screen",
-      "show-as-new",
-      NULL
+    "transient",
+    "tray",
+    "persistent",
+    "hide-on-lock-screen",
+    "hide-content-on-lock-screen",
+    "show-as-new",
+    NULL
   };
 
   if (!check_value_type ("display-hint", value, G_VARIANT_TYPE_STRING_ARRAY, error))

--- a/src/notification.c
+++ b/src/notification.c
@@ -254,11 +254,11 @@ markup_parser_text (GMarkupParseContext  *context,
 }
 
 static void
-markup_parser_start_element (GMarkupParseContext *context,
-                             const gchar         *element_name,
+markup_parser_start_element (GMarkupParseContext  *context,
+                             const gchar          *element_name,
                              const gchar         **attribute_names,
                              const gchar         **attribute_values,
-                             gpointer             user_data,
+                             gpointer              user_data,
                              GError              **error)
 {
   GString *composed = user_data;
@@ -287,9 +287,9 @@ markup_parser_start_element (GMarkupParseContext *context,
 }
 
 static void
-markup_parser_end_element (GMarkupParseContext *context,
-                           const gchar         *element_name,
-                           gpointer             user_data,
+markup_parser_end_element (GMarkupParseContext  *context,
+                           const gchar          *element_name,
+                           gpointer              user_data,
                            GError              **error)
 {
   GString *composed = user_data;


### PR DESCRIPTION
Main commit:

```
    notification: Use separate fd list for input and output
    
    Doing this means we don't unnecessarily forward file descriptors that
    weren't intended to be passed along.
    
    For the notification portal, this avoids forwarding file descriptors
    from the app to the backend that were dropped due to being placed in an
    unsupported property.
```

I haven't tested this yet, I just ran the tests.