### PR TITLE
Allow build-time tests to be run in environments where bwrap can't work

### DIFF
--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -653,6 +653,7 @@ xdp_validate_sound (XdpSealedFd *sound)
   g_autoptr(GKeyFile) key_file = NULL;
   g_autofree char *output = NULL;
   const char *sound_validator = LIBEXECDIR "/xdg-desktop-portal-validate-sound";
+  gsize i;
 
   if (g_getenv ("XDP_VALIDATE_SOUND"))
     sound_validator = g_getenv ("XDP_VALIDATE_SOUND");
@@ -663,11 +664,13 @@ xdp_validate_sound (XdpSealedFd *sound)
       return FALSE;
     }
 
-  args[0] = sound_validator;
-  args[1] = "--sandbox";
-  args[2] = "--fd";
-  args[3] = G_STRINGIFY (VALIDATOR_INPUT_FD);
-  args[4] = NULL;
+  i = 0;
+  args[i++] = sound_validator;
+  args[i++] = "--sandbox";
+  args[i++] = "--fd";
+  args[i++] = G_STRINGIFY (VALIDATOR_INPUT_FD);
+  g_assert (i < G_N_ELEMENTS (args));
+  args[i++] = NULL;
 
   output = xdp_spawn_full (args, xdp_sealed_fd_dup_fd (sound), VALIDATOR_INPUT_FD, &error);
   if (!output)

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -602,7 +602,10 @@ xdp_validate_icon (XdpSealedFd  *icon,
 
   i = 0;
   args[i++] = icon_validator;
-  args[i++] = "--sandbox";
+
+  if (g_getenv ("XDP_VALIDATE_ICON_INSECURE") == NULL)
+    args[i++] = "--sandbox";
+
   args[i++] = "--fd";
   args[i++] = G_STRINGIFY (VALIDATOR_INPUT_FD);
   args[i++] = "--ruleset";

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -666,7 +666,10 @@ xdp_validate_sound (XdpSealedFd *sound)
 
   i = 0;
   args[i++] = sound_validator;
-  args[i++] = "--sandbox";
+
+  if (g_getenv ("XDP_VALIDATE_SOUND_INSECURE") == NULL)
+    args[i++] = "--sandbox";
+
   args[i++] = "--fd";
   args[i++] = G_STRINGIFY (VALIDATOR_INPUT_FD);
   g_assert (i < G_N_ELEMENTS (args));

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -587,6 +587,7 @@ xdp_validate_icon (XdpSealedFd  *icon,
   const char *icon_validator = LIBEXECDIR "/xdg-desktop-portal-validate-icon";
   const char *args[7];
   int size;
+  size_t i;
   g_autofree char *output = NULL;
   g_autoptr(GKeyFile) key_file = NULL;
 
@@ -599,13 +600,15 @@ xdp_validate_icon (XdpSealedFd  *icon,
       return FALSE;
     }
 
-  args[0] = icon_validator;
-  args[1] = "--sandbox";
-  args[2] = "--fd";
-  args[3] = G_STRINGIFY (VALIDATOR_INPUT_FD);
-  args[4] = "--ruleset";
-  args[5] = icon_type_to_string (icon_type);
-  args[6] = NULL;
+  i = 0;
+  args[i++] = icon_validator;
+  args[i++] = "--sandbox";
+  args[i++] = "--fd";
+  args[i++] = G_STRINGIFY (VALIDATOR_INPUT_FD);
+  args[i++] = "--ruleset";
+  args[i++] = icon_type_to_string (icon_type);
+  g_assert (i < G_N_ELEMENTS (args));
+  args[i++] = NULL;
 
   output = xdp_spawn_full (args, xdp_sealed_fd_dup_fd (icon), VALIDATOR_INPUT_FD, &error);
   if (!output)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,46 @@
+xdg-desktop-portal test suite
+=============================
+
+## Environment
+
+Some relevant environment variables that can be set during testing,
+but should not normally be set on production systems:
+
+* `FLATPAK_BWRAP`: Path to the **bwrap**(1) executable
+    (default: discovered at build-time)
+
+* `LIBEXECDIR`: If set, look for the x-d-p executable in this directory
+
+* `TEST_IN_CI`: If set (to any value), some tests that are not always
+    reliable are skipped.
+    Set this for automated QA testing, leave it unset during development.
+
+* `XDP_VALIDATE_ICON_INSECURE`: If set (to any value), x-d-p doesn't
+    sandbox the icon validator using **bwrap**(1), even if sandboxed
+    validation was enabled at compile time.
+    This can be used to run build-time tests in a chroot or unprivileged
+    container environment, where **bwrap**(1) normally can't work.
+    It should never be set on a production system that will be validating
+    untrusted icons!
+
+* `XDP_VALIDATE_SOUND_INSECURE`: Same as `XDP_VALIDATE_ICON_INSECURE`,
+    but for sounds
+
+### Used automatically
+
+These environment variables are set automatically and shouldn't need to be
+changed, but developers improving the test suite might need to be aware
+of them:
+
+* `XDG_DESKTOP_PORTAL_DIR`: If set, it will be used instead of the
+    compile-time path (normally `/usr/share/xdg-desktop-portal/portals`)
+
+* `XDP_UNINSTALLED`: Set to 1 when running build-time tests on a version
+    of x-d-p that has not yet been installed. Leave unset when running
+    "as-installed" tests on the system copy of x-d-p.
+
+* `XDP_VALIDATE_ICON`: Path to `x-d-p-validate-icon` executable in the
+    build directory
+
+* `XDP_VALIDATE_SOUND`: Path to `x-d-p-validate-sound` executable in the
+    build directory


### PR DESCRIPTION
Resolves #1497.

In limited build environments, the tests can be run as:

```
XDP_VALIDATE_ICON_INSECURE=1 XDP_VALIDATE_SOUND_INSECURE=1 meson test -C ${builddir}
```

(variable names chosen to discourage users from making use of this in production to validate genuinely untrusted icons/sounds).

* xdp_validate_icon: Assign argument indices automatically

* xdp_validate_icon: Allow sandboxing of the validator to be disabled
    
    OS distributions often compile packages and run their build-time tests
    in a chroot environment or an unprivileged container, and bubblewrap
    cannot usually work in either of those environments.

* xdp_validate_sound: Assign argument indices automatically

* xdp_validate_sound: Allow sandboxing of the validator to be disabled
    
    Same reasoning as for the icon validator.