### PR TITLE
Improve host XdpAppInfo handling and force empty app id for Camera portal

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -78,6 +78,11 @@ query_permission_sync (XdpRequest *request)
   const char *app_id;
   gboolean allowed;
 
+  /* The app id detection is still unreliable and some backends do check if the
+   * window matches the app id. Because that app id for host apps comes from the
+   * app itself through wayland, the checks can fail.
+   * This should be removed when app id detection has become more reliable.
+   */
   if (xdp_app_info_is_host (request->app_info))
     app_id = "";
   else

--- a/tests/camera.c
+++ b/tests/camera.c
@@ -19,15 +19,21 @@ extern gchar *appid;
 static void
 set_camera_permissions (const char *permission)
 {
+  const char *permission_app_id;
   const char *permissions[2] = { NULL, NULL };
   g_autoptr(GError) error = NULL;
+
+  /* x-d-p currently defaults to the empty app id for the camera portal for
+   * host XdpAppInfos (which the XdpAppInfoTest is). So instead of using the
+   * `extern gchar *appid` we have to use "" for now. */
+  permission_app_id = "";
 
   permissions[0] = permission;
   xdp_dbus_impl_permission_store_call_set_permission_sync (permission_store,
                                                            "devices",
                                                            TRUE,
                                                            "camera",
-                                                           "",
+                                                           permission_app_id,
                                                            permissions,
                                                            NULL,
                                                            &error);


### PR DESCRIPTION
* The first commit adds a missing environment variable to the tests README
* The next commit tightens the requirements for host app id's detected from the cgroup to also require a matching GAppInfo
* The third commit cleans up the camera portal function for querying permissions
* The last commit forces an empty app id for the Camera portal (essentially the same as https://github.com/flatpak/xdg-desktop-portal/pull/1512)
