### PR TITLE
Use g_auto and G_VARIANT_BUILDER_INIT for all GVariantBuilders

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -72,12 +72,11 @@ send_response_in_thread_func (GTask        *task,
   Request *request = task_data;
   guint response;
   GVariant *results;
-  GVariantBuilder new_results;
+  g_auto(GVariantBuilder) new_results =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) idv = NULL;
   g_autoptr(GVariant) namev = NULL;
   const char *image;
-
-  g_variant_builder_init (&new_results, G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
 

--- a/src/account.c
+++ b/src/account.c
@@ -183,7 +183,8 @@ handle_get_user_information (XdpDbusAccount *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   g_debug ("Handling GetUserInformation");
 
@@ -203,7 +204,6 @@ handle_get_user_information (XdpDbusAccount *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &options,
                       user_information_options, G_N_ELEMENTS (user_information_options),
                       NULL);

--- a/src/background.c
+++ b/src/background.c
@@ -352,18 +352,18 @@ remove_outdated_instances (int stamp)
 static void
 update_background_monitor_properties (void)
 {
-  GVariantBuilder builder;
+  g_auto(GVariantBuilder) builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("aa{sv}"));
   GHashTableIter iter;
   InstanceData *data;
   char *id;
-
-  g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
 
   G_LOCK (applications);
   g_hash_table_iter_init (&iter, applications);
   while (g_hash_table_iter_next (&iter, (gpointer *)&id, (gpointer *)&data))
     {
-      GVariantBuilder app_builder;
+      g_auto(GVariantBuilder) app_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       const char *app_id;
       const char *id;
 
@@ -377,7 +377,6 @@ update_background_monitor_properties (void)
       app_id = flatpak_instance_get_app (data->instance);
       g_assert (app_id != NULL);
 
-      g_variant_builder_init (&app_builder, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&app_builder, "{sv}", "app_id", g_variant_new_string (app_id));
       g_variant_builder_add (&app_builder, "{sv}", "instance", g_variant_new_string (id));
       if (data->status_message)
@@ -811,7 +810,8 @@ handle_request_background_in_thread_func (GTask *task,
 
   if (permission == PERMISSION_ASK)
     {
-      GVariantBuilder opt_builder;
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree char *app_id = NULL;
       g_autofree char *title = NULL;
       g_autofree char *subtitle = NULL;
@@ -835,7 +835,6 @@ handle_request_background_in_thread_func (GTask *task,
 
       g_debug ("Calling backend for background access for: %s", id);
 
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&opt_builder, "{sv}", "deny_label", g_variant_new_string (_("Don't allow")));
       g_variant_builder_add (&opt_builder, "{sv}", "grant_label", g_variant_new_string (_("Allow")));
       if (!xdp_dbus_impl_access_call_access_dialog_sync (access_impl,
@@ -883,9 +882,9 @@ handle_request_background_in_thread_func (GTask *task,
   if (request->exported)
     {
       XdgDesktopPortalResponseEnum portal_response;
-      GVariantBuilder results;
+      g_auto(GVariantBuilder) results =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-      g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&results, "{sv}", "background", g_variant_new_boolean (allowed));
       g_variant_builder_add (&results, "{sv}", "autostart", g_variant_new_boolean (autostart_enabled));
 
@@ -1160,7 +1159,8 @@ handle_set_status (XdpDbusBackground     *object,
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GTask) task = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   const char *id = NULL;
   Call *call;
 
@@ -1187,7 +1187,6 @@ handle_set_status (XdpDbusBackground     *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &opt_builder,
                            set_status_options,
                            G_N_ELEMENTS (set_status_options),

--- a/src/background.c
+++ b/src/background.c
@@ -784,7 +784,7 @@ handle_request_background_in_thread_func (GTask *task,
   gboolean autostart_enabled;
   gboolean allowed;
   g_autoptr(GError) error = NULL;
-  const char * const *autostart_exec = { NULL };
+  g_autofree const char **autostart_exec = { NULL };
   gboolean activatable = FALSE;
 
   REQUEST_AUTOLOCK (request);
@@ -970,12 +970,12 @@ handle_request_background (XdpDbusBackground *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   g_autoptr(GTask) task = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &opt_builder,
                            background_options, G_N_ELEMENTS (background_options),
                            &error))

--- a/src/background.c
+++ b/src/background.c
@@ -710,8 +710,6 @@ enable_autostart_sync (XdpAppInfo          *app_info,
       return FALSE;
     }
 
-  cmd = g_strjoinv (" ", exec);
-
   file = g_strconcat (appid, ".desktop", NULL);
   dir = g_build_filename (g_get_user_config_dir (), "autostart", NULL);
   path = g_build_filename (dir, file, NULL);
@@ -743,12 +741,19 @@ enable_autostart_sync (XdpAppInfo          *app_info,
                          appid); /* FIXME: The app id isn't the name */
   g_key_file_set_string (keyfile,
                          G_KEY_FILE_DESKTOP_GROUP,
-                         G_KEY_FILE_DESKTOP_KEY_EXEC,
-                         cmd);
-  g_key_file_set_string (keyfile,
-                         G_KEY_FILE_DESKTOP_GROUP,
                          "X-XDP-Autostart",
                          appid);
+
+  if (exec)
+    cmd = g_strjoinv (" ", exec);
+
+  if (cmd)
+    {
+      g_key_file_set_string (keyfile,
+                             G_KEY_FILE_DESKTOP_GROUP,
+                             G_KEY_FILE_DESKTOP_KEY_EXEC,
+                             cmd);
+    }
 
   if (activatable)
     {

--- a/src/camera.c
+++ b/src/camera.c
@@ -83,7 +83,8 @@ query_permission_sync (Request *request)
   permission = get_permission_sync (app_id, PERMISSION_TABLE, PERMISSION_DEVICE_CAMERA);
   if (permission == PERMISSION_ASK || permission == PERMISSION_UNSET)
     {
-      GVariantBuilder opt_builder;
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree char *title = NULL;
       g_autofree char *body = NULL;
       guint32 response = 2;
@@ -98,7 +99,6 @@ query_permission_sync (Request *request)
           info = (GAppInfo*)g_desktop_app_info_new (desktop_id);
         }
 
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&opt_builder, "{sv}", "icon", g_variant_new_string ("camera-web-symbolic"));
 
       if (info)
@@ -173,10 +173,9 @@ handle_access_camera_in_thread_func (GTask *task,
 
   if (request->exported)
     {
-      GVariantBuilder results;
+      g_auto(GVariantBuilder) results =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       guint32 response;
-
-      g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
 
       response = allowed ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS
                          : XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED;

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -114,7 +114,8 @@ handle_set_selection (XdpDbusClipboard *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -148,7 +149,6 @@ handle_set_selection (XdpDbusClipboard *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options,
                            &options_builder,
                            clipboard_set_selection_options,

--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -481,11 +481,10 @@ prepare_install_done (GObject      *source,
   guint response = 2;
   g_autoptr(GVariant) results = NULL;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder results_builder;
+  g_auto(GVariantBuilder) results_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
-
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_dbus_impl_dynamic_launcher_call_prepare_install_finish (XDP_DBUS_IMPL_DYNAMIC_LAUNCHER (source),
                                                                    &response,
@@ -541,10 +540,6 @@ out:
                                       g_variant_builder_end (&results_builder));
 
       request_unexport (request);
-    }
-  else
-    {
-      g_variant_builder_clear (&results_builder);
     }
 }
 
@@ -620,7 +615,8 @@ handle_prepare_install (XdpDbusDynamicLauncher *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autofree char *icon_format = NULL;
   g_autofree char *icon_size = NULL;
   g_autoptr(GVariant) icon_v = NULL;
@@ -641,7 +637,6 @@ handle_prepare_install (XdpDbusDynamicLauncher *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &opt_builder,
                            prepare_install_options, G_N_ELEMENTS (prepare_install_options), &error))
     {

--- a/src/email.c
+++ b/src/email.c
@@ -213,12 +213,11 @@ handle_compose_email (XdpDbusEmail *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  g_auto(GVariantBuilder) options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) attachment_fds = NULL;
 
   g_debug ("Handling ComposeEmail");
-
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
 

--- a/src/email.c
+++ b/src/email.c
@@ -79,9 +79,9 @@ send_response_in_thread_func (GTask        *task,
 
   if (request->exported)
     {
-      GVariantBuilder new_results;
+      g_auto(GVariantBuilder) new_results =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-      g_variant_builder_init (&new_results, G_VARIANT_TYPE_VARDICT);
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       response,
                                       g_variant_builder_end (&new_results));
@@ -235,10 +235,10 @@ handle_compose_email (XdpDbusEmail *object,
   attachment_fds = g_variant_lookup_value (arg_options, "attachment_fds", G_VARIANT_TYPE ("ah"));
   if (attachment_fds)
     {
-      GVariantBuilder attachments;
+      g_auto(GVariantBuilder) attachments =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_STRING_ARRAY);
       int i;
 
-      g_variant_builder_init (&attachments, G_VARIANT_TYPE_STRING_ARRAY);
       for (i = 0; i < g_variant_n_children (attachment_fds); i++)
         {
           g_autofree char *path = NULL;

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -73,8 +73,10 @@ send_response_in_thread_func (GTask        *task,
                               GCancellable *cancellable)
 {
   Request *request = task_data;
-  GVariantBuilder results;
-  GVariantBuilder ruris;
+  g_auto(GVariantBuilder) results =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+  g_auto(GVariantBuilder) ruris =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_STRING_ARRAY);
   guint response;
   GVariant *options;
   DocumentFlags flags = DOCUMENT_FLAG_WRITABLE | DOCUMENT_FLAG_DIRECTORY;
@@ -82,9 +84,6 @@ send_response_in_thread_func (GTask        *task,
   GVariant *choices;
   GVariant *current_filter;
   GVariant *writable;
-
-  g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
-  g_variant_builder_init (&ruris, G_VARIANT_TYPE_STRING_ARRAY);
 
   REQUEST_AUTOLOCK (request);
 
@@ -531,14 +530,14 @@ handle_open_file (XdpDbusFileChooser *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) dir_option = NULL;
 
   g_debug ("Handling OpenFile");
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options,
                            open_file_options, G_N_ELEMENTS (open_file_options),
                            &error))
@@ -660,7 +659,8 @@ handle_save_file (XdpDbusFileChooser *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   XdpDbusImplRequest *impl_request;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   g_debug ("Handling SaveFile");
 
@@ -676,7 +676,6 @@ handle_save_file (XdpDbusFileChooser *object,
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options,
                            save_file_options, G_N_ELEMENTS (save_file_options),
                            &error))
@@ -819,7 +818,8 @@ handle_save_files (XdpDbusFileChooser *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   XdpDbusImplRequest *impl_request;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   if (xdp_dbus_impl_lockdown_get_disable_save_to_disk (lockdown))
     {
@@ -833,7 +833,6 @@ handle_save_files (XdpDbusFileChooser *object,
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options,
                            save_files_options, G_N_ELEMENTS (save_files_options),
                            &error))

--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -233,13 +233,13 @@ handle_create_session (XdpDbusGlobalShortcuts *object,
   Request *request = request_from_invocation (invocation);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  g_auto(GVariantBuilder) options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   Session *session;
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            global_shortcuts_create_session_options,
                            G_N_ELEMENTS (global_shortcuts_create_session_options),
@@ -388,13 +388,12 @@ handle_bind_shortcuts (XdpDbusGlobalShortcuts *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GVariant) shortcuts = NULL;
-  g_auto(GVariantBuilder) shortcuts_builder;
-  g_auto(GVariantBuilder) options_builder;
+  g_auto(GVariantBuilder) shortcuts_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
-
-  g_variant_builder_init (&shortcuts_builder, G_VARIANT_TYPE_ARRAY);
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_filter_options (arg_options, &options_builder,
                            global_shortcuts_bind_shortcuts_options,

--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -159,7 +159,8 @@ session_created_cb (GObject *source_object,
   guint response = 2;
   g_autoptr (GVariant) results = NULL;
   gboolean should_close_session;
-  GVariantBuilder results_builder;
+  g_auto(GVariantBuilder) results_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GError) error = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -167,8 +168,6 @@ session_created_cb (GObject *source_object,
   session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
-
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_dbus_impl_global_shortcuts_call_create_session_finish (impl,
                                                                   &response,
@@ -210,10 +209,6 @@ out:
                                       response,
                                       g_variant_builder_end (&results_builder));
       request_unexport (request);
-    }
-  else
-    {
-      g_variant_builder_clear (&results_builder);
     }
 
   if (should_close_session)
@@ -318,9 +313,9 @@ shortcuts_bound_cb (GObject *source_object,
     {
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -346,7 +341,8 @@ xdp_verify_shortcuts (GVariant *shortcuts,
   iter = g_variant_iter_new (shortcuts);
   while (g_variant_iter_loop (iter, "(s@a{sv})", &shortcut_name, &values))
     {
-      GVariantBuilder shortcut_builder;
+      g_auto(GVariantBuilder) shortcut_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
       if (shortcut_name[0] == 0)
         {
@@ -357,7 +353,6 @@ xdp_verify_shortcuts (GVariant *shortcuts,
           return FALSE;
         }
 
-      g_variant_builder_init (&shortcut_builder, G_VARIANT_TYPE_VARDICT);
       if (!xdp_filter_options (values, &shortcut_builder,
                                global_shortcuts_keys,
                                G_N_ELEMENTS (global_shortcuts_keys),
@@ -488,9 +483,9 @@ shortcuts_listed_cb (GObject *source_object,
     {
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -513,18 +508,17 @@ handle_list_shortcuts (XdpDbusGlobalShortcuts *object,
   Session *session;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            global_shortcuts_list_shortcuts_options,
                            G_N_ELEMENTS (global_shortcuts_list_shortcuts_options),
                            &error))
     {
-      g_variant_builder_clear (&options_builder);
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -88,9 +88,8 @@ inhibit_done (GObject *source,
 
   if (request->exported)
     {
-      GVariantBuilder new_results;
-
-      g_variant_builder_init (&new_results, G_VARIANT_TYPE_VARDICT);
+      g_auto(GVariantBuilder) new_results =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       response,
@@ -201,7 +200,8 @@ handle_inhibit (XdpDbusInhibit *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   g_autoptr(GTask) task = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -215,7 +215,6 @@ handle_inhibit (XdpDbusInhibit *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &opt_builder,
                       inhibit_options, G_N_ELEMENTS (inhibit_options),
                       NULL);
@@ -348,7 +347,8 @@ create_monitor_done (GObject *source_object,
   Session *session;
   guint response = 2;
   gboolean should_close_session;
-  GVariantBuilder results_builder;
+  g_auto(GVariantBuilder) results_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GError) error = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -356,8 +356,6 @@ create_monitor_done (GObject *source_object,
   session = g_object_get_data (G_OBJECT (request), "session");
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_data (G_OBJECT (request), "session", NULL);
-
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_dbus_impl_inhibit_call_create_monitor_finish (impl, &response, res, &error))
     {
@@ -395,10 +393,6 @@ out:
                                       response,
                                       g_variant_builder_end (&results_builder));
       request_unexport (request);
-    }
-  else
-    {
-      g_variant_builder_clear (&results_builder);
     }
 
   if (should_close_session)

--- a/src/input-capture.c
+++ b/src/input-capture.c
@@ -134,7 +134,8 @@ create_session_done (GObject      *source_object,
 {
   g_autoptr(Request) request = data;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder results_builder;
+  g_auto(GVariantBuilder) results_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   GVariant *results;
   Session *session;
   gboolean should_close_session;
@@ -146,8 +147,6 @@ create_session_done (GObject      *source_object,
   session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
-
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_dbus_impl_input_capture_call_create_session_finish (impl,
                                                                &response,
@@ -200,10 +199,6 @@ out:
                                       g_variant_builder_end (&results_builder));
       request_unexport (request);
     }
-  else
-    {
-      g_variant_builder_clear (&results_builder);
-    }
 
   if (should_close_session)
     session_close (session, FALSE);
@@ -240,7 +235,8 @@ handle_create_session (XdpDbusInputCapture   *object,
   Request *request = request_from_invocation (invocation);
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   Session *session;
 
@@ -268,7 +264,6 @@ handle_create_session (XdpDbusInputCapture   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            input_capture_create_session_options,
                            G_N_ELEMENTS (input_capture_create_session_options),
@@ -335,9 +330,9 @@ get_zones_done (GObject      *source_object,
     {
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -364,7 +359,8 @@ handle_get_zones (XdpDbusInputCapture   *object,
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   InputCaptureSession *input_capture_session;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   Session *session;
 
@@ -423,7 +419,6 @@ handle_get_zones (XdpDbusInputCapture   *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            input_capture_get_zones_options,
                            G_N_ELEMENTS (input_capture_get_zones_options),
@@ -491,9 +486,9 @@ set_pointer_barriers_done (GObject      *source_object,
     {
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -520,7 +515,8 @@ handle_set_pointer_barriers (XdpDbusInputCapture   *object,
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   InputCaptureSession *input_capture_session;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   Session *session;
 
@@ -579,7 +575,6 @@ handle_set_pointer_barriers (XdpDbusInputCapture   *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            input_capture_set_pointer_barriers_options,
                            G_N_ELEMENTS (input_capture_set_pointer_barriers_options),
@@ -625,7 +620,8 @@ handle_enable (XdpDbusInputCapture   *object,
   Session *session;
   InputCaptureSession *input_capture_session;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   session = acquire_session_from_call (arg_session_handle, call);
   if (!session)
@@ -670,8 +666,6 @@ handle_enable (XdpDbusInputCapture   *object,
          return G_DBUS_METHOD_INVOCATION_HANDLED;
      }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
-
   if (!xdp_filter_options (arg_options, &options_builder,
                            input_capture_enable_options,
                            G_N_ELEMENTS (input_capture_enable_options),
@@ -703,7 +697,7 @@ handle_enable (XdpDbusInputCapture   *object,
   xdp_dbus_impl_input_capture_call_enable (impl,
                                            arg_session_handle,
                                            xdp_app_info_get_id (call->app_info),
-					   g_variant_builder_end (&options_builder),
+                                           g_variant_builder_end (&options_builder),
                                            NULL,
                                            NULL,
                                            NULL);
@@ -726,7 +720,8 @@ handle_disable (XdpDbusInputCapture   *object,
   Session *session;
   InputCaptureSession *input_capture_session;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   session = acquire_session_from_call (arg_session_handle, call);
   if (!session)
@@ -771,7 +766,6 @@ handle_disable (XdpDbusInputCapture   *object,
          return G_DBUS_METHOD_INVOCATION_HANDLED;
      }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            input_capture_disable_options,
                            G_N_ELEMENTS (input_capture_disable_options),
@@ -827,7 +821,8 @@ handle_release (XdpDbusInputCapture   *object,
   Session *session;
   InputCaptureSession *input_capture_session;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   session = acquire_session_from_call (arg_session_handle, call);
   if (!session)
@@ -872,7 +867,6 @@ handle_release (XdpDbusInputCapture   *object,
         return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            input_capture_release_options,
                            G_N_ELEMENTS (input_capture_release_options),
@@ -926,7 +920,8 @@ handle_connect_to_eis (XdpDbusInputCapture   *object,
   InputCaptureSession *input_capture_session;
   g_autoptr(GUnixFDList) out_fd_list = NULL;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder empty;
+  g_auto(GVariantBuilder) empty =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   GVariant *fd;
 
   session = acquire_session_from_call (arg_session_handle, call);
@@ -971,8 +966,6 @@ handle_connect_to_eis (XdpDbusInputCapture   *object,
                                                  "Invalid session");
           return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
-
-  g_variant_builder_init (&empty, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_dbus_impl_input_capture_call_connect_to_eis_sync (impl,
                                                              arg_session_handle,

--- a/src/location.c
+++ b/src/location.c
@@ -525,7 +525,8 @@ handle_start_in_thread_func (GTask *task,
       guint access_response = 2;
       g_autoptr(GVariant) access_results = NULL;
       g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-      GVariantBuilder access_opt_builder;
+      g_auto(GVariantBuilder) access_opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree char *app_id = NULL;
       g_autofree char *title = NULL;
       g_autofree char *subtitle = NULL;
@@ -539,7 +540,6 @@ handle_start_in_thread_func (GTask *task,
 
       request_set_impl_request (request, impl_request);
 
-      g_variant_builder_init (&access_opt_builder, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&access_opt_builder, "{sv}",
                              "deny_label", g_variant_new_string (_("Deny Access")));
       g_variant_builder_add (&access_opt_builder, "{sv}",
@@ -632,10 +632,10 @@ handle_start_in_thread_func (GTask *task,
 out:
   if (request->exported)
     {
-      GVariantBuilder opt_builder;
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
       g_debug ("sending response: %d", response);
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       response,
                                       g_variant_builder_end (&opt_builder));

--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -144,11 +144,11 @@ handle_get_status (XdpDbusNetworkMonitor *object,
   else
     {
       NetworkMonitor *nm = (NetworkMonitor *)object;
-      GVariantBuilder status;
+      g_auto(GVariantBuilder) status =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       gboolean b;
       guint c;
 
-      g_variant_builder_init (&status, G_VARIANT_TYPE_VARDICT);
       b = g_network_monitor_get_network_available (nm->monitor);
       g_variant_builder_add (&status, "{sv}",
                              "available", g_variant_new_boolean (b));

--- a/src/notification.c
+++ b/src/notification.c
@@ -1051,7 +1051,8 @@ handle_add_in_thread_func (GTask        *task,
                            GCancellable *cancellable)
 {
   CallData *call_data = task_data;
-  GVariantBuilder builder;
+  g_auto(GVariantBuilder) builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GError) error = NULL;
 
   CALL_DATA_AUTOLOCK (call_data);
@@ -1068,16 +1069,12 @@ handle_add_in_thread_func (GTask        *task,
       return;
     }
 
-  g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
-
   if (!parse_notification (&builder,
                            call_data->notification,
                            call_data->in_fd_list,
                            call_data->out_fd_list,
                            &error))
     {
-      g_variant_builder_clear (&builder);
-
       g_prefix_error (&error, "invalid notification: ");
       g_task_return_error (task, g_steal_pointer (&error));
       return;

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -354,14 +354,11 @@ send_response_in_thread_func (GTask *task,
   guint response;
   GVariant *options;
   const char *choice;
-  GVariantBuilder opt_builder;
 
   REQUEST_AUTOLOCK (request);
 
   response = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (request), "response"));
   options = (GVariant *)g_object_get_data (G_OBJECT (request), "options");
-
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
 
   if (response != 0)
     goto out;
@@ -390,6 +387,9 @@ send_response_in_thread_func (GTask *task,
 out:
   if (request->exported)
     {
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       response,
                                       g_variant_builder_end (&opt_builder));

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -607,7 +607,8 @@ handle_open_in_thread_func (GTask *task,
   gint latest_count;
   gint latest_threshold;
   gboolean ask_for_content_type;
-  GVariantBuilder opts_builder;
+  g_auto(GVariantBuilder) opts_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   gboolean skip_app_chooser = FALSE;
   g_auto(XdpFd) fd = -1;
   gboolean writable = FALSE;
@@ -632,7 +633,6 @@ handle_open_in_thread_func (GTask *task,
       g_warning ("Rejecting invalid open-uri request (both URI and fd are set)");
       if (request->exported)
         {
-          g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
           xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                           XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
                                           g_variant_builder_end (&opts_builder));
@@ -652,7 +652,6 @@ handle_open_in_thread_func (GTask *task,
           /* Reject the request */
           if (request->exported)
             {
-              g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
               xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                               XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
                                               g_variant_builder_end (&opts_builder));
@@ -668,7 +667,6 @@ handle_open_in_thread_func (GTask *task,
           if (request->exported)
             {
               g_debug ("Rejecting open request as content-type couldn't be fetched for '%s'", uri);
-              g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
               xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                               XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
                                               g_variant_builder_end (&opts_builder));
@@ -714,7 +712,6 @@ handle_open_in_thread_func (GTask *task,
 
           if (request->exported)
             {
-              g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
               xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                               XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
                                               g_variant_builder_end (&opts_builder));
@@ -765,7 +762,6 @@ handle_open_in_thread_func (GTask *task,
             }
           else
             {
-              g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
               xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                               XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS,
                                               g_variant_builder_end (&opts_builder));
@@ -872,7 +868,6 @@ handle_open_in_thread_func (GTask *task,
             {
               if (!result)
                 g_debug ("Open request for '%s' failed: %s", uri, error->message);
-              g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
               xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                               result ? XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS : XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
                                               g_variant_builder_end (&opts_builder));
@@ -882,8 +877,6 @@ handle_open_in_thread_func (GTask *task,
           return;
         }
     }
-
-  g_variant_builder_init (&opts_builder, G_VARIANT_TYPE_VARDICT);
 
   if (latest_id != NULL)
     g_variant_builder_add (&opts_builder, "{sv}", "last_choice", g_variant_new_string (latest_id));

--- a/src/print.c
+++ b/src/print.c
@@ -89,9 +89,8 @@ print_done (GObject *source,
 
   if (request->exported)
     {
-      GVariantBuilder opt_builder;
-
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       response,
@@ -153,7 +152,8 @@ handle_print (XdpDbusPrint *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   if (xdp_dbus_impl_lockdown_get_disable_printing (lockdown))
     {
@@ -182,7 +182,6 @@ handle_print (XdpDbusPrint *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &opt_builder,
                       print_options, G_N_ELEMENTS (print_options), NULL);
   xdp_dbus_impl_print_call_print(impl,
@@ -232,9 +231,8 @@ prepare_print_done (GObject *source,
 
   if (request->exported)
     {
-      GVariantBuilder opt_builder;
-
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
       if (response == 0)
         xdp_filter_options (options, &opt_builder,
@@ -268,7 +266,8 @@ handle_prepare_print (XdpDbusPrint *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   if (xdp_dbus_impl_lockdown_get_disable_printing (lockdown))
     {
@@ -296,7 +295,6 @@ handle_prepare_print (XdpDbusPrint *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &opt_builder,
                       prepare_print_options, G_N_ELEMENTS (prepare_print_options), NULL);
   xdp_dbus_impl_print_call_prepare_print (impl,

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -230,14 +230,14 @@ create_session_done (GObject *source_object,
   Session *session;
   guint response = 2;
   gboolean should_close_session;
-  GVariantBuilder results_builder;
+  g_auto(GVariantBuilder) results_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GError) error = NULL;
 
   REQUEST_AUTOLOCK (request);
 
   session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
 
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
 
@@ -281,10 +281,6 @@ out:
                                       g_variant_builder_end (&results_builder));
       request_unexport (request);
     }
-  else
-    {
-      g_variant_builder_clear (&results_builder);
-    }
 
   if (should_close_session)
     session_close (session, FALSE);
@@ -299,7 +295,8 @@ handle_create_session (XdpDbusRemoteDesktop *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -326,7 +323,6 @@ handle_create_session (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   options = g_variant_ref_sink (g_variant_builder_end (&options_builder));
 
   g_object_set_qdata_full (G_OBJECT (request),
@@ -383,9 +379,9 @@ select_devices_done (GObject *source_object,
     {
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -505,7 +501,8 @@ handle_select_devices (XdpDbusRemoteDesktop *object,
   RemoteDesktopSession *remote_desktop_session;
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -548,7 +545,6 @@ handle_select_devices (XdpDbusRemoteDesktop *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_select_devices_options,
                            G_N_ELEMENTS (remote_desktop_select_devices_options),
@@ -679,9 +675,9 @@ start_done (GObject *source_object,
 
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -713,7 +709,8 @@ handle_start (XdpDbusRemoteDesktop *object,
   RemoteDesktopSession *remote_desktop_session;
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -767,7 +764,6 @@ handle_start (XdpDbusRemoteDesktop *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   options = g_variant_ref_sink (g_variant_builder_end (&options_builder));
 
   g_object_set_qdata_full (G_OBJECT (request),
@@ -851,7 +847,8 @@ handle_notify_pointer_motion (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -876,7 +873,6 @@ handle_notify_pointer_motion (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -909,7 +905,8 @@ handle_notify_pointer_motion_absolute (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -943,7 +940,6 @@ handle_notify_pointer_motion_absolute (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -977,7 +973,8 @@ handle_notify_pointer_button (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1002,7 +999,6 @@ handle_notify_pointer_button (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -1040,7 +1036,8 @@ handle_notify_pointer_axis (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1065,7 +1062,6 @@ handle_notify_pointer_axis (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_pointer_axis_options,
                            G_N_ELEMENTS (remote_desktop_notify_pointer_axis_options),
@@ -1098,7 +1094,8 @@ handle_notify_pointer_axis_discrete (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1123,7 +1120,6 @@ handle_notify_pointer_axis_discrete (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -1156,7 +1152,8 @@ handle_notify_keyboard_keycode (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1181,7 +1178,6 @@ handle_notify_keyboard_keycode (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -1214,7 +1210,8 @@ handle_notify_keyboard_keysym (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1239,7 +1236,6 @@ handle_notify_keyboard_keysym (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -1274,7 +1270,8 @@ handle_notify_touch_down (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1308,7 +1305,6 @@ handle_notify_touch_down (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -1344,7 +1340,8 @@ handle_notify_touch_motion (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1378,7 +1375,6 @@ handle_notify_touch_motion (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -1411,7 +1407,8 @@ handle_notify_touch_up (XdpDbusRemoteDesktop *object,
 {
   Call *call = call_from_invocation (invocation);
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
@@ -1436,7 +1433,6 @@ handle_notify_touch_up (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_notify_options,
                            G_N_ELEMENTS (remote_desktop_notify_options),
@@ -1473,7 +1469,8 @@ handle_connect_to_eis (XdpDbusRemoteDesktop *object,
   RemoteDesktopSession *remote_desktop_session;
   g_autoptr(GUnixFDList) out_fd_list = NULL;
   g_autoptr(GError) error = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   GVariant *fd;
 
   session = acquire_session_from_call (arg_session_handle, call);
@@ -1526,7 +1523,6 @@ handle_connect_to_eis (XdpDbusRemoteDesktop *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            remote_desktop_connect_to_eis_options,
                            G_N_ELEMENTS (remote_desktop_connect_to_eis_options),

--- a/src/restore-token.c
+++ b/src/restore-token.c
@@ -108,12 +108,12 @@ xdp_session_persistence_set_persistent_permissions (Session *session,
                                                     GVariant *restore_data)
 {
   g_autoptr(GError) error = NULL;
-  GVariantBuilder permissions_builder;
+  g_auto(GVariantBuilder) permissions_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("a{sas}"));
   g_auto(GStrv) permission = NULL;
 
   permission = permissions_from_tristate (PERMISSION_YES);
 
-  g_variant_builder_init (&permissions_builder, G_VARIANT_TYPE ("a{sas}"));
   g_variant_builder_add (&permissions_builder, "{s^a&s}", session->app_id, permission);
 
   if (!xdp_dbus_impl_permission_store_call_set_sync (get_permission_store (),
@@ -186,13 +186,12 @@ xdp_session_persistence_replace_restore_token_with_data (Session *session,
                                                          char **out_restore_token)
 {
   GVariantIter options_iter;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   char *key;
   GVariant *value;
 
   g_variant_iter_init (&options_iter, *in_out_options);
-
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
 
   while (g_variant_iter_next (&options_iter, "{&sv}", &key, &value))
     {
@@ -322,13 +321,12 @@ xdp_session_persistence_replace_restore_data_with_token (Session *session,
                                                          GVariant **in_out_restore_data)
 {
   g_autoptr(GVariant) results = *in_out_results;
-  GVariantBuilder results_builder;
+  g_auto(GVariantBuilder) results_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   GVariantIter iter;
   const char *key;
   GVariant *value;
   gboolean found_restore_data = FALSE;
-
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
 
   g_variant_iter_init (&iter, results);
   while (g_variant_iter_next (&iter, "{&sv}", &key, &value))

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -161,7 +161,8 @@ create_session_done (GObject *source_object,
   Session *session;
   guint response = 2;
   gboolean should_close_session;
-  GVariantBuilder results_builder;
+  g_auto(GVariantBuilder) results_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GError) error = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -169,8 +170,6 @@ create_session_done (GObject *source_object,
   session = g_object_get_qdata (G_OBJECT (request), quark_request_session);
   SESSION_AUTOLOCK_UNREF (g_object_ref (session));
   g_object_set_qdata (G_OBJECT (request), quark_request_session, NULL);
-
-  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_dbus_impl_screen_cast_call_create_session_finish (impl,
                                                              &response,
@@ -213,10 +212,6 @@ out:
                                       g_variant_builder_end (&results_builder));
       request_unexport (request);
     }
-  else
-    {
-      g_variant_builder_clear (&results_builder);
-    }
 
   if (should_close_session)
     session_close (session, FALSE);
@@ -231,7 +226,8 @@ handle_create_session (XdpDbusScreenCast *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   Session *session;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -258,7 +254,6 @@ handle_create_session (XdpDbusScreenCast *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   options = g_variant_ref_sink (g_variant_builder_end (&options_builder));
 
   g_object_set_qdata_full (G_OBJECT (request),
@@ -314,9 +309,9 @@ select_sources_done (GObject *source_object,
     {
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -490,7 +485,8 @@ handle_select_sources (XdpDbusScreenCast *object,
   Session *session;
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -575,7 +571,6 @@ handle_select_sources (XdpDbusScreenCast *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   if (!xdp_filter_options (arg_options, &options_builder,
                            screen_cast_select_sources_options,
                            G_N_ELEMENTS (screen_cast_select_sources_options),
@@ -816,9 +811,9 @@ start_done (GObject *source_object,
 
       if (!results)
         {
-          GVariantBuilder results_builder;
+          g_auto(GVariantBuilder) results_builder =
+            G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-          g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
           results = g_variant_ref_sink (g_variant_builder_end (&results_builder));
         }
 
@@ -851,7 +846,8 @@ handle_start (XdpDbusScreenCast *object,
   ScreenCastSession *screen_cast_session;
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options_builder;
+  g_auto(GVariantBuilder) options_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(GVariant) options = NULL;
 
   REQUEST_AUTOLOCK (request);
@@ -913,7 +909,6 @@ handle_start (XdpDbusScreenCast *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&options_builder, G_VARIANT_TYPE_VARDICT);
   options = g_variant_ref_sink (g_variant_builder_end (&options_builder));
 
   g_object_set_qdata_full (G_OBJECT (request),

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -81,6 +81,11 @@ send_response (Request *request,
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request), response, results);
       request_unexport (request);
     }
+  else
+    {
+      g_variant_ref_sink (results);
+      g_variant_unref (results);
+    }
 }
 
 static void

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -95,15 +95,14 @@ send_response_in_thread_func (GTask *task,
                               GCancellable *cancellable)
 {
   Request *request = task_data;
-  GVariantBuilder results;
+  g_auto(GVariantBuilder) results =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   guint response;
   GVariant *options;
   g_autoptr(GError) error = NULL;
   const char *retval;
 
   REQUEST_AUTOLOCK (request);
-
-  g_variant_builder_init (&results, G_VARIANT_TYPE_VARDICT);
 
   response = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (request), "response"));
   options = (GVariant *)g_object_get_data (G_OBJECT (request), "options");
@@ -199,7 +198,8 @@ handle_screenshot_in_thread_func (GTask *task,
   Request *request = REQUEST (task_data);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   Permission permission;
   GVariant *options;
   gboolean permission_store_checked = FALSE;
@@ -208,8 +208,6 @@ handle_screenshot_in_thread_func (GTask *task,
   const char *app_id;
 
   REQUEST_AUTOLOCK (request);
-
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
 
   app_id = xdp_app_info_get_id (request->app_info);
   parent_window = ((const char *)g_object_get_data (G_OBJECT (request), "parent-window"));
@@ -226,7 +224,8 @@ handle_screenshot_in_thread_func (GTask *task,
   if (!interactive && permission != PERMISSION_YES)
     {
       g_autoptr(GVariant) access_results = NULL;
-      GVariantBuilder access_opt_builder;
+      g_auto(GVariantBuilder) access_opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree gchar *subtitle = NULL;
       g_autofree gchar *title = NULL;
       const gchar *body;
@@ -238,7 +237,6 @@ handle_screenshot_in_thread_func (GTask *task,
           return;
         }
 
-      g_variant_builder_init (&access_opt_builder, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&access_opt_builder, "{sv}",
                              "deny_label", g_variant_new_string (_("Deny")));
       g_variant_builder_add (&access_opt_builder, "{sv}",
@@ -413,7 +411,8 @@ handle_pick_color (XdpDbusScreenshot *object,
   Request *request = request_from_invocation (invocation);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
 
@@ -432,7 +431,6 @@ handle_pick_color (XdpDbusScreenshot *object,
   request_set_impl_request (request, impl_request);
   request_export (request, g_dbus_method_invocation_get_connection (invocation));
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (arg_options, &opt_builder,
                       pick_color_options, G_N_ELEMENTS (pick_color_options),
                       NULL);

--- a/src/secret.c
+++ b/src/secret.c
@@ -75,9 +75,8 @@ send_response_in_thread_func (GTask *task,
 {
   Request *request = task_data;
   guint response;
-  GVariantBuilder new_results;
-
-  g_variant_builder_init (&new_results, G_VARIANT_TYPE_VARDICT);
+  g_auto(GVariantBuilder) new_results =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
 
@@ -132,7 +131,8 @@ handle_retrieve_secret (XdpDbusSecret *object,
   const char *app_id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  GVariantBuilder options;
+  g_auto(GVariantBuilder) options =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
   REQUEST_AUTOLOCK (request);
 
@@ -147,8 +147,6 @@ handle_retrieve_secret (XdpDbusSecret *object,
       g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
-
-  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
 
   if (!xdp_filter_options (arg_options, &options,
                            retrieve_secret_options, G_N_ELEMENTS (retrieve_secret_options),

--- a/src/session.c
+++ b/src/session.c
@@ -178,9 +178,9 @@ session_close (Session *session,
 
   if (notify_closed)
     {
-      GVariantBuilder details_builder;
+      g_auto(GVariantBuilder) details_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-      g_variant_builder_init (&details_builder, G_VARIANT_TYPE_VARDICT);
       g_dbus_connection_emit_signal (session->connection,
                                      session->sender,
                                      session->id,

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -68,10 +68,10 @@ send_response (Request *request,
 {
   if (request->exported)
     {
-      GVariantBuilder opt_builder;
+      g_auto(GVariantBuilder) opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
       g_debug ("sending response: %d", response);
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       response,
                                       g_variant_builder_end (&opt_builder));
@@ -130,7 +130,8 @@ handle_set_wallpaper_in_thread_func (GTask *task,
   const char *id = xdp_app_info_get_id (request->app_info);
   g_autoptr(GError) error = NULL;
   g_autofree char *uri = NULL;
-  GVariantBuilder opt_builder;
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   GVariant *options;
   gboolean show_preview = FALSE;
@@ -149,7 +150,6 @@ handle_set_wallpaper_in_thread_func (GTask *task,
       g_warning ("Rejecting invalid set-wallpaper request (both URI and fd are set)");
       if (request->exported)
         {
-          g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
           xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                           XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
                                           g_variant_builder_end (&opt_builder));
@@ -172,13 +172,13 @@ handle_set_wallpaper_in_thread_func (GTask *task,
     {
       guint access_response = 2;
       g_autoptr(GVariant) access_results = NULL;
-      GVariantBuilder access_opt_builder;
+      g_auto(GVariantBuilder) access_opt_builder =
+        G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree gchar *app_id = NULL;
       g_autofree gchar *title = NULL;
       g_autofree gchar *subtitle = NULL;
       const gchar *body;
 
-      g_variant_builder_init (&access_opt_builder, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&access_opt_builder, "{sv}",
                              "deny_label", g_variant_new_string (_("Deny")));
       g_variant_builder_add (&access_opt_builder, "{sv}",
@@ -257,7 +257,6 @@ handle_set_wallpaper_in_thread_func (GTask *task,
           /* Reject the request */
           if (request->exported)
             {
-              g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
               xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                               XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
                                               g_variant_builder_end (&opt_builder));
@@ -287,7 +286,6 @@ handle_set_wallpaper_in_thread_func (GTask *task,
 
   request_set_impl_request (request, impl_request);
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_filter_options (options, &opt_builder,
                       wallpaper_options, G_N_ELEMENTS (wallpaper_options),
                       NULL);


### PR DESCRIPTION
* Always initialize g_auto(GVariantBuilder)
* Use g_auto and G_VARIANT_BUILDER_INIT for all GVariantBuilders
    
    One has to be very careful about the control flow and early exits
    without the g_auto which can easily result in memory leaks. I noticed at
    least 5 cases where the change does fix a leak, even though it might be
    a bit hard to trigger.
    
    This also makes sure that all g_auto usages are initialized correctly.
