### PR TITLE
notification: Use categories from xdg desktop notification spec

### DIFF
--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -279,7 +279,7 @@
 
           The following categories are standarized so far:
 
-          * ``im.message``
+          * ``im.received``
 
             Intended for instant messaging apps displaying notifications for new messages.
 
@@ -331,7 +331,7 @@
 
               Disable the speakerphone for the ongoing call.
 
-          * ``call.missed``
+          * ``call.unanswered``
 
             Intended to be used by call apps when a call was missed.
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -877,11 +877,11 @@ parse_category (GVariantBuilder  *builder,
 {
   const char *category;
   const char *supported_categories[] = {
-    "im.message",
+    "im.received",
     "alarm.ringing",
     "call.incoming",
     "call.ongoing",
-    "call.missed",
+    "call.unanswered",
     "weather.warning.extreme",
     "cellbroadcast.danger.extreme",
     "cellbroadcast.danger.severe",

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -515,7 +515,7 @@ test_notification_category (void)
 
   notification_s = "{ 'title': <'test notification 5'>, "
                    "  'body': <'test notification body 5'>, "
-                   "  'category': <'im.message'>"
+                   "  'category': <'im.received'>"
                    "}";
 
   run_notification_test ("test5", notification_s, NULL, FALSE);


### PR DESCRIPTION
The xdg spec¹ uses slightly different names thus making it hard for apps
to use API like `g_notification_set_category` in a way that works for
portaled and non-portaled use cases.

It also makes things slighlty more consistent as the current call.*
sub-categories (`.incoming`, `.ongoing`) indicate a state while the `im`
category indicates a type (`message`).

1) https://specifications.freedesktop.org/notification-spec/1.2/categories.html