### PR TITLE
tests: Translate pytest exit status to Meson/ginsttest-runner convention [pytest approach]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,13 @@ def pytest_configure() -> None:
     ensure_umockdev_loaded()
 
 
+def pytest_sessionfinish(session, exitstatus):
+    # Meson and ginsttest-runner expect tests to exit with status 77 if all
+    # tests were skipped
+    if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
+        session.exitstatus = 77
+
+
 def ensure_environment_set() -> None:
     env_vars = [
         "XDG_DESKTOP_PORTAL_PATH",


### PR DESCRIPTION
Alternative to https://github.com/flatpak/xdg-desktop-portal/pull/1577 which implements it directly in the pytest conftest which should work transparently for build and installed tests.

/cc @smcv 