### PR TITLE
Tests: Use pytest instead of pytest-3.

### DIFF
--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -39,4 +39,4 @@ export XDG_DESKTOP_PORTAL_PATH="$BUILDDIR/src/xdg-desktop-portal"
 export XDG_DOCUMENT_PORTAL_PATH="$BUILDDIR/document-portal/xdg-document-portal"
 export XDG_PERMISSION_STORE_PATH="$BUILDDIR/document-portal/xdg-permission-store"
 
-exec pytest-3 "$@"
+exec pytest "$@"


### PR DESCRIPTION
Back in a time of transition from Python 2 to 3, `pytest-3` was an indicator to use the Python 3 edition. However, this is no longer the case, and if `pytest-3` still exists, it's only for compatibility reasons. Let's not use it.