### PR TITLE
Tests logging

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,7 +26,25 @@ _counter = count()
 
 ASV = Dict[str, Any]
 
-logger = logging.getLogger("tests")
+
+def init_logger(name: str):
+    """
+    Common logging setup for tests. Use as:
+
+        >>> import tests as xdp
+        >>> logger = xdp.init_logger(__name__)
+        >>> logger.debug("foo")
+
+    """
+    logging.basicConfig(
+        format="%(levelname).1s|%(name)s: %(message)s", level=logging.DEBUG
+    )
+    logger = logging.getLogger(f"xdp.{name}")
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+logger = init_logger("utils")
 
 
 def is_in_ci() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ import os
 import sys
 import tempfile
 import subprocess
-import fcntl
 import time
 import signal
 from pathlib import Path
@@ -258,11 +257,9 @@ def _get_server_for_module(
             "/dbusmock",
             dbusmock.OBJECT_MANAGER_IFACE,
             bustype,
-            stdout=subprocess.PIPE,
+            stdout=None,
+            stderr=None,
         )
-
-        flags = fcntl.fcntl(server.process.stdout, fcntl.F_GETFL)
-        fcntl.fcntl(server.process.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
         busses[bustype][module.BUS_NAME] = server
         return server
@@ -288,11 +285,6 @@ def _get_main_obj_for_module(
 
 
 def _terminate_mock_p(process: subprocess.Popen) -> None:
-    if process.stdout:
-        out = (process.stdout.read() or b"").decode("utf-8")
-        if out:
-            print(out)
-        process.stdout.close()
     process.terminate()
     process.wait()
 

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -8,12 +8,12 @@ import dbusmock
 import logging
 
 
-def init_template_logger(name: str):
+def init_logger(name: str):
     """
     Common logging setup for the impl.portal templates. Use as:
 
-        >>> from tests.templates import init_template_logger
-        >>> logger = init_template_logger(__name__)
+        >>> from tests.templates import init_logger
+        >>> logger = init_logger(__name__)
         >>> logger.debug("foo")
 
     """
@@ -25,7 +25,7 @@ def init_template_logger(name: str):
     return logger
 
 
-logger = init_template_logger("request")
+logger = init_logger("request")
 
 
 class Response(NamedTuple):

--- a/tests/templates/access.py
+++ b/tests/templates/access.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
 from gi.repository import GLib
@@ -14,7 +14,7 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Access"
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/account.py
+++ b/tests/templates/account.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 import dbus.service
 import dbus
 from gi.repository import GLib
@@ -12,7 +12,7 @@ MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Account"
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/appchooser.py
+++ b/tests/templates/appchooser.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
 from gi.repository import GLib
@@ -15,7 +15,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.AppChooser"
 VERSION = 2
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/background.py
+++ b/tests/templates/background.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import init_template_logger
+from tests.templates import init_logger
 import dbus.service
 import dbus
 from gi.repository import GLib
@@ -13,7 +13,7 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Background"
 VERSION = 1
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/clipboard.py
+++ b/tests/templates/clipboard.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import init_template_logger
+from tests.templates import init_logger
 import dbus.service
 import dbus
 import tempfile
@@ -15,7 +15,7 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Clipboard"
 VERSION = 1
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/email.py
+++ b/tests/templates/email.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 import dbus.service
 
 from gi.repository import GLib
@@ -15,7 +15,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Email"
 VERSION = 3
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/filechooser.py
+++ b/tests/templates/filechooser.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
 from gi.repository import GLib
@@ -15,7 +15,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.FileChooser"
 VERSION = 4
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/geoclue2.py
+++ b/tests/templates/geoclue2.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from tests.templates import init_template_logger
+from tests.templates import init_logger
 import dbus.service
 import dbus
 
@@ -15,7 +15,7 @@ MOCK_IFACE = "org.freedesktop.GeoClue2.Mock"
 SYSTEM_BUS = True
 VERSION = 1
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest, ImplSession
+from tests.templates import Response, init_logger, ImplRequest, ImplSession
 import dbus
 import dbus.service
 import time
@@ -18,7 +18,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.GlobalShortcuts"
 VERSION = 1
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest, ImplSession
+from tests.templates import Response, init_logger, ImplRequest, ImplSession
 
 import dbus.service
 from gi.repository import GLib
@@ -23,7 +23,7 @@ class SessionState(Enum):
     ENDING = 3
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/lockdown.py
+++ b/tests/templates/lockdown.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import init_template_logger
+from tests.templates import init_logger
 
 import dbus.service
 
@@ -13,7 +13,7 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Lockdown"
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/notification.py
+++ b/tests/templates/notification.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import init_template_logger
+from tests.templates import init_logger
 
 import dbus.service
 from dbusmock import MOCK_IFACE
@@ -15,7 +15,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Notification"
 VERSION = 2
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/print.py
+++ b/tests/templates/print.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
 from gi.repository import GLib
@@ -15,7 +15,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Print"
 VERSION = 3
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest, ImplSession
+from tests.templates import Response, init_logger, ImplRequest, ImplSession
 import dbus
 import dbus.service
 import socket
@@ -17,7 +17,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.RemoteDesktop"
 VERSION = 2
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/screenshot.py
+++ b/tests/templates/screenshot.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
 from gi.repository import GLib
@@ -15,7 +15,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Screenshot"
 VERSION = 2
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/settings.py
+++ b/tests/templates/settings.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import init_template_logger
+from tests.templates import init_logger
 
 import dbus.service
 from dbusmock import MOCK_IFACE
@@ -15,7 +15,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Settings"
 VERSION = 2
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/usb.py
+++ b/tests/templates/usb.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 import dbus
 import dbus.service
 from dbusmock import MOCK_IFACE
@@ -17,7 +17,7 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Usb"
 VERSION = 1
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):

--- a/tests/templates/wallpaper.py
+++ b/tests/templates/wallpaper.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from tests.templates import Response, init_template_logger, ImplRequest
+from tests.templates import Response, init_logger, ImplRequest
 
 import dbus
 import dbus.service
@@ -14,7 +14,7 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Wallpaper"
 
 
-logger = init_template_logger(__name__)
+logger = init_logger(__name__)
 
 
 def load(mock, parameters={}):


### PR DESCRIPTION
Print everything to stdout/stderr. Currently the logging of all the templates never made it to the output of pytest, and the logging in `tests/__init__.py` ends up in a completely different section (the python log capture, instead of the stdout/stderr capture) which makes it hard to tell the order of things.