### PR TITLE
settings: Add animation-scale, status-shapes, and always-show-scrollbars keys

### DIFF
--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -58,6 +58,27 @@
 
       Unknown values should be treated as 0 (no preference).
 
+    * ``org.freedesktop.appearance`` ``animation-scale`` (``d``)
+
+      Indicates whether the system prefers an interface that removes, 
+      speeds up, slows down, or replaces non-essential animations.
+      Supported values are:
+
+      - ``0.0``: All non-essential animations disabled
+      - ``1.0``: All non-essential animations enabled
+
+      Unknown values should be treated as 1.0 (all non-essential animations enabled).
+
+    * ``org.freedesktop.appearance`` ``status-shapes`` (``b``)
+
+      Indicates whether the system prefers an interface that uses shapes
+      to indicate status in addition to or instead of color. 
+
+    * ``org.freedesktop.appearance`` ``always-show-scrollbars`` (``b``)
+
+      Indicates whether the system prefers an interface where scrollbars
+      are always visible. 
+
     Implementations can provide other keys; they are entirely
     implementation details that are undocumented. If you are a
     toolkit and want to use this please open an issue.

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -62,7 +62,28 @@
 
       Unknown values should be treated as ``0`` (no preference).
 
-    This documentation describes version 2 of this interface.
+    * ``org.freedesktop.appearance`` ``animation-scale`` (``d``)
+
+      Indicates whether the system prefers an interface that removes, 
+      speeds up, slows down, or replaces non-essential animations.
+      Supported values are:
+
+      - ``0.0``: All non-essential animations disabled
+      - ``1.0``: All non-essential animations enabled
+
+      Unknown values should be treated as 1.0 (all non-essential animations enabled).
+
+    * ``org.freedesktop.appearance`` ``status-shapes`` (``b``)
+
+      Indicates whether the system prefers an interface that uses shapes
+      to indicate status in addition to or instead of color. 
+
+    * ``org.freedesktop.appearance`` ``always-show-scrollbars`` (``b``)
+
+      Indicates whether the system prefers an interface where scrollbars
+      are always visible. 
+
+    This documentation describes version 3 of this interface.
   -->
   <interface name="org.freedesktop.portal.Settings">
 


### PR DESCRIPTION
This allows applications to follow more accessibility preferences across different desktops, without relying on keys under the org.gnome namespace. See the descriptions of the keys themselves for more details.

Client implementations:

- [ ] GTK
- [ ] QT

Portal implementations: 
- [x] GTK: https://github.com/flatpak/xdg-desktop-portal-gtk/pull/510
- [ ] GNOME
- [ ] KDE
- [ ] Cosmic
- [ ] Pantheon

Ack on Budgie, from @serebit 