### PR TITLE
GlobalShortcuts: Add a request to configure shortcuts

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -28,7 +28,7 @@
       This portal lets applications register global shortcuts so they can
       act regardless of the system state upon an input event.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.GlobalShortcuts">
     <!--
@@ -106,6 +106,28 @@
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
 
+    <!--
+        ConfigureShortcuts:
+        @session_handle: Object path for the :ref:`org.freedesktop.portal.Session` object representing the session
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
+        @options: Vardict with optional further information
+
+        Request showing a configuration UI so the user is able to conigure all shortcuts of this session.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate the configuration window.
+
+        This method was added in version 2 of this interface.
+    -->
+    <method name="ConfigureShortcuts">
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="parent_window" direction="in" />
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+    </method>
     <!--
         Activated:
         @session_handle: Session that requested the shortcut

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -41,7 +41,7 @@
       #org.freedesktop.portal.GlobalShortcuts::Deactivated signals are emitted,
       respecitvely, whenever a shortcut is activated and deactivated.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.GlobalShortcuts">
     <!--
@@ -181,6 +181,29 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="request_handle" direction="out"/>
+    </method>
+
+    <!--
+        ConfigureShortcuts:
+        @session_handle: Object path for the :ref:`org.freedesktop.portal.Session` object representing the session
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
+        @options: Vardict with optional further information
+
+        Request showing a configuration UI so the user is able to conigure all shortcuts of this session.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate the configuration window.
+
+        This method was added in version 2 of this interface.
+    -->
+    <method name="ConfigureShortcuts">
+      <arg type="o" name="session_handle" direction="in"/>
+      <arg type="s" name="parent_window" direction="in" />
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
     </method>
 
     <!--

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -143,6 +143,15 @@ def ListShortcuts(
 
 
 @dbus.service.method(
+    MAIN_IFACE,
+    in_signature="osa{sv}",
+    out_signature="",
+)
+def ConfigureShortcuts(self, session_handle, parent_window, options):
+    assert session_handle in self.sessions
+
+
+@dbus.service.method(
     MOCK_IFACE,
     in_signature="os",
     out_signature="",


### PR DESCRIPTION
As mentioned on Matrix this allows an application to steer their users to the place where they can configure global shortcutcs of the application.

kde portal impl: https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/commit/a8b7532e33d98bdaf034a92c624bc63adaceec5c
client side impl in ashpd: https://github.com/Sodivad/ashpd/commit/21be0f546438b52be27a49a8c79c621753059c43