### PR TITLE
build/tests: Check for python found and version in single require call

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -284,8 +284,7 @@ python = pymod.find_installation(
 
 enable_pytest = get_option('pytest') \
   .require(pytest.found()) \
-  .require(python.found()) \
-  .require(python.language_version().version_compare('>=3.9'),
+  .require(python.found() and python.language_version().version_compare('>=3.9'),
            error_message: 'Python version >=3.9 is required') \
   .require(umockdev_dep.found()) \
   .require(have_wav_parse,


### PR DESCRIPTION
We can only use the python object if it was found and the arguments for require are all evaluated, even if the resulting feature is disabled.

Fixes: 1c6dd182 ("tests: Check for required WAV decoder for notification tests")
Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1547