### PR TITLE
tests/run-test.sh: Add new tool to simplify running tests

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -65,14 +65,12 @@ test(
   protocol: test_protocol,
 )
 
+run_test = find_program('run-test.sh')
+
 pytest_args = ['--verbose', '--log-level=DEBUG']
 
 pytest_env = environment()
-pytest_env.set('XDG_DESKTOP_PORTAL_PATH', xdg_desktop_portal.full_path())
-pytest_env.set('XDG_PERMISSION_STORE_PATH', xdg_permission_store.full_path())
-pytest_env.set('XDG_DOCUMENT_PORTAL_PATH', xdg_document_portal.full_path())
-pytest_env.set('XDP_VALIDATE_ICON', xdp_validate_icon.full_path())
-pytest_env.set('XDP_VALIDATE_SOUND', xdp_validate_sound.full_path())
+pytest_env.set('BUILDDIR', meson.project_build_root())
 
 # pytest xdist is nice because it significantly speeds up our
 # test process, but it's not required
@@ -137,7 +135,7 @@ foreach pytest_file : pytest_files
   testname = pytest_file.replace('.py', '').replace('test_', '')
   test(
     'integration/@0@'.format(testname),
-    pytest,
+    run_test,
     args: [meson.current_source_dir() / pytest_file] + pytest_args,
     env: pytest_env,
     suite: ['integration'],

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# - Runs pytest with the required environment to run tests on an x-d-p build
+# - By default, the tests run on the first x-d-p build directory that is found
+#   inside the source tree
+# - The BUILDDIR environment variable can be set to a specific x-d-p build
+#   directory
+# - All arguments are passed along to pytest
+# - Check tests/README.md for useful environment variables
+#
+# Examples:
+#
+#   ./run-test.sh ./test_camera.py -k test_version -v -s
+#
+#   BUILDDIR=../_build ./run-test.sh ./test_usb.py
+#
+
+set -euo pipefail
+
+function fail()
+{
+  sed -n '/^#$/,/^$/p' ${BASH_SOURCE[0]}
+  echo $1
+  exit 1
+}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+BUILDDIR=${BUILDDIR:-$(find "${SCRIPT_DIR}/.." -maxdepth 2 -name 'build.ninja' -printf "%h\n" -quit)}
+
+[ ! -f "${BUILDDIR}/build.ninja" ] && fail "Path '${BUILDDIR}' does not appear to be a build dir"
+
+echo "Running tests on build dir: $(readlink -f "${BUILDDIR}")"
+echo ""
+
+export XDP_VALIDATE_SOUND=$BUILDDIR/src/xdg-desktop-portal-validate-sound
+export XDP_VALIDATE_ICON=$BUILDDIR/src/xdg-desktop-portal-validate-icon
+export XDG_DESKTOP_PORTAL_PATH=$BUILDDIR/src/xdg-desktop-portal
+export XDG_DOCUMENT_PORTAL_PATH=$BUILDDIR/document-portal/xdg-document-portal
+export XDG_PERMISSION_STORE_PATH=$BUILDDIR/document-portal/xdg-permission-store
+
+exec pytest-3 $@


### PR DESCRIPTION
Running the tests outside of meson gives more control but also requires setting up a bunch of environment variables. The new script sets everything up automatically if the standard build directory is used.