### PR TITLE
docs: Fix typos in for-contributors.rst

### DIFF
--- a/doc/for-contributors.rst
+++ b/doc/for-contributors.rst
@@ -4,11 +4,12 @@ For Contributors
 Thanks for your interest in contributing to XDG Desktop Portal!
 
 XDG Desktop Portal is a D-Bus oriented, security-sensitive service,
-as it mediates the interactions sandboxed apps and the host system.
+as it mediates the interactions between sandboxed apps and the host
+system.
 
-In the sections below you will find information about the how to
-start contributing to XDG Desktop Portal, the expected coding and
-code submission practices, as well as internal documentation about
+In the sections below you will find information about how to start
+contributing to XDG Desktop Portal, the expected coding and code
+submission practices, as well as internal documentation about
 more complex parts of XDG Desktop Portal.
 
 .. toctree::


### PR DESCRIPTION
Add missing "between" in paragraph 1, remove extra "the" in paragraph 2.