### PR TITLE
Camera: use an empty app id for host apps

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -78,7 +78,10 @@ query_permission_sync (XdpRequest *request)
   const char *app_id;
   gboolean allowed;
 
-  app_id = (const char *)g_object_get_data (G_OBJECT (request), "app-id");
+  if (xdp_app_info_is_host (request->app_info))
+    app_id = "";
+  else
+    app_id = (const char *)g_object_get_data (G_OBJECT (request), "app-id");
 
   permission = xdp_get_permission_sync (app_id, PERMISSION_TABLE, PERMISSION_DEVICE_CAMERA);
   if (permission == XDP_PERMISSION_ASK || permission == XDP_PERMISSION_UNSET)

--- a/tests/camera.c
+++ b/tests/camera.c
@@ -27,7 +27,7 @@ set_camera_permissions (const char *permission)
                                                            "devices",
                                                            TRUE,
                                                            "camera",
-                                                           appid,
+                                                           "",
                                                            permissions,
                                                            NULL,
                                                            &error);


### PR DESCRIPTION
Sending an app id that doesn't resolve to valid app info (e.g. a desktop file is not found) will automatically reject camera request, because the backend is not able to verify whether the app (based on app id) runs in the background. Same will happen if the app id resolves to an app where our app was started from. This happens for example when you start apps
in GNOME using Alt + F2, where we get invalid app id from cgroups and since it doesn't find opened application window for this app, it will automatically reject the request. Using an empty id fixes this problem.