### PR TITLE
Try harder to find the host path for the documents

### DIFF
--- a/src/xdp-documents.h
+++ b/src/xdp-documents.h
@@ -44,3 +44,5 @@ char *xdp_get_real_path_for_doc_path (const char *path,
                                       XdpAppInfo *app_info);
 
 char *xdp_get_real_path_for_doc_id (const char *doc_id);
+
+char * xdp_resolve_document_portal_path (const char *path);


### PR DESCRIPTION
When the access to the directory is provided by the portal (like browser download directory) the stored files in the directory are not found by xdp_get_real_path_for_doc_path and /run/user/... path is opened instead of host path by the OpenFile or OpenDirectory portal.