### PR TITLE
test: Depend on a recent enough version of libportal

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -120,7 +120,7 @@ geoclue_dep = dependency(
 )
 libportal_dep = dependency(
   'libportal',
-  version: '>= 0.8.1',
+  version: '>= 0.9.0',
   required: get_option('libportal'),
   fallback: ['libportal', 'libportal_dep'],
   default_options: [


### PR DESCRIPTION
Without this the build fail if you have libportal 0.8.1 installed

This is needed for the notification work.