### PR TITLE
tests/templates: Store config in dataclass

### DIFF
--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -25,7 +25,7 @@ def init_logger(name: str):
     return logger
 
 
-logger = init_logger("request")
+logger = init_logger("utils")
 
 
 class Response(NamedTuple):

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -3,6 +3,7 @@
 # This file is formatted with Python Black
 
 from typing import Callable, Dict, Optional, NamedTuple
+from gi.repository import GLib
 import dbus
 import dbusmock
 import logging
@@ -35,62 +36,103 @@ class Response(NamedTuple):
 
 class ImplRequest:
     """
-    Implementation of a org.freedesktop.impl.portal.Request object. Typically
-    this object needs to be merely exported:
+    Implementation of a ``org.freedesktop.impl.portal.Request`` object exposed
+    on the object path ``handle``.
 
-        >>> r = ImplRequest(mock, "org.freedesktop.impl.portal.Test", handle)
-        >>> r.export()
+    The dbus method implementations need to be invoked asynchronously and the
+    async callbacks must be passed in ``cb_success`` and ``cb_error``.
 
-    Where the test or the backend implementation relies on the Closed() method
-    of the ImplRequest, provide a callback to be invoked.
-
-        >>> r.export(close_callback=my_callback)
-
-    Note that the latter only works if the test invokes methods
-    asynchronously.
-
-    .. attribute:: closed
-
-        Set to True if the Close() method on the Request was invoked
-
+    The request either waits until it is closed by x-d-p (``wait_for_close``) or
+    responds to the request (``respond``).
     """
 
-    def __init__(self, mock: "dbusmock.DBusMockObject", busname: str, handle: str):
+    def __init__(
+        self,
+        mock: "dbusmock.DBusMockObject",
+        busname: str,
+        handle: str,
+        logger,
+        cb_success,
+        cb_error,
+    ):
         self.mock = mock
-        self.handle = handle
-        self.closed = False
-        self._close_callback: Optional[Callable] = None
-
         bus = mock.connection
         proxy = bus.get_object(busname, handle)
-        mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
+        self.mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
+        self.handle = handle
+        self.logger = logger
+        self.cb_success = cb_success
+        self.cb_error = cb_error
 
-        # Register for the Close() call on the impl.Request. If it gets
-        # called, use the side-channel RequestClosed signal so we can notify
-        # the test that the impl.Request was actually closed by the
-        # xdg-desktop-portal
+    def respond(self, response, delay=0, done_cb=None):
+        def reply():
+            nonlocal response
+            logger.debug(f"Request {self.handle}: trying to reply")
+            if callable(response):
+                try:
+                    response = response()
+                except Exception as e:
+                    logger.critical(
+                        f"Request {self.handle}: failed getting response: {e}"
+                    )
+                    self.cb_error(e)
+                    self._unexport()
+                    return
+
+            assert response
+            logger.debug(f"Request {self.handle}: replying {response}")
+
+            self.cb_success(response.response, response.results)
+            self._unexport()
+
+            if done_cb:
+                done_cb()
+
+        self._export()
+
+        if delay > 0:
+            logger.debug(f"Request {self.handle}: scheduling delay of {delay}ms")
+            GLib.timeout_add(delay, reply)
+        else:
+            reply()
+
+    def wait_for_close(self, close_callback=None):
+        def closed():
+            logger.debug(f"Request {self.handle}: closed")
+
+            self.mock.EmitSignal(
+                "org.freedesktop.impl.portal.Mock",
+                "RequestClosed",
+                "s",
+                (self.handle,),
+            )
+
+            if close_callback:
+                try:
+                    close_callback()
+                except Exception as e:
+                    logger.critical(f"Request {self.handle}: failed running close: {e}")
+                    self.cb_error(e)
+                    self._unexport()
+                    return
+
+            response = Response(2, {})
+            self.cb_success(response.response, response.results)
+            self._unexport()
+
         def cb_methodcall(name, args):
             if name == "Close":
-                self.closed = True
-                logger.debug(f"Close() on {self}")
-                if self._close_callback:
-                    self._close_callback()
-                self.mock.EmitSignal(
-                    "org.freedesktop.impl.portal.Mock",
-                    "RequestClosed",
-                    "s",
-                    (self.handle,),
-                )
-                self.mock.RemoveObject(self.handle)
+                closed()
 
-        mock_interface.connect_to_signal("MethodCalled", cb_methodcall)
+        self._export()
 
-    def export(self, close_callback: Optional[Callable] = None):
-        """
-        Create the object on the bus. If close_callback is not None, that
-        callback will be invoked in response to the Close() method called on
-        this object.
-        """
+        logger.debug(f"Request {self.handle}: waiting for x-d-p to call close")
+        self.mock_interface.connect_to_signal("MethodCalled", cb_methodcall)
+
+    def _export(self):
+        # In the future we can pass a class extending
+        # dbusmock.mockobject.DBusMockObject as mock_class to avoid going
+        # through the mock MethodCalled signal
         self.mock.AddObject(
             path=self.handle,
             interface="org.freedesktop.impl.portal.Request",
@@ -104,8 +146,9 @@ class ImplRequest:
                 )
             ],
         )
-        self._close_callback = close_callback
-        return self
+
+    def _unexport(self):
+        self.mock.RemoveObject(self.handle)
 
     def unexport(self):
         self.mock.RemoveObject(self.handle)

--- a/tests/templates/access.py
+++ b/tests/templates/access.py
@@ -5,6 +5,7 @@
 from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -16,12 +17,22 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Access"
 logger = init_logger(__name__)
 
 
+@dataclass
+class AccessParameters:
+    delay: int
+    response: int
+    expect_close: bool
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.expect_close: bool = parameters.get("expect-close", False)
+    assert not hasattr(mock, "access_params")
+    mock.access_params = AccessParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        expect_close=parameters.get("expect-close", False),
+    )
 
 
 @dbus.service.method(
@@ -45,6 +56,7 @@ def AccessDialog(
     logger.debug(
         f"AccessDialog({handle}, {app_id}, {parent_window}, {title}, {subtitle}, {body}, {options})"
     )
+    params = self.access_params
 
     request = ImplRequest(
         self,
@@ -55,7 +67,7 @@ def AccessDialog(
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, {}), delay=self.delay)
+        request.respond(Response(params.response, {}), delay=params.delay)

--- a/tests/templates/appchooser.py
+++ b/tests/templates/appchooser.py
@@ -5,6 +5,7 @@
 from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -17,12 +18,23 @@ VERSION = 2
 logger = init_logger(__name__)
 
 
+@dataclass
+class AppchooserParameters:
+    delay: int
+    response: int
+    expect_close: bool
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.expect_close: bool = parameters.get("expect-close", False)
+    assert not hasattr(mock, "appchooser_params")
+    mock.appchooser_params = AppchooserParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        expect_close=parameters.get("expect-close", False),
+    )
+
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
@@ -45,6 +57,7 @@ def ChooseApplication(
     logger.debug(
         f"ChooseApplication({handle}, {app_id}, {parent_window}, {choices}, {options})"
     )
+    params = self.appchooser_params
 
     request = ImplRequest(
         self,
@@ -55,10 +68,10 @@ def ChooseApplication(
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, {}), delay=self.delay)
+        request.respond(Response(params.response, {}), delay=params.delay)
 
 
 @dbus.service.method(

--- a/tests/templates/background.py
+++ b/tests/templates/background.py
@@ -3,9 +3,12 @@
 # This file is formatted with Python Black
 
 from tests.templates import init_logger
+
 import dbus.service
 import dbus
 from gi.repository import GLib
+from dataclasses import dataclass
+
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
@@ -13,13 +16,22 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Background"
 VERSION = 1
 
+
 logger = init_logger(__name__)
+
+
+@dataclass
+class BackgroundParameters:
+    delay: int
 
 
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
+    assert not hasattr(mock, "background_params")
+    mock.background_params = BackgroundParameters(
+        delay=parameters.get("delay", 200),
+    )
 
 
 @dbus.service.method(
@@ -30,13 +42,14 @@ def load(mock, parameters={}):
 )
 def GetAppState(self, cb_success, cb_error):
     logger.debug("GetAppState()")
+    params = self.background_params
 
     # FIXME: implement?
     def reply():
         cb_success({})
 
-    logger.debug(f"scheduling delay of {self.delay}")
-    GLib.timeout_add(self.delay, reply)
+    logger.debug(f"scheduling delay of {params.delay}")
+    GLib.timeout_add(params.delay, reply)
 
 
 @dbus.service.method(
@@ -47,9 +60,10 @@ def GetAppState(self, cb_success, cb_error):
 )
 def NotifyBackground(self, handle, app_id, name, cb_success, cb_error):
     logger.debug(f"NotifyBackground({handle}, {app_id}, {name})")
+    params = self.background_params
 
-    logger.debug(f"scheduling delay of {self.delay}")
-    GLib.timeout_add(self.delay, cb_success)
+    logger.debug(f"scheduling delay of {params.delay}")
+    GLib.timeout_add(params.delay, cb_success)
 
 
 @dbus.service.method(

--- a/tests/templates/email.py
+++ b/tests/templates/email.py
@@ -5,8 +5,6 @@
 from tests.templates import Response, init_logger, ImplRequest
 import dbus.service
 
-from gi.repository import GLib
-
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
@@ -41,30 +39,18 @@ def load(mock, parameters={}):
     async_callbacks=("cb_success", "cb_error"),
 )
 def ComposeEmail(self, handle, app_id, parent_window, options, cb_success, cb_error):
-    try:
-        logger.debug(f"ComposeEmail({handle}, {app_id}, {parent_window}, {options})")
+    logger.debug(f"ComposeEmail({handle}, {app_id}, {parent_window}, {options})")
 
-        response = Response(self.response, {})
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        request = ImplRequest(self, BUS_NAME, handle)
-
-        if self.expect_close:
-
-            def closed_callback():
-                response = Response(2, {})
-                logger.debug(f"ComposeEmail Close() response {response}")
-                cb_success(response.response, response.results)
-
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            def reply():
-                logger.debug(f"ComposeEmail with response {response}")
-                cb_success(response.response, response.results)
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, {}), delay=self.delay)

--- a/tests/templates/email.py
+++ b/tests/templates/email.py
@@ -3,7 +3,9 @@
 # This file is formatted with Python Black
 
 from tests.templates import Response, init_logger, ImplRequest
+
 import dbus.service
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -16,12 +18,23 @@ VERSION = 3
 logger = init_logger(__name__)
 
 
+@dataclass
+class EmailParameters:
+    delay: int
+    response: int
+    expect_close: bool
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.expect_close: bool = parameters.get("expect-close", False)
+    assert not hasattr(mock, "email_params")
+    mock.email_params = EmailParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        expect_close=parameters.get("expect-close", False),
+    )
+
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
@@ -40,6 +53,7 @@ def load(mock, parameters={}):
 )
 def ComposeEmail(self, handle, app_id, parent_window, options, cb_success, cb_error):
     logger.debug(f"ComposeEmail({handle}, {app_id}, {parent_window}, {options})")
+    params = self.email_params
 
     request = ImplRequest(
         self,
@@ -50,7 +64,7 @@ def ComposeEmail(self, handle, app_id, parent_window, options, cb_success, cb_er
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, {}), delay=self.delay)
+        request.respond(Response(params.response, {}), delay=params.delay)

--- a/tests/templates/filechooser.py
+++ b/tests/templates/filechooser.py
@@ -5,7 +5,6 @@
 from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
-from gi.repository import GLib
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -42,32 +41,21 @@ def load(mock, parameters={}):
     async_callbacks=("cb_success", "cb_error"),
 )
 def OpenFile(self, handle, app_id, parent_window, title, options, cb_success, cb_error):
-    try:
-        logger.debug(
-            f"OpenFile({handle}, {app_id}, {parent_window}, {title}, {options})"
-        )
+    logger.debug(f"OpenFile({handle}, {app_id}, {parent_window}, {title}, {options})")
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"OpenFile Close() response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        def reply_callback():
-            response = Response(self.response, self.results)
-            logger.debug(f"OpenFile with response {response}")
-            cb_success(response.response, response.results)
-
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, self.results), delay=self.delay)
 
 
 @dbus.service.method(
@@ -77,29 +65,18 @@ def OpenFile(self, handle, app_id, parent_window, title, options, cb_success, cb
     async_callbacks=("cb_success", "cb_error"),
 )
 def SaveFile(self, handle, app_id, parent_window, title, options, cb_success, cb_error):
-    try:
-        logger.debug(
-            f"SaveFile({handle}, {app_id}, {parent_window}, {title}, {options})"
-        )
+    logger.debug(f"SaveFile({handle}, {app_id}, {parent_window}, {title}, {options})")
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"SaveFile Close() response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        def reply_callback():
-            response = Response(self.response, self.results)
-            logger.debug(f"SaveFile with response {response}")
-            cb_success(response.response, response.results)
-
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, self.results), delay=self.delay)

--- a/tests/templates/geoclue2.py
+++ b/tests/templates/geoclue2.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from tests.templates import init_logger
+
 import dbus.service
 import dbus
 

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -46,44 +46,29 @@ def load(mock, parameters={}):
     async_callbacks=("cb_success", "cb_error"),
 )
 def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_error):
-    try:
-        logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
+    logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
 
-        session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
-        self.sessions[session_handle] = session
+    session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
+    self.sessions[session_handle] = session
 
-        response = Response(self.response, {"session_handle": session.handle})
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        request = ImplRequest(self, BUS_NAME, handle)
-
-        if self.expect_close:
-
-            def closed_callback():
-                response = Response(2, {})
-                logger.debug(f"CreateSession Close() response {response}")
-                cb_success(response.response, response.results)
-
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            def reply():
-                logger.debug(f"CreateSession with response {response}")
-                cb_success(response.response, response.results)
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply)
-
-            if self.force_close > 0:
-
-                def force_close():
-                    session.close()
-
-                GLib.timeout_add(self.force_close, force_close)
-
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(
+            Response(self.response, {"session_handle": session.handle}),
+            delay=self.delay,
+        )
+        if self.force_close > 0:
+            GLib.timeout_add(self.force_close, session.close)
 
 
 @dbus.service.method(
@@ -102,27 +87,29 @@ def BindShortcuts(
     cb_success,
     cb_error,
 ):
-    try:
-        logger.debug(
-            f"BindShortcuts({handle}, {session_handle}, {shortcuts}, {options})"
-        )
+    logger.debug(f"BindShortcuts({handle}, {session_handle}, {shortcuts}, {options})")
 
-        assert session_handle in self.sessions
-        response = Response(self.response, {})
-        request = ImplRequest(self, BUS_NAME, handle)
-        request.export()
+    assert session_handle in self.sessions
+
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
+
+    if self.expect_close:
+        request.wait_for_close()
+    else:
 
         def reply():
-            logger.debug(f"BindShortcuts with response {response}")
+            logger.debug(f"BindShortcuts with shortcuts {shortcuts}")
             self.sessions[session_handle].shortcuts = shortcuts
-            cb_success(response.response, response.results)
+            return Response(self.response, {})
 
-        logger.debug(f"scheduling delay of {self.delay}")
-        GLib.timeout_add(self.delay, reply)
-
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+        request.respond(reply, delay=self.delay)
 
 
 @dbus.service.method(

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -8,6 +8,7 @@ import dbus.service
 from gi.repository import GLib
 from enum import Enum
 from dbusmock import MOCK_IFACE
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -17,21 +18,32 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Inhibit"
 VERSION = 3
 
 
+logger = init_logger(__name__)
+
+
 class SessionState(Enum):
     RUNNING = 1
     QUERY_END = 2
     ENDING = 3
 
 
-logger = init_logger(__name__)
+@dataclass
+class InhibitParameters:
+    delay: int
+    response: int
+    expect_close: bool
 
 
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.expect_close: bool = parameters.get("expect-close", False)
+    assert not hasattr(mock, "inhibit_params")
+    mock.inhibit_params = InhibitParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        expect_close=parameters.get("expect-close", False),
+    )
+
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
@@ -52,6 +64,7 @@ def load(mock, parameters={}):
 )
 def Inhibit(self, handle, app_id, window, flags, options, cb_success, cb_error):
     logger.debug(f"Inhibit({handle}, {app_id}, {window}, {flags}, {options})")
+    params = self.inhibit_params
 
     request = ImplRequest(
         self,
@@ -62,10 +75,10 @@ def Inhibit(self, handle, app_id, window, flags, options, cb_success, cb_error):
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, {}), delay=self.delay)
+        request.respond(Response(params.response, {}), delay=params.delay)
 
 
 @dbus.service.method(
@@ -105,6 +118,7 @@ def ArmTimer(self, session_handle):
 )
 def CreateMonitor(self, handle, session_handle, app_id, window, cb_success, cb_error):
     logger.debug(f"CreateMonitor({handle}, {session_handle}, {app_id}, {window})")
+    params = self.inhibit_params
 
     session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
     self.sessions[session_handle] = session
@@ -122,7 +136,7 @@ def CreateMonitor(self, handle, session_handle, app_id, window, cb_success, cb_e
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
 
@@ -130,7 +144,7 @@ def CreateMonitor(self, handle, session_handle, app_id, window, cb_success, cb_e
             self.ArmTimer(session_handle)
 
         request.respond(
-            Response(self.response, {}), delay=self.delay, done_cb=arm_timer
+            Response(params.response, {}), delay=params.delay, done_cb=arm_timer
         )
 
 

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -51,30 +51,21 @@ def load(mock, parameters={}):
     async_callbacks=("cb_success", "cb_error"),
 )
 def Inhibit(self, handle, app_id, window, flags, options, cb_success, cb_error):
-    try:
-        logger.debug(f"Inhibit({handle}, {app_id}, {window}, {flags}, {options})")
+    logger.debug(f"Inhibit({handle}, {app_id}, {window}, {flags}, {options})")
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"Inhibit Close() response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        def reply_callback():
-            response = Response(self.response, {})
-            logger.debug(f"Inhibit with response {response}")
-            cb_success(response.response, response.results)
-
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, {}), delay=self.delay)
 
 
 @dbus.service.method(
@@ -113,35 +104,34 @@ def ArmTimer(self, session_handle):
     async_callbacks=("cb_success", "cb_error"),
 )
 def CreateMonitor(self, handle, session_handle, app_id, window, cb_success, cb_error):
-    try:
-        logger.debug(f"CreateMonitor({handle}, {session_handle}, {app_id}, {window})")
+    logger.debug(f"CreateMonitor({handle}, {session_handle}, {app_id}, {window})")
 
-        session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
-        self.sessions[session_handle] = session
+    session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
+    self.sessions[session_handle] = session
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"CreateMonitor Close() response {response}")
-            cb_success(response.response)
+    # This is unregular: the backend doesn't return the results vardict
+    def internal_cb_success(response, results):
+        cb_success(response)
 
-        def reply_callback():
-            response = Response(self.response, {})
-            logger.debug(f"CreateMonitor with response {response}")
-            cb_success(response.response)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        internal_cb_success,
+        cb_error,
+    )
+
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+
+        def arm_timer():
             self.ArmTimer(session_handle)
 
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+        request.respond(
+            Response(self.response, {}), delay=self.delay, done_cb=arm_timer
+        )
 
 
 @dbus.service.method(

--- a/tests/templates/inputcapture.py
+++ b/tests/templates/inputcapture.py
@@ -2,14 +2,16 @@
 #
 # This file is formatted with Python Black
 
+from tests.templates import Response, init_logger
+
 from collections import namedtuple
 from itertools import count
 from gi.repository import GLib
-
+from dataclasses import dataclass
 import dbus
 import dbus.service
-import logging
 import socket
+
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
@@ -17,38 +19,52 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.InputCapture"
 VERSION = 1
 
-logger = logging.getLogger(f"templates.{__name__}")
-logger.setLevel(logging.DEBUG)
+
+logger = init_logger(__name__)
+
 
 serials = count()
 
-Response = namedtuple("Response", ["response", "results"])
+
 Barrier = namedtuple("Barrier", ["id", "position"])
+
+
+@dataclass
+class InputcaptureParameters:
+    delay: int
+    supported_capabilities: int
+    capabilities: int
+    default_zone: list
+    disable_delay: int
+    activated_delay: int
+    deactivated_delay: int
 
 
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
-    # Delay before Request.response
-    mock.delay: int = parameters.get("delay", 0)
 
-    mock.supported_capabilities = parameters.get("supported_capabilities", 0xF)
-    # The actual ones we reply with in the CreateSession request
-    mock.capabilities = parameters.get("capabilities", None)
+    assert not hasattr(mock, "inputcapture_params")
+    mock.inputcapture_params = InputcaptureParameters(
+        delay=parameters.get("delay", 0),
+        supported_capabilities=parameters.get("supported_capabilities", 0xF),
+        capabilities=parameters.get("capabilities", None),
+        default_zone=parameters.get("default-zone", [(1920, 1080, 0, 0)]),
+        disable_delay=parameters.get("disable-delay", 0),
+        activated_delay=parameters.get("activated-delay", 0),
+        deactivated_delay=parameters.get("deactivated-delay", 0),
+    )
 
-    mock.default_zone = parameters.get("default-zone", [(1920, 1080, 0, 0)])
-    mock.current_zones = mock.default_zone
+    mock.current_zones = mock.inputcapture_params.default_zone
     mock.current_zone_set = next(serials)
-
-    mock.disable_delay = parameters.get("disable-delay", 0)
-    mock.activated_delay = parameters.get("activated-delay", 0)
-    mock.deactivated_delay = parameters.get("deactivated-delay", 0)
 
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
             {
                 "version": dbus.UInt32(parameters.get("version", VERSION)),
-                "SupportedCapabilities": dbus.UInt32(mock.supported_capabilities),
+                "SupportedCapabilities": dbus.UInt32(
+                    mock.inputcapture_params.supported_capabilities
+                ),
             }
         ),
     )
@@ -64,16 +80,17 @@ def load(mock, parameters={}):
 def CreateSession(self, handle, session_handle, app_id, parent_window, options):
     try:
         logger.debug(f"CreateSession({parent_window}, {options})")
+        params = self.inputcapture_params
 
         assert "capabilities" in options
 
         # Filter to the subset of supported capabilities
-        if self.capabilities is None:
+        if params.capabilities is None:
             capabilities = options["capabilities"]
         else:
-            capabilities = self.capabilities
+            capabilities = params.capabilities
 
-        capabilities &= self.supported_capabilities
+        capabilities &= params.supported_capabilities
         response = Response(0, {})
 
         response.results["capabilities"] = dbus.UInt32(capabilities)
@@ -95,11 +112,12 @@ def CreateSession(self, handle, session_handle, app_id, parent_window, options):
 def GetZones(self, handle, session_handle, app_id, options):
     try:
         logger.debug(f"GetZones({session_handle}, {options})")
+        params = self.inputcapture_params
 
         assert session_handle in self.active_session_handles
 
         response = Response(0, {})
-        response.results["zones"] = self.default_zone
+        response.results["zones"] = params.default_zone
         response.results["zone_set"] = dbus.UInt32(
             self.current_zone_set, variant_level=1
         )
@@ -191,6 +209,7 @@ def SetPointerBarriers(
 def Enable(self, session_handle, app_id, options):
     try:
         logger.debug(f"Enable({session_handle}, {options})")
+        params = self.inputcapture_params
 
         assert session_handle in self.active_session_handles
 
@@ -199,15 +218,15 @@ def Enable(self, session_handle, app_id, options):
         barrier = self.current_barriers[0]
         pos = (barrier.position[0] + 10, barrier.position[1] + 20)
 
-        if self.disable_delay > 0:
+        if params.disable_delay > 0:
 
             def disable():
                 logger.debug("emitting Disabled")
                 self.EmitSignal(MAIN_IFACE, "Disabled", "oa{sv}", [session_handle, {}])
 
-            GLib.timeout_add(self.disable_delay, disable)
+            GLib.timeout_add(params.disable_delay, disable)
 
-        if self.activated_delay > 0:
+        if params.activated_delay > 0:
 
             def activated():
                 logger.debug("emitting Activated")
@@ -222,9 +241,9 @@ def Enable(self, session_handle, app_id, options):
                     MAIN_IFACE, "Activated", "oa{sv}", [session_handle, options]
                 )
 
-            GLib.timeout_add(self.activated_delay, activated)
+            GLib.timeout_add(params.activated_delay, activated)
 
-        if self.deactivated_delay > 0:
+        if params.deactivated_delay > 0:
 
             def deactivated():
                 logger.debug("emitting Deactivated")
@@ -238,7 +257,7 @@ def Enable(self, session_handle, app_id, options):
                     MAIN_IFACE, "Deactivated", "oa{sv}", [session_handle, options]
                 )
 
-            GLib.timeout_add(self.deactivated_delay, deactivated)
+            GLib.timeout_add(params.deactivated_delay, deactivated)
 
     except Exception as e:
         logger.critical(e)

--- a/tests/templates/print.py
+++ b/tests/templates/print.py
@@ -5,6 +5,7 @@
 from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -17,14 +18,27 @@ VERSION = 3
 logger = init_logger(__name__)
 
 
+@dataclass
+class PrintParameters:
+    delay: int
+    response: int
+    results: dict
+    expect_close: bool
+    prepare_results: dict
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.prepare_results: bool = parameters.get("prepare-results", {})
-    mock.results: bool = parameters.get("results", {})
-    mock.expect_close: bool = parameters.get("expect-close", False)
+    assert not hasattr(mock, "print_params")
+    mock.print_params = PrintParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        results=parameters.get("results", {}),
+        expect_close=parameters.get("expect-close", False),
+        prepare_results=parameters.get("prepare-results", {}),
+    )
+
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
@@ -56,6 +70,7 @@ def PreparePrint(
     logger.debug(
         f"PreparePrint({handle}, {app_id}, {parent_window}, {title}, {settings}, {page_setup}, {options})"
     )
+    params = self.print_params
 
     request = ImplRequest(
         self,
@@ -66,10 +81,12 @@ def PreparePrint(
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, self.prepare_results), delay=self.delay)
+        request.respond(
+            Response(params.response, params.prepare_results), delay=params.delay
+        )
 
 
 @dbus.service.method(
@@ -84,6 +101,7 @@ def Print(
     logger.debug(
         f"Print({handle}, {app_id}, {parent_window}, {title}, {fd}, {options})"
     )
+    params = self.print_params
 
     request = ImplRequest(
         self,
@@ -94,7 +112,7 @@ def Print(
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, self.results), delay=self.delay)
+        request.respond(Response(params.response, params.results), delay=params.delay)

--- a/tests/templates/print.py
+++ b/tests/templates/print.py
@@ -5,7 +5,6 @@
 from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
-from gi.repository import GLib
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -54,32 +53,23 @@ def PreparePrint(
     cb_success,
     cb_error,
 ):
-    try:
-        logger.debug(
-            f"PreparePrint({handle}, {app_id}, {parent_window}, {title}, {settings}, {page_setup}, {options})"
-        )
+    logger.debug(
+        f"PreparePrint({handle}, {app_id}, {parent_window}, {title}, {settings}, {page_setup}, {options})"
+    )
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"PreparePrint Close() response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        def reply_callback():
-            response = Response(self.response, self.prepare_results)
-            logger.debug(f"PreparePrint with response {response}")
-            cb_success(response.response, response.results)
-
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, self.prepare_results), delay=self.delay)
 
 
 @dbus.service.method(
@@ -91,29 +81,20 @@ def PreparePrint(
 def Print(
     self, handle, app_id, parent_window, title, fd, options, cb_success, cb_error
 ):
-    try:
-        logger.debug(
-            f"Print({handle}, {app_id}, {parent_window}, {title}, {fd}, {options})"
-        )
+    logger.debug(
+        f"Print({handle}, {app_id}, {parent_window}, {title}, {fd}, {options})"
+    )
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"Print Close() response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        def reply_callback():
-            response = Response(self.response, self.results)
-            logger.debug(f"Print with response {response}")
-            cb_success(response.response, response.results)
-
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, self.results), delay=self.delay)

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -50,44 +50,29 @@ def load(mock, parameters={}):
     async_callbacks=("cb_success", "cb_error"),
 )
 def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_error):
-    try:
-        logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
+    logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
 
-        session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
-        self.sessions[session_handle] = session
+    session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
+    self.sessions[session_handle] = session
 
-        response = Response(self.response, {"session_handle": session.handle})
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        request = ImplRequest(self, BUS_NAME, handle)
-
-        if self.expect_close:
-
-            def closed_callback():
-                response = Response(2, {})
-                logger.debug(f"CreateSession Close() response {response}")
-                cb_success(response.response, response.results)
-
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            def reply():
-                logger.debug(f"CreateSession with response {response}")
-                cb_success(response.response, response.results)
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply)
-
-            if self.force_close > 0:
-
-                def force_close():
-                    session.close()
-
-                GLib.timeout_add(self.force_close, force_close)
-
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(
+            Response(self.response, {"session_handle": session.handle}),
+            delay=self.delay,
+        )
+        if self.force_close > 0:
+            GLib.timeout_add(self.force_close, session.close)
 
 
 @dbus.service.method(
@@ -97,24 +82,23 @@ def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_
     async_callbacks=("cb_success", "cb_error"),
 )
 def SelectDevices(self, handle, session_handle, app_id, options, cb_success, cb_error):
-    try:
-        logger.debug(f"SelectDevices({handle}, {session_handle}, {app_id}, {options})")
+    logger.debug(f"SelectDevices({handle}, {session_handle}, {app_id}, {options})")
 
-        assert session_handle in self.sessions
-        response = Response(self.response, {})
-        request = ImplRequest(self, BUS_NAME, handle)
-        request.export()
+    assert session_handle in self.sessions
 
-        def reply():
-            logger.debug(f"SelectDevices with response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        logger.debug(f"scheduling delay of {self.delay}")
-        GLib.timeout_add(self.delay, reply)
-
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, {}), delay=self.delay)
 
 
 @dbus.service.method(
@@ -126,40 +110,29 @@ def SelectDevices(self, handle, session_handle, app_id, options, cb_success, cb_
 def Start(
     self, handle, session_handle, app_id, parent_window, options, cb_success, cb_error
 ):
-    try:
-        logger.debug(
-            f"Start({handle}, {session_handle}, {parent_window}, {app_id}, {options})"
-        )
+    logger.debug(
+        f"Start({handle}, {session_handle}, {parent_window}, {app_id}, {options})"
+    )
 
-        assert session_handle in self.sessions
-        response = Response(self.response, {})
+    assert session_handle in self.sessions
 
-        if self.force_clipoboard_enabled:
-            response.results["clipboard_enabled"] = True
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        request = ImplRequest(self, BUS_NAME, handle)
+    response = Response(self.response, {})
+    if self.force_clipoboard_enabled:
+        response.results["clipboard_enabled"] = True
 
-        if self.expect_close:
-
-            def closed_callback():
-                response = Response(2, {})
-                logger.debug(f"Start Close() response {response}")
-                cb_success(response.response, response.results)
-
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            def reply():
-                logger.debug(f"Start with response {response}")
-                cb_success(response.response, response.results)
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply)
-
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(response, delay=self.delay)
 
 
 @dbus.service.method(

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -3,12 +3,13 @@
 # This file is formatted with Python Black
 
 from tests.templates import Response, init_logger, ImplRequest, ImplSession
+
 from dbusmock import MOCK_IFACE
 import dbus
 import dbus.service
 import socket
-
 from gi.repository import GLib
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -21,17 +22,29 @@ VERSION = 2
 logger = init_logger(__name__)
 
 
+@dataclass
+class RemotedesktopParameters:
+    delay: int
+    response: int
+    expect_close: bool
+    force_close: int
+    force_clipoboard_enabled: bool
+    fail_connect_to_eis: bool
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.expect_close: bool = parameters.get("expect-close", False)
-    mock.force_close: int = parameters.get("force-close", 0)
-    mock.force_clipoboard_enabled: bool = parameters.get(
-        "force-clipboard-enabled", False
+    assert not hasattr(mock, "remotedesktop_params")
+    mock.remotedesktop_params = RemotedesktopParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        expect_close=parameters.get("expect-close", False),
+        force_close=parameters.get("force-close", 0),
+        force_clipoboard_enabled=parameters.get("force-clipboard-enabled", False),
+        fail_connect_to_eis=parameters.get("fail-connect-to-eis", False),
     )
-    mock.fail_connect_to_eis: bool = parameters.get("fail-connect-to-eis", False)
+
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
@@ -51,6 +64,7 @@ def load(mock, parameters={}):
 )
 def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_error):
     logger.debug(f"CreateSession({handle}, {session_handle}, {app_id}, {options})")
+    params = self.remotedesktop_params
 
     session = ImplSession(self, BUS_NAME, session_handle, app_id).export()
     self.sessions[session_handle] = session
@@ -64,15 +78,15 @@ def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
         request.respond(
-            Response(self.response, {"session_handle": session.handle}),
-            delay=self.delay,
+            Response(params.response, {"session_handle": session.handle}),
+            delay=params.delay,
         )
-        if self.force_close > 0:
-            GLib.timeout_add(self.force_close, session.close)
+        if params.force_close > 0:
+            GLib.timeout_add(params.force_close, session.close)
 
 
 @dbus.service.method(
@@ -83,6 +97,7 @@ def CreateSession(self, handle, session_handle, app_id, options, cb_success, cb_
 )
 def SelectDevices(self, handle, session_handle, app_id, options, cb_success, cb_error):
     logger.debug(f"SelectDevices({handle}, {session_handle}, {app_id}, {options})")
+    params = self.remotedesktop_params
 
     assert session_handle in self.sessions
 
@@ -95,10 +110,10 @@ def SelectDevices(self, handle, session_handle, app_id, options, cb_success, cb_
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, {}), delay=self.delay)
+        request.respond(Response(params.response, {}), delay=params.delay)
 
 
 @dbus.service.method(
@@ -113,6 +128,7 @@ def Start(
     logger.debug(
         f"Start({handle}, {session_handle}, {parent_window}, {app_id}, {options})"
     )
+    params = self.remotedesktop_params
 
     assert session_handle in self.sessions
 
@@ -125,14 +141,14 @@ def Start(
         cb_error,
     )
 
-    response = Response(self.response, {})
-    if self.force_clipoboard_enabled:
+    response = Response(params.response, {})
+    if params.force_clipoboard_enabled:
         response.results["clipboard_enabled"] = True
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(response, delay=self.delay)
+        request.respond(response, delay=params.delay)
 
 
 @dbus.service.method(
@@ -143,10 +159,11 @@ def Start(
 def ConnectToEIS(self, session_handle, app_id, options):
     try:
         logger.debug(f"ConnectToEIS({session_handle}, {app_id}, {options})")
+        params = self.remotedesktop_params
 
         assert session_handle in self.sessions
 
-        if self.fail_connect_to_eis:
+        if params.fail_connect_to_eis:
             raise dbus.exceptions.DBusException("Purposely failing ConnectToEIS")
 
         sockets = socket.socketpair()

--- a/tests/templates/screenshot.py
+++ b/tests/templates/screenshot.py
@@ -5,6 +5,7 @@
 from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -17,13 +18,25 @@ VERSION = 2
 logger = init_logger(__name__)
 
 
+@dataclass
+class ScreenshotParameters:
+    delay: int
+    response: int
+    results: dict
+    expect_close: bool
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.results = parameters.get("results", {})
-    mock.expect_close: bool = parameters.get("expect-close", False)
+    assert not hasattr(mock, "screenshot_params")
+    mock.screenshot_params = ScreenshotParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        results=parameters.get("results", {}),
+        expect_close=parameters.get("expect-close", False),
+    )
+
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
@@ -42,6 +55,7 @@ def load(mock, parameters={}):
 )
 def Screenshot(self, handle, app_id, parent_window, options, cb_success, cb_error):
     logger.debug(f"Screenshot({handle}, {app_id}, {parent_window}, {options})")
+    params = self.screenshot_params
 
     request = ImplRequest(
         self,
@@ -52,10 +66,10 @@ def Screenshot(self, handle, app_id, parent_window, options, cb_success, cb_erro
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, self.results), delay=self.delay)
+        request.respond(Response(params.response, params.results), delay=params.delay)
 
 
 @dbus.service.method(
@@ -66,6 +80,7 @@ def Screenshot(self, handle, app_id, parent_window, options, cb_success, cb_erro
 )
 def PickColor(self, handle, app_id, parent_window, options, cb_success, cb_error):
     logger.debug(f"PickColor({handle}, {app_id}, {parent_window}, {options})")
+    params = self.screenshot_params
 
     request = ImplRequest(
         self,
@@ -76,7 +91,7 @@ def PickColor(self, handle, app_id, parent_window, options, cb_success, cb_error
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, self.results), delay=self.delay)
+        request.respond(Response(params.response, params.results), delay=params.delay)

--- a/tests/templates/screenshot.py
+++ b/tests/templates/screenshot.py
@@ -5,7 +5,6 @@
 from tests.templates import Response, init_logger, ImplRequest
 
 import dbus.service
-from gi.repository import GLib
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -42,30 +41,21 @@ def load(mock, parameters={}):
     async_callbacks=("cb_success", "cb_error"),
 )
 def Screenshot(self, handle, app_id, parent_window, options, cb_success, cb_error):
-    try:
-        logger.debug(f"Screenshot({handle}, {app_id}, {parent_window}, {options})")
+    logger.debug(f"Screenshot({handle}, {app_id}, {parent_window}, {options})")
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"Screenshot Close() response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        def reply_callback():
-            response = Response(self.response, self.results)
-            logger.debug(f"Screenshot with response {response}")
-            cb_success(response.response, response.results)
-
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, self.results), delay=self.delay)
 
 
 @dbus.service.method(
@@ -75,27 +65,18 @@ def Screenshot(self, handle, app_id, parent_window, options, cb_success, cb_erro
     async_callbacks=("cb_success", "cb_error"),
 )
 def PickColor(self, handle, app_id, parent_window, options, cb_success, cb_error):
-    try:
-        logger.debug(f"PickColor({handle}, {app_id}, {parent_window}, {options})")
+    logger.debug(f"PickColor({handle}, {app_id}, {parent_window}, {options})")
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"PickColor Close() response {response}")
-            cb_success(response.response, response.results)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        cb_success,
+        cb_error,
+    )
 
-        def reply_callback():
-            response = Response(self.response, self.results)
-            logger.debug(f"PickColor with response {response}")
-            cb_success(response.response, response.results)
-
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, self.results), delay=self.delay)

--- a/tests/templates/settings.py
+++ b/tests/templates/settings.py
@@ -6,6 +6,7 @@ from tests.templates import init_logger
 
 import dbus.service
 from dbusmock import MOCK_IFACE
+from dataclasses import dataclass
 
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
@@ -18,10 +19,19 @@ VERSION = 2
 logger = init_logger(__name__)
 
 
+@dataclass
+class SettingsParameters:
+    settings: dict
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.settings = parameters.get("settings", {})
+    assert not hasattr(mock, "settings_params")
+    mock.settings_params = SettingsParameters(
+        settings=parameters.get("settings", {}),
+    )
+
     mock.AddProperties(
         MAIN_IFACE,
         dbus.Dictionary(
@@ -39,21 +49,22 @@ def load(mock, parameters={}):
 )
 def ReadAll(self, namespaces):
     logger.debug(f"ReadAll({namespaces})")
+    settings = self.settings_params.settings
 
     if len(namespaces) == 0 or (len(namespaces) == 1 and namespaces[0] == ""):
-        return self.settings
+        return settings
 
     def find_matching(namespace):
         if len(namespace) >= 3 and namespace[-2:] == ".*":
             ns_prefix = namespace[:-2]
             matches = {}
-            for ns in self.settings:
+            for ns in settings:
                 if ns.startswith(ns_prefix):
-                    matches[ns] = self.settings[ns]
+                    matches[ns] = settings[ns]
             return matches
 
-        if namespace in self.settings:
-            return {namespace: self.settings[namespace]}
+        if namespace in settings:
+            return {namespace: settings[namespace]}
 
         return {}
 
@@ -71,8 +82,9 @@ def ReadAll(self, namespaces):
 )
 def Read(self, namespace, key):
     logger.debug(f"Read({namespace}, {key})")
+    settings = self.settings_params.settings
 
-    return self.settings[namespace][key]
+    return settings[namespace][key]
 
 
 @dbus.service.method(
@@ -81,7 +93,10 @@ def Read(self, namespace, key):
     out_signature="",
 )
 def SetSetting(self, namespace, key, value):
-    self.settings.setdefault(namespace, {})[key] = value
+    logger.debug(f"SetSetting({namespace}, {key}, {value})")
+    settings = self.settings_params.settings
+
+    settings.setdefault(namespace, {})[key] = value
 
     self.EmitSignal(
         MAIN_IFACE,

--- a/tests/templates/wallpaper.py
+++ b/tests/templates/wallpaper.py
@@ -6,7 +6,6 @@ from tests.templates import Response, init_logger, ImplRequest
 
 import dbus
 import dbus.service
-from gi.repository import GLib
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
@@ -34,29 +33,24 @@ def load(mock, parameters={}):
 def SetWallpaperURI(
     self, handle, app_id, parent_window, uri, options, cb_success, cb_error
 ):
-    try:
-        logger.debug(
-            f"SetWallpaperURI({handle}, {app_id}, {parent_window}, {uri}, {options})"
-        )
+    logger.debug(
+        f"SetWallpaperURI({handle}, {app_id}, {parent_window}, {uri}, {options})"
+    )
 
-        def closed_callback():
-            response = Response(2, {})
-            logger.debug(f"SetWallpaperURI Close() response {response}")
-            cb_success(response.response)
+    # This is unregular: the backend doesn't return the results vardict
+    def internal_cb_success(response, results):
+        cb_success(response)
 
-        def reply_callback():
-            response = Response(self.response, {})
-            logger.debug(f"SetWallpaperURI with response {response}")
-            cb_success(response.response)
+    request = ImplRequest(
+        self,
+        BUS_NAME,
+        handle,
+        logger,
+        internal_cb_success,
+        cb_error,
+    )
 
-        request = ImplRequest(self, BUS_NAME, handle)
-        if self.expect_close:
-            request.export(closed_callback)
-        else:
-            request.export()
-
-            logger.debug(f"scheduling delay of {self.delay}")
-            GLib.timeout_add(self.delay, reply_callback)
-    except Exception as e:
-        logger.critical(e)
-        cb_error(e)
+    if self.expect_close:
+        request.wait_for_close()
+    else:
+        request.respond(Response(self.response, {}), delay=self.delay)

--- a/tests/templates/wallpaper.py
+++ b/tests/templates/wallpaper.py
@@ -6,6 +6,8 @@ from tests.templates import Response, init_logger, ImplRequest
 
 import dbus
 import dbus.service
+from dataclasses import dataclass
+
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
@@ -16,12 +18,22 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Wallpaper"
 logger = init_logger(__name__)
 
 
+@dataclass
+class WallpaperParameters:
+    delay: int
+    response: int
+    expect_close: bool
+
+
 def load(mock, parameters={}):
     logger.debug(f"Loading parameters: {parameters}")
 
-    mock.delay: int = parameters.get("delay", 200)
-    mock.response: int = parameters.get("response", 0)
-    mock.expect_close: bool = parameters.get("expect-close", False)
+    assert not hasattr(mock, "wallpaper_params")
+    mock.wallpaper_params = WallpaperParameters(
+        delay=parameters.get("delay", 200),
+        response=parameters.get("response", 0),
+        expect_close=parameters.get("expect-close", False),
+    )
 
 
 @dbus.service.method(
@@ -36,6 +48,7 @@ def SetWallpaperURI(
     logger.debug(
         f"SetWallpaperURI({handle}, {app_id}, {parent_window}, {uri}, {options})"
     )
+    params = self.wallpaper_params
 
     # This is unregular: the backend doesn't return the results vardict
     def internal_cb_success(response, results):
@@ -50,7 +63,7 @@ def SetWallpaperURI(
         cb_error,
     )
 
-    if self.expect_close:
+    if params.expect_close:
         request.wait_for_close()
     else:
-        request.respond(Response(self.response, {}), delay=self.delay)
+        request.respond(Response(params.response, {}), delay=params.delay)


### PR DESCRIPTION
    The templates are loaded onto the MAIN_OBJ which is the same for all
    portal impls. That means if a test case sets up multiple templates, they
    all operate on the same object.
    
    If we set, for example, `mock.delay` in both templates, the latter will
    overwrite the former.
    
    This commit loads the parameters into a dataclass that's available as
    mock.${classname}_params.
    
    Technically we have similar issues whenever we access self in the dbus
    method implementations, but for the most part we use different variables
    in different templates.

depends on https://github.com/flatpak/xdg-desktop-portal/pull/1607