### PR TITLE
Temporarily neutralize the host app registry

### DIFF
--- a/doc/api-reference.rst
+++ b/doc/api-reference.rst
@@ -4,20 +4,8 @@ API Reference
 Portal interfaces are available to sandboxed applications with the default
 filtered session bus access of Flatpak.
 
-Desktop portals appear under the bus name ``org.freedesktop.portal.Desktop``
-and the object path ``/org/freedesktop/portal/desktop`` on the session bus,
-unless specified otherwise.
-
-Apps running on the host system have access to a special interface for
-registering themselves with XDG Desktop Portal. Registering a host app with
-XDG Desktop Portal overwrites the automatic detection based on the
-`XDG cgroup pathname standardization for applications
-<https://systemd.io/DESKTOP_ENVIRONMENTS/#xdg-standardization-for-applications>`_.
-This might improve the user experience when the host app was launched in a way
-that doesn't follow the standard. See
-:doc:`org.freedesktop.host.portal.Registry <doc-org.freedesktop.host.portal.Registry>`
-
-All apps have access to the portals below:
+Unless otherwise specified, they appear under the bus name ``org.freedesktop.portal.Desktop``
+and the object path ``/org/freedesktop/portal/desktop`` on the session bus.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/fix-rst-dbus.py
+++ b/doc/fix-rst-dbus.py
@@ -20,8 +20,6 @@ def adjust_title(lines):
         adjusted_title = title.replace("org.freedesktop.portal.", "")
     elif title.startswith("org.freedesktop.impl.portal"):
         adjusted_title = title.replace("org.freedesktop.impl.portal.", "")
-    elif title.startswith("org.freedesktop.host.portal"):
-        adjusted_title = title.replace("org.freedesktop.host.portal.", "")
     elif title.startswith("org.freedesktop.background.Monitor"):
         adjusted_title = title.replace(
             "org.freedesktop.background.Monitor", "Background Apps Monitor"

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -40,9 +40,6 @@ if build_documentation
   foreach i: portal_sources
     all_interfaces_xml += i
   endforeach
-  foreach i: portal_host_sources
-    all_interfaces_xml += i
-  endforeach
   foreach i: portal_impl_sources
     all_interfaces_xml += i
   endforeach

--- a/src/meson.build
+++ b/src/meson.build
@@ -96,7 +96,7 @@ xdg_desktop_portal_sources = files(
   'print.c',
   'proxy-resolver.c',
   'realtime.c',
-  'registry.c',
+  #'registry.c',
   'remote-desktop.c',
   'screen-cast.c',
   'screenshot.c',

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -60,7 +60,9 @@
 #include "print.h"
 #include "proxy-resolver.h"
 #include "realtime.h"
+#if 0
 #include "registry.h"
+#endif
 #include "remote-desktop.h"
 #include "xdp-request.h"
 #include "screen-cast.h"
@@ -188,6 +190,7 @@ export_portal_implementation (GDBusConnection *connection,
   g_debug ("providing portal %s", g_dbus_interface_skeleton_get_info (skeleton)->name);
 }
 
+#if 0
 static void
 export_host_portal_implementation (GDBusConnection        *connection,
                                    GDBusInterfaceSkeleton *skeleton)
@@ -214,6 +217,7 @@ export_host_portal_implementation (GDBusConnection        *connection,
 
   g_debug ("providing portal %s", g_dbus_interface_skeleton_get_info (skeleton)->name);
 }
+#endif
 
 static void
 peer_died_cb (const char *name)
@@ -401,7 +405,9 @@ on_bus_acquired (GDBusConnection *connection,
                                   xdp_usb_create (connection, implementation->dbus_name));
 #endif
 
+#if 0
   export_host_portal_implementation (connection, registry_create (connection));
+#endif
 }
 
 static void

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -100,7 +100,7 @@ pytest_files = [
   'test_openuri.py',
   'test_permission_store.py',
   'test_print.py',
-  'test_registry.py',
+  #'test_registry.py',
   'test_remotedesktop.py',
   'test_settings.py',
   'test_screenshot.py',


### PR DESCRIPTION
For the 1.20 release. This should be reverted once that's released.