### PR TITLE
permission-db: Do not crash on NULL child_app_id

### DIFF
--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -1030,7 +1030,10 @@ permission_db_entry_get_permissions_variant (PermissionDbEntry *entry,
       child = g_variant_get_child_value (app_array, m);
       g_variant_get_child (child, 0, "&s", &child_app_id);
 
-      cmp = strcmp (app_id, child_app_id);
+      if (child_app_id == NULL)
+        g_warning ("Got NULL app-id in the store when getting permissions for %s", app_id);
+
+      cmp = g_strcmp0 (app_id, child_app_id);
       if (cmp == 0)
         {
           res = g_variant_get_child_value (child, 1);


### PR DESCRIPTION
The callers of this function check whether the return value is NULL.

~~Fixes: https://github.com/flatpak/xdg-desktop-portal/issues/1616~~