### PR TITLE
Avoid spurious warnings when dbus.service stops

### DIFF
--- a/document-portal/xdg-document-portal.service.in
+++ b/document-portal/xdg-document-portal.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=flatpak document portal service
 PartOf=graphical-session.target
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 BusName=org.freedesktop.portal.Documents

--- a/document-portal/xdg-permission-store.service.in
+++ b/document-portal/xdg-permission-store.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=sandboxed app permission store
 PartOf=graphical-session.target
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 BusName=org.freedesktop.impl.portal.PermissionStore

--- a/src/xdg-desktop-portal.service.in
+++ b/src/xdg-desktop-portal.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=Portal service
 PartOf=graphical-session.target
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Services in this project generate a warning when they lose ownership of their D-Bus name, which happens routinely when dbus.service exits (e.g. when the user logs out).

Stop services before dbus.service exits, to avoid this warning.