### PR TITLE
ci: Set XDP_TEST_IN_CI in the release workflow too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     container:
       image: ${{ needs.build-container.outputs.image }}
       options: ${{ needs.build-container.outputs.image_options }}
+      env:
+        XDP_TEST_IN_CI: 1
 
     steps:
       - name: Configure git user


### PR DESCRIPTION
So we can run the release action and skip the USB test, which is known to be failing only on CI.