### PR TITLE
Add `GetTables` to `org.freedesktop.impl.portal.PermissionStore`

### DIFF
--- a/data/org.freedesktop.impl.portal.PermissionStore.xml
+++ b/data/org.freedesktop.impl.portal.PermissionStore.xml
@@ -179,6 +179,16 @@
     </method>
 
     <!--
+        GetTables:
+        @tables: All available tables 
+
+        Returns all available tables .
+    -->
+    <method name="GetTables">
+      <arg name="tables" type="as" direction="out"/>
+    </method>
+
+    <!--
         Changed:
         @table: the name of the table
         @ids: IDs of the changed resource

--- a/tests/test_permission_store.py
+++ b/tests/test_permission_store.py
@@ -73,6 +73,12 @@ class PermissionStore(xdp.GDBusIface):
             GLib.Variant("(sss)", (table, id, app)),
         )
 
+    def GetTables(self):
+        return self._call(
+            "GetTables",
+            GLib.Variant("()", ()),
+        )
+
 
 class TestPermissionStore:
     def test_version(self, portals, dbus_con):
@@ -89,7 +95,7 @@ class TestPermissionStore:
             "org.freedesktop.impl.portal.PermissionStore",
             "version",
         )
-        assert int(portal_version) == 2
+        assert int(portal_version) == 3
 
     def test_delete_race(self, portals, dbus_con):
         permission_store_intf = PermissionStore()
@@ -296,3 +302,9 @@ class TestPermissionStore:
         result, _ = permission_store_intf.GetPermission(table, id, "no-such-app")
         permissions = result.unpack()[0]
         assert permissions == []
+
+    def test_get_tables(self, portals, dbus_con):
+        permission_store_intf = PermissionStore()
+
+        result, _ = permission_store_intf.GetTables()
+        assert result.unpack() == ([],)


### PR DESCRIPTION
You can do everything with the permission store using D-Bus except getting a list of all tables. If you want to get a list of all available tables you need to get a list of all files in `$XDG_DATA_HOME/flatpab/db`. This new functions allows now getting a list of all tables using D-Bus, so you no longer need the filesystem.