### PR TITLE
XdpAppInfo: set missing is_valid_sub_app_id in class_init

### DIFF
--- a/src/xdp-app-info-flatpak.c
+++ b/src/xdp-app-info-flatpak.c
@@ -509,6 +509,8 @@ xdp_app_info_flatpak_class_init (XdpAppInfoFlatpakClass *klass)
     xdp_app_info_flatpak_validate_autostart;
   app_info_class->validate_dynamic_launcher =
     xdp_app_info_flatpak_validate_dynamic_launcher;
+  app_info_class->is_valid_sub_app_id =
+    xdp_app_info_flatpak_is_valid_sub_app_id;
 }
 
 static void

--- a/src/xdp-app-info-host.c
+++ b/src/xdp-app-info-host.c
@@ -93,6 +93,8 @@ xdp_app_info_host_class_init (XdpAppInfoHostClass *klass)
     xdp_app_info_host_validate_autostart;
   app_info_class->validate_dynamic_launcher =
     xdp_app_info_host_validate_dynamic_launcher;
+  app_info_class->is_valid_sub_app_id =
+    xdp_app_info_host_is_valid_sub_app_id;
 }
 
 static void


### PR DESCRIPTION
The dynamic launcher portal is broken in postmarketOS v24.12. Seems the `xdp_app_info_flatpak_is_valid_sub_app_id()` and `xdp_app_info_host_is_valid_sub_app_id()` were forgotten to be added to the `class_init()` functions.