### PR TITLE
Add the Go package to list of libraries

### DIFF
--- a/doc/convenience-libraries.rst
+++ b/doc/convenience-libraries.rst
@@ -12,5 +12,8 @@ the development of apps:
   provides a GObject API to interact with portals. It provides language bindings
   to a variety of other languages, such as **Python**, **JavaScript**, **Vala**,
   and more. It has support for GTK3, GTK4, Qt 5, and Qt 6.
+* `portal <https://github.com/rymdport/portal>`_: a **Go** module that provides
+  native APIs for interacting with portals from idiomatic Go code.
+  It aims to be both toolkit agnostic and easy to use.
 * `xdg_desktop_portal <https://pub.dev/packages/xdg_desktop_portal>`_: a native
   **Dart** package to interact with portals in **Dart** and **Flutter**.


### PR DESCRIPTION
This adds https://github.com/rymdport/portal to the list of convenience libraries.