### PR TITLE
Allow host apps to register themselves

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -39,6 +39,10 @@ portal_sources = files(
   'org.freedesktop.portal.Wallpaper.xml',
 )
 
+portal_host_sources = files(
+  'org.freedesktop.host.portal.Registry.xml',
+)
+
 portal_impl_sources = files(
   'org.freedesktop.impl.portal.Access.xml',
   'org.freedesktop.impl.portal.Account.xml',
@@ -70,6 +74,6 @@ background_monitor_sources = files(
   'org.freedesktop.background.Monitor.xml',
 )
 
-install_data([portal_sources, portal_impl_sources],
+install_data([portal_sources, portal_host_sources, portal_impl_sources],
     install_dir: datadir / 'dbus-1' / 'interfaces',
 )

--- a/data/org.freedesktop.host.portal.Registry.xml
+++ b/data/org.freedesktop.host.portal.Registry.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2024 Red Hat, Inc.
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Jonas Ådahl <jadahl@redhat.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.host.portal.Registry:
+      @short_description: Interface to associate D-Bus peers with application
+      ids.
+
+      This simple interface lets unsandboxed applications register their
+      D-Bus connections and associate it with an application ID that will be
+      used in portals.
+
+      This interface will not work with applications xdg-desktop-portal
+      identifies as sandboxed.
+
+      This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.host.portal.Registry">
+    <!--
+        Register:
+        @app_id: Application identifier
+        @options: Vardict with optional further information
+
+        Register a D-Bus peer and associate it with an application ID. The
+        application ID must be able to match the basename of a .desktop file
+        that describes the application.
+
+        The application ID will be used in org.freedesktop.portal APIs to
+        associate a portal action with an application.
+
+        Registering can only done at most once; any subsequent call will result
+        in an error.
+
+        Registering must be done before any portal method call; registering
+        after such a call will result in an error.
+    -->
+    <method name="Register">
+      <arg type="s" name="app_id" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+    </method>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1178,7 +1178,7 @@ handle_method (GCallback              method_callback,
   g_autoptr(XdpAppInfo) app_info = NULL;
   PortalMethod portal_method = (PortalMethod)method_callback;
 
-  app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, &error);
+  app_info = xdp_invocation_ensure_app_info_sync (invocation, NULL, &error);
   if (app_info == NULL)
     g_dbus_method_invocation_return_gerror (invocation, error);
   else

--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -527,7 +527,7 @@ handle_method (GCallback              method_callback,
   g_autoptr(XdpAppInfo) app_info = NULL;
   PortalMethod portal_method = (PortalMethod)method_callback;
 
-  app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, &error);
+  app_info = xdp_invocation_ensure_app_info_sync (invocation, NULL, &error);
   if (app_info == NULL)
     g_dbus_method_invocation_return_gerror (invocation, error);
   else

--- a/src/camera.c
+++ b/src/camera.c
@@ -291,7 +291,7 @@ handle_open_pipewire_remote (XdpDbusCamera *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, &error);
+  app_info = xdp_invocation_ensure_app_info_sync (invocation, NULL, &error);
   app_id = app_id_from_app_info (app_info);
   permission = xdp_get_permission_sync (app_id, PERMISSION_TABLE, PERMISSION_DEVICE_CAMERA);
   if (permission != XDP_PERMISSION_YES)

--- a/src/location.c
+++ b/src/location.c
@@ -134,7 +134,7 @@ location_session_new (GVariant *options,
 {
   GDBusConnection *connection = g_dbus_method_invocation_get_connection (invocation);
   const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
-  XdpAppInfo *app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, NULL);
+  XdpAppInfo *app_info = xdp_invocation_ensure_app_info_sync (invocation, NULL, NULL);
   XdpSession *session;
 
   session = g_initable_new (location_session_get_type (), NULL, error,

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,13 @@ portal_built_sources = gnome.gdbus_codegen(
   namespace: 'XdpDbus',
   docbook: 'portal',
 )
+host_built_sources = gnome.gdbus_codegen(
+  'xdp-host-dbus',
+  sources: portal_host_sources,
+  interface_prefix: 'org.freedesktop.host.portal',
+  namespace: 'XdpDbusHost',
+  docbook: 'portal',
+)
 impl_built_sources = gnome.gdbus_codegen(
   'xdp-impl-dbus',
   sources: portal_impl_sources,
@@ -89,6 +96,7 @@ xdg_desktop_portal_sources = files(
   'print.c',
   'proxy-resolver.c',
   'realtime.c',
+  'registry.c',
   'remote-desktop.c',
   'screen-cast.c',
   'screenshot.c',
@@ -112,6 +120,7 @@ xdg_desktop_portal_sources += [
   xdp_utils_sources,
   xdp_method_info_sources,
   portal_built_sources,
+  host_built_sources,
   impl_built_sources,
   background_monitor_built_sources,
   geoclue_built_sources,

--- a/src/registry.c
+++ b/src/registry.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2024 Red Hat, Inc
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#include "config.h"
+
+#include "registry.h"
+
+#include <stdio.h>
+
+#include "xdp-app-info-private.h"
+#include "xdp-app-info-test-private.h"
+#include "xdp-host-dbus.h"
+#include "xdp-utils.h"
+
+typedef struct _Registry Registry;
+typedef struct _RegistryClass RegistryClass;
+
+struct _Registry
+{
+  XdpDbusHostRegistrySkeleton parent_instance;
+};
+
+struct _RegistryClass
+{
+  XdpDbusHostRegistrySkeletonClass parent_class;
+};
+
+static Registry *registry;
+
+GType registry_get_type (void) G_GNUC_CONST;
+static void registry_iface_init (XdpDbusHostRegistryIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Registry, registry,
+                         XDP_DBUS_HOST_TYPE_REGISTRY_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_HOST_TYPE_REGISTRY,
+                                                registry_iface_init));
+
+static gboolean
+handle_register (XdpDbusHostRegistry   *object,
+                 GDBusMethodInvocation *invocation,
+                 const char            *arg_app_id,
+                 GVariant              *arg_options)
+{
+  g_autoptr(XdpAppInfo) app_info = NULL;
+  g_autoptr(GError) error = NULL;
+
+  app_info = xdp_invocation_register_host_app_info_sync (invocation, arg_app_id,
+                                                         NULL, &error);
+  if (!app_info)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_FAILED,
+                                             "Could not register app ID: %s",
+                                             error->message);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  if (g_strcmp0 (xdp_app_info_get_id (app_info), arg_app_id) != 0)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                                             "Registered too late");
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  xdp_dbus_host_registry_complete_register (object, invocation);
+
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+static void
+registry_iface_init (XdpDbusHostRegistryIface *iface)
+{
+  iface->handle_register = handle_register;
+}
+
+static void
+registry_init (Registry *registry)
+{
+  xdp_dbus_host_registry_set_version (XDP_DBUS_HOST_REGISTRY (registry), 1);
+}
+
+static void
+registry_class_init (RegistryClass *klass)
+{
+}
+
+GDBusInterfaceSkeleton *
+registry_create (GDBusConnection *connection)
+{
+  registry = g_object_new (registry_get_type (), NULL);
+
+  return G_DBUS_INTERFACE_SKELETON (registry);
+}

--- a/src/registry.h
+++ b/src/registry.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2024 Red Hat, Inc
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+GDBusInterfaceSkeleton * registry_create (GDBusConnection *connection);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -140,7 +140,7 @@ authorize_callback (GDBusInterfaceSkeleton *interface,
   g_autoptr(XdpAppInfo) app_info = NULL;
   g_autoptr(GError) error = NULL;
 
-  app_info = xdp_invocation_lookup_app_info_sync (invocation, NULL, &error);
+  app_info = xdp_invocation_ensure_app_info_sync (invocation, NULL, &error);
   if (app_info == NULL)
     {
       g_dbus_method_invocation_return_error (invocation,

--- a/src/xdp-app-info-flatpak-private.h
+++ b/src/xdp-app-info-flatpak-private.h
@@ -32,6 +32,10 @@ G_DECLARE_FINAL_TYPE (XdpAppInfoFlatpak,
                       XDP, APP_INFO_FLATPAK,
                       XdpAppInfo)
 
+gboolean xdp_is_flatpak (int        pid,
+                         gboolean  *is_flatpak,
+                         GError   **error);
+
 XdpAppInfo * xdp_app_info_flatpak_new (int      pid,
                                        int      pidfd,
                                        GError **error);

--- a/src/xdp-app-info-host-private.h
+++ b/src/xdp-app-info-host-private.h
@@ -35,6 +35,11 @@ G_DECLARE_FINAL_TYPE (XdpAppInfoHost,
 XdpAppInfo * xdp_app_info_host_new (int pid,
                                     int pidfd);
 
+XdpAppInfo *
+xdp_app_info_host_new_registered (int          pidfd,
+                                  const char  *app_id,
+                                  GError     **error);
+
 #ifdef HAVE_LIBSYSTEMD
 XDP_EXPORT_TEST
 char * _xdp_app_info_host_parse_app_id_from_unit_name (const char *unit);

--- a/src/xdp-app-info-host.c
+++ b/src/xdp-app-info-host.c
@@ -190,19 +190,18 @@ xdp_app_info_host_new (int pid,
                        int pidfd)
 {
   g_autoptr (XdpAppInfoHost) app_info_host = NULL;
-  g_autofree char *appid = NULL;
+  g_autofree char *app_id = NULL;
   g_autofree char *desktop_id = NULL;
   g_autoptr(GAppInfo) gappinfo = NULL;
 
-  appid = get_appid_from_pid (pid);
+  app_id = get_appid_from_pid (pid);
 
-  desktop_id = g_strconcat (appid, ".desktop", NULL);
-  gappinfo = G_APP_INFO (g_desktop_app_info_new (desktop_id));
+  desktop_id = g_strconcat (app_id, ".desktop", NULL);
 
   app_info_host = g_object_new (XDP_TYPE_APP_INFO_HOST, NULL);
   xdp_app_info_initialize (XDP_APP_INFO (app_info_host),
-                            /* engine, app id, instance */
-                           NULL, appid, NULL,
+                           /* engine, app id, instance */
+                           NULL, app_id, NULL,
                            pidfd, gappinfo,
                            /* supports_opath */ TRUE,
                            /* has_network */ TRUE,

--- a/src/xdp-app-info-snap-private.h
+++ b/src/xdp-app-info-snap-private.h
@@ -32,6 +32,10 @@ G_DECLARE_FINAL_TYPE (XdpAppInfoSnap,
                       XDP, APP_INFO_SNAP,
                       XdpAppInfo)
 
+gboolean xdp_is_snap (int        pid,
+                      gboolean  *is_snap,
+                      GError   **error);
+
 XdpAppInfo * xdp_app_info_snap_new (int      pid,
                                     int      pidfd,
                                     GError **error);

--- a/src/xdp-app-info-snap.c
+++ b/src/xdp-app-info-snap.c
@@ -135,6 +135,32 @@ end:
   return is_snap;
 }
 
+gboolean
+xdp_is_snap (int        pid,
+             gboolean  *is_snap,
+             GError   **error)
+{
+  g_autoptr(GError) local_error = NULL;
+
+  if (!pid_is_snap (pid, &local_error))
+    {
+      if (local_error && !g_error_matches (local_error, XDP_APP_INFO_ERROR,
+                                           XDP_APP_INFO_ERROR_WRONG_APP_KIND))
+        {
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
+
+      *is_snap = FALSE;
+      return TRUE;
+    }
+  else
+    {
+      *is_snap = TRUE;
+      return TRUE;
+    }
+}
+
 XdpAppInfo *
 xdp_app_info_snap_new (int      pid,
                        int      pidfd,

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -805,7 +805,7 @@ xdp_invocation_ensure_app_info_sync (GDBusMethodInvocation  *invocation,
                                      GError                **error)
 {
   GDBusConnection *connection = g_dbus_method_invocation_get_connection (invocation);
-  const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
+  const char *sender = g_dbus_method_invocation_get_sender (invocation);
   g_autoptr(XdpAppInfo) app_info = NULL;
 
   app_info = cache_lookup_app_info_by_sender (sender);

--- a/src/xdp-app-info.h
+++ b/src/xdp-app-info.h
@@ -81,6 +81,6 @@ gboolean xdp_app_info_validate_dynamic_launcher (XdpAppInfo  *app_info,
 
 const GPtrArray * xdp_app_info_get_usb_queries (XdpAppInfo *app_info);
 
-XdpAppInfo * xdp_invocation_lookup_app_info_sync (GDBusMethodInvocation  *invocation,
+XdpAppInfo * xdp_invocation_ensure_app_info_sync (GDBusMethodInvocation  *invocation,
                                                   GCancellable           *cancellable,
                                                   GError                **error);

--- a/src/xdp-app-info.h
+++ b/src/xdp-app-info.h
@@ -84,3 +84,8 @@ const GPtrArray * xdp_app_info_get_usb_queries (XdpAppInfo *app_info);
 XdpAppInfo * xdp_invocation_ensure_app_info_sync (GDBusMethodInvocation  *invocation,
                                                   GCancellable           *cancellable,
                                                   GError                **error);
+
+XdpAppInfo * xdp_invocation_register_host_app_info_sync (GDBusMethodInvocation  *invocation,
+                                                         const char             *app_id,
+                                                         GCancellable           *cancellable,
+                                                         GError                **error);

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -147,7 +147,7 @@ def get_mock_iface(bus: dbus.Bus, bus_name: Optional[str] = None) -> dbus.Interf
     return dbus.Interface(obj, dbusmock.MOCK_IFACE)
 
 
-def portal_interface_name(portal_name, domain: Optional[str] = None) -> str:
+def portal_interface_name(portal_name: str, domain: Optional[str] = None) -> str:
     """
     Returns the fully qualified interface for a portal name.
     """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -147,18 +147,23 @@ def get_mock_iface(bus: dbus.Bus, bus_name: Optional[str] = None) -> dbus.Interf
     return dbus.Interface(obj, dbusmock.MOCK_IFACE)
 
 
-def portal_interface_name(portal_name) -> str:
+def portal_interface_name(portal_name, domain: Optional[str] = None) -> str:
     """
     Returns the fully qualified interface for a portal name.
     """
-    return f"org.freedesktop.portal.{portal_name}"
+    if domain:
+        return f"org.freedesktop.{domain}.portal.{portal_name}"
+    else:
+        return f"org.freedesktop.portal.{portal_name}"
 
 
-def get_portal_iface(bus: dbus.Bus, name: str) -> dbus.Interface:
+def get_portal_iface(
+    bus: dbus.Bus, name: str, domain: Optional[str] = None
+) -> dbus.Interface:
     """
     Returns the dbus interface for a portal name.
     """
-    name = portal_interface_name(name)
+    name = portal_interface_name(name, domain)
     return get_iface(bus, name)
 
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -312,6 +312,7 @@ if enable_pytest
     'test_openuri.py',
     'test_permission_store.py',
     'test_print.py',
+    'test_registry.py',
     'test_remotedesktop.py',
     'test_settings.py',
     'test_screenshot.py',

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -142,9 +142,11 @@ class ImplSession:
         mock: dbusmock.DBusMockObject,
         busname: str,
         handle: str,
+        app_id: str,
     ):
         self.mock = mock  # the main mock object
         self.handle = handle
+        self.app_id = app_id
         self.closed = False
         self._close_callback: Optional[Callable] = None
 

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -49,7 +49,7 @@ def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_
     try:
         logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
 
-        session = ImplSession(self, BUS_NAME, session_handle).export()
+        session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
         self.sessions[session_handle] = session
 
         response = Response(self.response, {"session_handle": session.handle})

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -116,7 +116,7 @@ def CreateMonitor(self, handle, session_handle, app_id, window, cb_success, cb_e
     try:
         logger.debug(f"CreateMonitor({handle}, {session_handle}, {app_id}, {window})")
 
-        session = ImplSession(self, BUS_NAME, session_handle).export()
+        session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
         self.sessions[session_handle] = session
 
         def closed_callback():

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -52,7 +52,7 @@ def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_
     try:
         logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
 
-        session = ImplSession(self, BUS_NAME, session_handle).export()
+        session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
         self.sessions[session_handle] = session
 
         response = Response(self.response, {"session_handle": session.handle})

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -3,6 +3,7 @@
 # This file is formatted with Python Black
 
 from tests.templates import Response, init_logger, ImplRequest, ImplSession
+from dbusmock import MOCK_IFACE
 import dbus
 import dbus.service
 import socket
@@ -183,3 +184,11 @@ def ConnectToEIS(self, session_handle, app_id, options):
     except Exception as e:
         logger.critical(e)
         raise e
+
+
+@dbus.service.method(MOCK_IFACE, in_signature="s", out_signature="s")
+def GetSessionAppId(self, session_handle):
+    logger.debug(f"GetSessionAppId({session_handle})")
+
+    assert session_handle in self.sessions
+    return self.sessions[session_handle].app_id

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -38,10 +38,7 @@ class TestRegistry:
         request = xdp.Request(dbus_con, remotedesktop_intf)
 
         session_counter_attr_name = "session_counter"
-        if hasattr(self, session_counter_attr_name):
-            session_counter = getattr(self, session_counter_attr_name)
-        else:
-            session_counter = 0
+        session_counter = getattr(self, session_counter_attr_name, 0)
         setattr(self, session_counter_attr_name, session_counter + 1)
 
         options = {

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -128,3 +128,18 @@ class TestRegistry:
         app_id3 = mock_intf3.GetSessionAppId(session3.handle)
         assert app_id3 == expected_app_id
         dbus_con3.close()
+
+    def test_no_reregister(self, portals, dbus_con):
+        registry_intf = xdp.get_portal_iface(dbus_con, "Registry", domain="host")
+        mock_intf = xdp.get_mock_iface(dbus_con)
+
+        expected_app_id = "org.example.CorrectAppId"
+
+        registry_intf.Register(expected_app_id, {})
+        session = self.create_dummy_session(dbus_con)
+        app_id = mock_intf.GetSessionAppId(session.handle)
+        assert app_id == expected_app_id
+
+        with pytest.raises(dbus.exceptions.DBusException) as exc_info:
+            registry_intf.Register(expected_app_id, {})
+        exc_info.match(".*Connection already associated with an application ID.*")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -44,7 +44,6 @@ class TestRegistry:
             session_counter = 0
         setattr(self, session_counter_attr_name, session_counter + 1)
 
-        print(f"session_handle_token: {session_counter}")
         options = {
             "session_handle_token": f"session_token{session_counter}",
         }

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import tests as xdp
+
+import dbus
+import pytest
+
+
+@pytest.fixture
+def app_id():
+    return "org.example.WrongAppId"
+
+
+@pytest.fixture
+def required_templates():
+    return {"remotedesktop": {}}
+
+
+class TestRegistry:
+    def test_version(self, portals, dbus_con):
+        documents = dbus_con.get_object(
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+        )
+
+        properties_intf = dbus.Interface(
+            documents,
+            "org.freedesktop.DBus.Properties",
+        )
+        portal_version = properties_intf.Get(
+            "org.freedesktop.host.portal.Registry",
+            "version",
+        )
+        assert int(portal_version) == 1
+
+    def create_dummy_session(self, dbus_con):
+        remotedesktop_intf = xdp.get_portal_iface(dbus_con, "RemoteDesktop")
+        request = xdp.Request(dbus_con, remotedesktop_intf)
+
+        session_counter_attr_name = "session_counter"
+        if hasattr(self, session_counter_attr_name):
+            session_counter = getattr(self, session_counter_attr_name)
+        else:
+            session_counter = 0
+        setattr(self, session_counter_attr_name, session_counter + 1)
+
+        print(f"session_handle_token: {session_counter}")
+        options = {
+            "session_handle_token": f"session_token{session_counter}",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+        assert response.response == 0
+
+        return xdp.Session.from_response(dbus_con, response)
+
+    def test_registerless(self, portals, dbus_con, app_id):
+        mock_intf = xdp.get_mock_iface(dbus_con)
+
+        expected_app_id = app_id
+
+        session = self.create_dummy_session(dbus_con)
+
+        app_id = mock_intf.GetSessionAppId(session.handle)
+        assert app_id == expected_app_id
+
+    def test_register(self, portals, dbus_con):
+        registry_intf = xdp.get_portal_iface(dbus_con, "Registry", domain="host")
+        mock_intf = xdp.get_mock_iface(dbus_con)
+
+        expected_app_id = "org.example.CorrectAppId"
+        registry_intf.Register(expected_app_id, {})
+
+        session = self.create_dummy_session(dbus_con)
+
+        app_id = mock_intf.GetSessionAppId(session.handle)
+        assert app_id == expected_app_id
+
+    def test_late_register(self, portals, dbus_con, app_id):
+        registry_intf = xdp.get_portal_iface(dbus_con, "Registry", domain="host")
+        mock_intf = xdp.get_mock_iface(dbus_con)
+
+        expected_app_id = app_id
+        unexpected_app_id = "org.example.CorrectAppId"
+
+        session = self.create_dummy_session(dbus_con)
+
+        app_id = mock_intf.GetSessionAppId(session.handle)
+        assert app_id == expected_app_id
+
+        with pytest.raises(dbus.exceptions.DBusException) as exc_info:
+            registry_intf.Register(unexpected_app_id, {})
+        exc_info.match(".*Connection already associated with an application ID.*")
+
+        new_session = self.create_dummy_session(dbus_con)
+
+        new_app_id = mock_intf.GetSessionAppId(new_session.handle)
+        assert new_app_id == expected_app_id


### PR DESCRIPTION
For host apps, we currently require applications to run inside a cgroup with a name that allows xdg-desktop-portal to derive an application ID from it. This does not work reliably, and while the situation can improve, it's unlikely to ever be fool proof, as it in theory requires every potential piece of software that launches other applications to know how to launch it in a compatible way.

Cgroups is also a Linux specific API, which is problematic from a *nix wide portability perspective.

To address this, introduce a host-only portal API that allows applications to register their D-Bus connections, associating them with an application ID. This moves back the burden of associating an application with an application ID back to the application itself, instead of the application launcher.

Applications calling this overrides any applicion ID derived from the name fo the cgroup the application runs inside.


------

I'm not saying we should do this, but perhaps it is something we should consider doing. Relying only on cgroups is a noble idea, but it hasn't worked well so far, and while it's possible that at least a majority of cases can be handled by peeking at it and deriving the application ID, it's also likely that there will always be cases where it won't work, without any way for applications to get themselves to work.

Some downsides include:

 * Giving up on the idea to always have *host* apps run in a properly named cgroup, at least for any portal purposes. It's a good end goal in itself, but hard to say how reliable it can ever be.
 * Yet again more than one way to get the same piece of information, as in we're creating another mess for ourself.

Some upsides:

 * Applications can now fix themselves. They can't realistically do that by relying on cgroups.
 * Not Linux specific. While sandbox engines probably are, it's a good end goal to have portal API's be as widely adopted as possible.