### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # [XDG Desktop Portal](https://flatpak.github.io/xdg-desktop-portal/)
 
-A portal frontend service for [Flatpak](http://www.flatpak.org) and other
+A portal frontend service for [Flatpak](https://flatpak.org) and other
 desktop containment frameworks.
 
 xdg-desktop-portal works by exposing a series of D-Bus interfaces known as


### PR DESCRIPTION
The flatpak.org link gives me `net::ERR_CERT_COMMON_NAME_INVALID`. Using https and removing the `www` works.