### PR TITLE
tests: Set XDG_DATA_DIRS for as-installed testing

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -351,7 +351,9 @@ if enable_installed_tests
   ]
   foreach tf : testfiles
       data = configuration_data()
+      data.set('datadir', datadir)
       data.set('installed_testdir', installed_tests_dir)
+      data.set('installed_tests_data_dir', installed_tests_data_dir)
       data.set('libdir', libdir)
       data.set('exec', tf)
       configure_file(
@@ -365,7 +367,9 @@ if enable_installed_tests
 
   foreach p : portal_tests
       data = configuration_data()
+      data.set('datadir', datadir)
       data.set('installed_testdir', installed_tests_dir)
+      data.set('installed_tests_data_dir', installed_tests_data_dir)
       data.set('libdir', libdir)
       data.set('exec', 'test-portals -p /portal/@0@'.format(p))
       configure_file(
@@ -379,7 +383,9 @@ if enable_installed_tests
 
   foreach p : portal_limited
       data = configuration_data()
+      data.set('datadir', datadir)
       data.set('installed_testdir', installed_tests_dir)
+      data.set('installed_tests_data_dir', installed_tests_data_dir)
       data.set('libdir', libdir)
       data.set('exec', 'limited-portals -p /limited/@0@'.format(p))
       configure_file(

--- a/tests/template.test.in
+++ b/tests/template.test.in
@@ -1,4 +1,4 @@
 [Test]
 Type=session
-Exec=env LSAN_OPTIONS=exitcode=0 LD_LIBRARY_PATH=@libdir@:$LD_LIBRARY_PATH @installed_testdir@/@exec@ --tap
+Exec=env LSAN_OPTIONS=exitcode=0 LD_LIBRARY_PATH=@libdir@:$LD_LIBRARY_PATH XDG_DATA_DIRS=@installed_tests_data_dir@/share:@datadir@:/usr/local/share:/usr/share @installed_testdir@/@exec@ --tap
 Output=TAP


### PR DESCRIPTION
* tests: Set XDG_DATA_DIRS for as-installed testing
    
    test-portals-openuri.test will fail if it can't find furrfix.desktop
    (a mockup of Firefox) in the search path.
    
    We also need to make sure the build-time datadir and the default data
    directories /usr/local/share and /usr/share are still in the search path,
    for GSettings schemas.