### PR TITLE
settings: Add cursor-theme and cursor-theme-size

### DIFF
--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -62,6 +62,14 @@
 
       Unknown values should be treated as ``0`` (no preference).
 
+    * ``org.freedesktop.appearance``  ``cursor-theme`` (``s``)
+
+      Indicates the system's preferred cursor theme.
+
+    * ``org.freedesktop.appearance``  ``cursor-theme-size`` (``u``)
+
+      Indicates the system's preferred cursor theme size.
+
     This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Settings">


### PR DESCRIPTION
These aim to provide cursor theming settings that isn't to a desktop environment or toolkit.