### PR TITLE
tests: disable only sound-related notification tests if without wavparse

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -144,6 +144,9 @@ if gst_inspect.found()
 else
   have_wav_parse = false
 endif
+if have_wav_parse
+  config_h.set('HAVE_WAV_PARSE', 1)
+endif
 
 bwrap = find_program('bwrap', required: get_option('sandboxed-image-validation').allowed() or get_option('sandboxed-sound-validation').allowed())
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -101,18 +101,13 @@ if have_libportal
     'email.c',
     'filechooser.c',
     'inhibit.c',
+    'notification.c',
     'openuri.c',
     'print.c',
     'screenshot.c',
     'trash.c',
     'wallpaper.c',
     'glib-backports.c',
-  )
-endif
-
-if have_wav_parse
-  portals_test_sources += files(
-    'notification.c',
   )
 endif
 

--- a/tests/notification.c
+++ b/tests/notification.c
@@ -441,6 +441,11 @@ test_sound (const char *serialized_sound,
 static void
 test_file_sound (void)
 {
+#ifndef HAVE_WAV_PARSE
+  g_test_skip("wavparse isn't available");
+  return;
+#endif
+
   g_autoptr(GError) error = NULL;
   g_autofree char *uri = NULL;
   g_autofree char *serialized_sound_s = NULL;


### PR DESCRIPTION
Only sound-related tests require gstreamer wavparse plugin for validation, so it's okay to disable test_notification_sound but keep other notification tests.

This also fixes link failures when wavparse isn't available: we previously excluded notification.c from the source list in the missing case, but still used test_notification_* symbols in test-portals.c.

Fixes: 1c6dd18 ("tests: Check for required WAV decoder for notification tests")