### PR TITLE
doc: Fix a few typos and wrong references

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -22,8 +22,8 @@
 
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <!--
-      org.freedesktop.impl.portal.GlobalShortcut:
-      @short_description: GlobalShortcut portal backend interface
+      org.freedesktop.impl.portal.GlobalShortcuts:
+      @short_description: GlobalShortcuts portal backend interface
 
       This portal lets applications register global shortcuts so they can
       act regardless of the system state upon an input event.

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -22,8 +22,8 @@
 
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <!--
-      org.freedesktop.portal.GlobalShortcut:
-      @short_description: GlobalShortcut portal backend interface
+      org.freedesktop.portal.GlobalShortcuts:
+      @short_description: Portal for managing global shortcuts
 
       This portal lets applications create global shortcuts sessions, and
       register shortcuts to them. These shortcuts are activated regardless of

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -443,7 +443,7 @@
 
         To see how to pair a PipeWire stream with a libei device region, see the
         documentation for the ``mapping_id`` stream property in
-        org.freedesktop.portal.ScreenCast.Start().
+        :ref:`org.freedesktop.portal.ScreenCast.Start`.
 
         This method was added in version 2 of this interface.
     -->

--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -36,7 +36,7 @@
   <interface name="org.freedesktop.portal.Screenshot">
     <!--
         Screenshot:
-        @parent_window: Identifier for the application window, see :ref:`Common Conventions`</link>
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
         @options: Vardict with optional further information
         @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
 

--- a/doc/api-reference.rst
+++ b/doc/api-reference.rst
@@ -34,7 +34,6 @@ All apps have access to the portals below:
    doc-org.freedesktop.portal.Background.rst
    doc-org.freedesktop.portal.Camera.rst
    doc-org.freedesktop.portal.Clipboard.rst
-   doc-org.freedesktop.portal.Device.rst
    doc-org.freedesktop.portal.Documents.rst
    doc-org.freedesktop.portal.DynamicLauncher.rst
    doc-org.freedesktop.portal.Email.rst


### PR DESCRIPTION
Makes the Global Shortcuts description actually show up in the docs and the website, fixes a few links and manages to reduce the number of warnings being generated when building the docs.

Closes: #1663