### PR TITLE
tests/py: Remove pytest.ini

### DIFF
--- a/tests/.pytest.ini
+++ b/tests/.pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --ignore-glob=meson-logs


### PR DESCRIPTION
It was originally added in 8100fc4b to prevent the meson logs getting picked up by pytest.

The pytests are now being run from the source tree instead of the build dir so it is safe to remove the filen.