### PR TITLE
Memory leak fixes

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -72,12 +72,11 @@ send_response_in_thread_func (GTask        *task,
   Request *request = task_data;
   guint response;
   GVariant *results;
-  GVariantBuilder new_results;
+  g_auto(GVariantBuilder) new_results =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) idv = NULL;
   g_autoptr(GVariant) namev = NULL;
   const char *image;
-
-  g_variant_builder_init (&new_results, G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
 

--- a/src/background.c
+++ b/src/background.c
@@ -784,7 +784,7 @@ handle_request_background_in_thread_func (GTask *task,
   gboolean autostart_enabled;
   gboolean allowed;
   g_autoptr(GError) error = NULL;
-  const char * const *autostart_exec = { NULL };
+  g_autofree const char **autostart_exec = { NULL };
   gboolean activatable = FALSE;
 
   REQUEST_AUTOLOCK (request);
@@ -970,12 +970,12 @@ handle_request_background (XdpDbusBackground *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   g_autoptr(GTask) task = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &opt_builder,
                            background_options, G_N_ELEMENTS (background_options),
                            &error))

--- a/src/background.c
+++ b/src/background.c
@@ -710,8 +710,6 @@ enable_autostart_sync (XdpAppInfo          *app_info,
       return FALSE;
     }
 
-  cmd = g_strjoinv (" ", exec);
-
   file = g_strconcat (appid, ".desktop", NULL);
   dir = g_build_filename (g_get_user_config_dir (), "autostart", NULL);
   path = g_build_filename (dir, file, NULL);
@@ -743,12 +741,19 @@ enable_autostart_sync (XdpAppInfo          *app_info,
                          appid); /* FIXME: The app id isn't the name */
   g_key_file_set_string (keyfile,
                          G_KEY_FILE_DESKTOP_GROUP,
-                         G_KEY_FILE_DESKTOP_KEY_EXEC,
-                         cmd);
-  g_key_file_set_string (keyfile,
-                         G_KEY_FILE_DESKTOP_GROUP,
                          "X-XDP-Autostart",
                          appid);
+
+  if (exec)
+    cmd = g_strjoinv (" ", exec);
+
+  if (cmd)
+    {
+      g_key_file_set_string (keyfile,
+                             G_KEY_FILE_DESKTOP_GROUP,
+                             G_KEY_FILE_DESKTOP_KEY_EXEC,
+                             cmd);
+    }
 
   if (activatable)
     {

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -73,8 +73,10 @@ send_response_in_thread_func (GTask        *task,
                               GCancellable *cancellable)
 {
   Request *request = task_data;
-  GVariantBuilder results;
-  GVariantBuilder ruris;
+  g_auto(GVariantBuilder) results =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+  g_auto(GVariantBuilder) ruris =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_STRING_ARRAY);
   guint response;
   GVariant *options;
   DocumentFlags flags = DOCUMENT_FLAG_WRITABLE | DOCUMENT_FLAG_DIRECTORY;
@@ -82,9 +84,6 @@ send_response_in_thread_func (GTask        *task,
   GVariant *choices;
   GVariant *current_filter;
   GVariant *writable;
-
-  g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
-  g_variant_builder_init (&ruris, G_VARIANT_TYPE_STRING_ARRAY);
 
   REQUEST_AUTOLOCK (request);
 
@@ -531,14 +530,14 @@ handle_open_file (XdpDbusFileChooser *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) dir_option = NULL;
 
   g_debug ("Handling OpenFile");
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options,
                            open_file_options, G_N_ELEMENTS (open_file_options),
                            &error))
@@ -660,7 +659,8 @@ handle_save_file (XdpDbusFileChooser *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   XdpDbusImplRequest *impl_request;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   g_debug ("Handling SaveFile");
 
@@ -676,7 +676,6 @@ handle_save_file (XdpDbusFileChooser *object,
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options,
                            save_file_options, G_N_ELEMENTS (save_file_options),
                            &error))
@@ -819,7 +818,8 @@ handle_save_files (XdpDbusFileChooser *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   XdpDbusImplRequest *impl_request;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   if (xdp_dbus_impl_lockdown_get_disable_save_to_disk (lockdown))
     {
@@ -833,7 +833,6 @@ handle_save_files (XdpDbusFileChooser *object,
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options,
                            save_files_options, G_N_ELEMENTS (save_files_options),
                            &error))

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -354,14 +354,11 @@ send_response_in_thread_func (GTask *task,
   guint response;
   GVariant *options;
   const char *choice;
-  GVariantBuilder opt_builder;
 
   REQUEST_AUTOLOCK (request);
 
   response = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (request), "response"));
   options = (GVariant *)g_object_get_data (G_OBJECT (request), "options");
-
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
 
   if (response != 0)
     goto out;
@@ -390,6 +387,9 @@ send_response_in_thread_func (GTask *task,
 out:
   if (request->exported)
     {
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       response,
                                       g_variant_builder_end (&opt_builder));

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -81,6 +81,11 @@ send_response (Request *request,
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request), response, results);
       request_unexport (request);
     }
+  else
+    {
+      g_variant_ref_sink (results);
+      g_variant_unref (results);
+    }
 }
 
 static void


### PR DESCRIPTION
Fixes a bunch of memory leaks of GVariantBuilders. It also introduces G_VARIANT_BUILDER_UNSET (https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4377) which I would like to get into glib.