### PR TITLE
Fix build with pipewire 1.3.82

### DIFF
--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -331,7 +331,7 @@ pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
   remote->registry = (struct pw_proxy*) pw_core_get_registry (remote->core,
                                                               PW_VERSION_REGISTRY,
                                                               0);
-  pw_registry_add_listener (remote->registry,
+  pw_registry_add_listener ((struct pw_registry*)remote->registry,
                             &remote->registry_listener,
                             &registry_events,
                             remote);


### PR DESCRIPTION
While submitting pipewire 1.3.82 to openSUSE Tumbleweed I noticed this cast is needed to build xdg-desktop-portal. This was already submitted as an issue in #1611 in Debian testing, in which the reporter doesn't mention the used pipewire version but says "I am also building my own pipewire" so I guess it's one of the latest RCs (1.3.81 or 1.3.82).

Fixes: #1611