### PR TITLE
Wait for debugger

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1719,6 +1719,21 @@ main (int    argc,
   g_autoptr(GOptionContext) context = NULL;
   GDBusMethodInvocation *invocation;
 
+  if (g_getenv ("XDG_DOCUMENT_PORTAL_WAIT_FOR_DEBUGGER") != NULL)
+    {
+      g_printerr ("document portal (PID %d) is waiting for a debugger. "
+                  "Use `gdb -p %d` to connect. \n",
+                  getpid (), getpid ());
+
+      if (raise (SIGSTOP) == -1)
+        {
+          g_printerr ("Failed waiting for debugger\n");
+          exit (1);
+        }
+
+      raise (SIGCONT);
+    }
+
   g_log_writer_default_set_use_stderr (TRUE);
 
   setlocale (LC_ALL, "");

--- a/document-portal/permission-store.c
+++ b/document-portal/permission-store.c
@@ -92,6 +92,21 @@ main (int    argc,
   GOptionContext *context;
   g_autoptr(GError) error = NULL;
 
+  if (g_getenv ("XDG_PERMISSION_STORE_WAIT_FOR_DEBUGGER") != NULL)
+    {
+      g_printerr ("\npermission store (PID %d) is waiting for a debugger. "
+                  "Use `gdb -p %d` to connect. \n",
+                  getpid (), getpid ());
+
+      if (raise (SIGSTOP) == -1)
+        {
+          g_printerr ("Failed waiting for debugger\n");
+          exit (1);
+        }
+
+      raise (SIGCONT);
+    }
+
   g_log_writer_default_set_use_stderr (TRUE);
 
   setlocale (LC_ALL, "");

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -443,6 +443,21 @@ main (int argc, char *argv[])
   g_autoptr(GSource) signal_handler_source = NULL;
   g_autoptr(GOptionContext) context = NULL;
 
+  if (g_getenv ("XDG_DESKTOP_PORTAL_WAIT_FOR_DEBUGGER") != NULL)
+    {
+      g_printerr ("\ndesktop portal (PID %d) is waiting for a debugger. "
+                  "Use `gdb -p %d` to connect. \n",
+                  getpid (), getpid ());
+
+      if (raise (SIGSTOP) == -1)
+        {
+          g_printerr ("Failed waiting for debugger\n");
+          exit (1);
+        }
+
+      raise (SIGCONT);
+    }
+
   setlocale (LC_ALL, "");
   bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,17 @@ harness behaves.
 Some optional environment variables that can be set to help with debugging.
 
 * `XDP_DBUS_MONITOR`: If set, starts dbus-monitor on the test dbus server
+
 * `XDP_DBUS_TIMEOUT`: Maximum timeout for dbus calls in ms (default: 5s)
+
+* `XDG_DESKTOP_PORTAL_WAIT_FOR_DEBUGGER`: Makes xdg-desktop-portal wait for
+    a debugger to attach by raising SIGSTOP
+
+* `XDG_DOCUMENT_PORTAL_WAIT_FOR_DEBUGGER`: Makes xdg-document-portal wait
+    for a debugger to attach by raising SIGSTOP
+
+* `XDG_PERMISSION_STORE_WAIT_FOR_DEBUGGER`: Makes xdg-permission-store wait
+    for a debugger to attach by raising SIGSTOP
 
 Internal environment variables the tests use via pytest fixtures to set up the
 environment they need.


### PR DESCRIPTION
This is especially useful when the binaries are run as part of a test and getting the debugger to the right place takes a bit of effort.

Without the `raise (SIGCONT);` I get into a loop of SIGSTOPs in gdb and I don't understand why.