### PR TITLE
test: Fix calling pytest from meson

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -138,7 +138,7 @@ foreach pytest_file : pytest_files
   test(
     'integration/@0@'.format(testname),
     pytest,
-    args: [meson.current_source_dir()] + pytest_args + ['-k', testname],
+    args: [meson.current_source_dir() / pytest_file] + pytest_args,
     env: pytest_env,
     suite: ['integration'],
     timeout: 120,


### PR DESCRIPTION
I did an oopsie while rebasing the branch containing 005da4c3 and partially undid fedbd63c ("build: Change the pytest invocation to run a specific file").

Fixes: 005da4c3 ("build: Use a single `tests` option to control if we build any tests")