### PR TITLE
notification: Escape the href attribute of links when re-serializing

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -253,7 +253,15 @@ markup_parser_text (GMarkupParseContext  *context,
 {
   GString *composed = user_data;
 
-  g_string_append_len (composed, text, text_len);
+  while (text_len > 0)
+    {
+      gsize len = MIN (text_len, G_MAXSSIZE);
+      g_autofree char *escaped = g_markup_escape_text (text, len);
+
+      g_string_append (composed, escaped);
+      text_len -= len;
+      text += len;
+    }
 }
 
 static void

--- a/src/notification.c
+++ b/src/notification.c
@@ -282,7 +282,9 @@ markup_parser_start_element (GMarkupParseContext  *context,
         {
           if (strcmp (attribute_names[i], "href") == 0)
             {
-              g_string_append_printf (composed, "<a href=\"%s\">", attribute_values[i]);
+              g_autofree char *escaped = g_markup_escape_text (attribute_values[i], -1);
+
+              g_string_append_printf (composed, "<a href=\"%s\">", escaped);
               break;
             }
         }

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -161,6 +161,10 @@ class TestNotification:
                 'test <a href="https://example.com"><b>Some link</b></a>',
             ),
             (
+                '<a href="https://xkcd.com/327/#&quot;&gt;&lt;html&gt;"></a>',
+                '<a href="https://xkcd.com/327/#&quot;&gt;&lt;html&gt;"></a>',
+            ),
+            (
                 "test \n newline \n\n some more space \n  with trailing space ",
                 "test newline some more space with trailing space",
             ),

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -161,6 +161,10 @@ class TestNotification:
                 'test <a href="https://example.com"><b>Some link</b></a>',
             ),
             (
+                "&lt;html&gt;",
+                "&lt;html&gt;",
+            ),
+            (
                 '<a href="https://xkcd.com/327/#&quot;&gt;&lt;html&gt;"></a>',
                 '<a href="https://xkcd.com/327/#&quot;&gt;&lt;html&gt;"></a>',
             ),


### PR DESCRIPTION
* notification: Escape the href attribute of links when re-serializing

    Otherwise they'll be emitted unescaped, changing the meaning of the
    notification body.
    
    Fixes: ebff872d "notification: Add new property markup-body to support markup"
    Resolves: https://github.com/flatpak/xdg-desktop-portal/issues/1545

* tests: Assert that href attributes are escaped correctly
    
    Strictly speaking the exact form of escaping used here is an
    implementation detail of GLib (it would be equally valid to re-escape
    the encoded characters with numeric character references like
    `&#34;&#62;&#60;html&#62;` or similar), but it seems unlikely that
    GLib will change this in practice.

* notification: Escape the body text of the markup-body when re-serializing
    
    Similar to #1545, otherwise they'll be emitted unescaped, changing the
    meaning of the notification body.
    
    Fixes: ebff872d "notification: Add new property markup-body to support markup"

* tests: Assert that markup-body text is escaped correctly