### PR TITLE
ci: Install doc dependencies via pip

### DIFF
--- a/.github/workflows/Containerfile
+++ b/.github/workflows/Containerfile
@@ -49,8 +49,6 @@ RUN apt install -y --no-install-recommends \
     python3-dbus
 
 # Install doc dependencies
-RUN apt install -y --no-install-recommends \
-    python3-sphinx-copybutton \
-    python3-sphinxext-opengraph \
-    furo \
-    python3-sphinx
+RUN apt install -y --no-install-recommends python3-pip
+RUN pip install --user --break-system-packages furo">=2024.04.27" \
+    sphinx-copybutton sphinxext-opengraph matplotlib

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,5 +1,5 @@
 env:
-  IMAGE_TAG: 20241016-2
+  IMAGE_TAG: 20241022-0
 
 on:
   workflow_call:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build docs
         run: |
+          export PYTHONPATH="/root/.local/lib/python$(python3 -c 'import sys; print("{}.{}".format(*sys.version_info))')/site-packages:$PYTHONPATH"
+          export PATH="/root/.local/bin:$PATH"
           meson setup builddir -Ddocumentation=enabled
           ninja -C builddir doc/html
 


### PR DESCRIPTION
Fixes the current messed up CSS/theme in https://flatpak.github.io/xdg-desktop-portal/docs/index.html, deployed at https://bbhtt.github.io/xdg-desktop-portal/docs/index.html