### PR TITLE
tests: Translate pytest exit status to Meson/ginsttest-runner convention

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -278,7 +278,8 @@ enable_pytest = get_option('pytest') \
   .allowed()
 
 if enable_pytest
-  pytest_args = [meson.current_source_dir(), '--verbose', '--log-level=DEBUG']
+  pytest_wrapper = find_program('pytest-wrapper.sh')
+  pytest_args = [pytest.full_path(), meson.current_source_dir(), '--verbose', '--log-level=DEBUG']
 
   pytest_env = environment()
   pytest_env.set('XDG_DESKTOP_PORTAL_PATH', xdg_desktop_portal.full_path())
@@ -322,7 +323,7 @@ if enable_pytest
     testname = pytest_file.replace('.py', '')
     test(
       'pytest/@0@'.format(testname),
-      pytest,
+      pytest_wrapper,
       args: pytest_args + ['-k', testname],
       env: pytest_env,
       suite: ['pytest'],

--- a/tests/pytest-wrapper.sh
+++ b/tests/pytest-wrapper.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Copyright 2025 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+set -eu
+e=0
+"$@" || e="$?"
+
+if [ "$e" = 5 ]; then
+    # pytest exits with status 5 if all tests were skipped.
+    # Meson and ginsttest-runner expect tests to exit with status 77 in
+    # this situation, like Automake
+    exit 77
+fi
+
+exit "$e"


### PR DESCRIPTION
Resolves: https://github.com/flatpak/xdg-desktop-portal/issues/1575

---

This is a pretty crude way to remap the exit status, but it's better than nothing.

#1525 is probably going to need something a lot like this too.