### PR TITLE
registry: Add hint about reregistration on restarts

### DIFF
--- a/data/org.freedesktop.host.portal.Registry.xml
+++ b/data/org.freedesktop.host.portal.Registry.xml
@@ -52,6 +52,9 @@
 
         Registering must be done before any portal method call; registering
         after such a call will result in an error.
+
+        Applications should ideally listen for name appeared D-Bus signalling to
+        re-register the peer if the portal service is restarted.
     -->
     <method name="Register">
       <arg type="s" name="app_id" direction="in"/>


### PR DESCRIPTION
The portal service may be restarted for various reasons, and ideally applications should handle that gracefully by re-registering.