### PR TITLE
tests: Fix implementation D-Bus names

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -145,7 +145,7 @@ def get_mock_iface(bus: dbus.Bus, bus_name: Optional[str] = None) -> dbus.Interf
     Returns the mock interface of the xdg-desktop-portal.
     """
     if not bus_name:
-        bus_name = "org.freedesktop.impl.portal.Test"
+        bus_name = "org.freedesktop.impl.portal.desktop.Test"
 
     obj = bus.get_object(bus_name, "/org/freedesktop/portal/desktop")
     return dbus.Interface(obj, dbusmock.MOCK_IFACE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,7 @@ default=test;
 
     files["test.portal"] = """
 [portal]
-DBusName=org.freedesktop.impl.portal.Test
+DBusName=org.freedesktop.impl.portal.desktop.Test
 Interfaces={}
 """.format(";".join(portals)).encode("utf-8")
 

--- a/tests/templates/__init__.py
+++ b/tests/templates/__init__.py
@@ -173,7 +173,7 @@ class ImplSession:
     instantiate this directly, instead use ``ImplSession.export()``. Typically
     like this:
 
-        >>> s = ImplSession.export(mock, "org.freedesktop.impl.portal.Test", "/path/foo")
+        >>> s = ImplSession.export(mock, "org.freedesktop.impl.portal.desktop.Test", "/path/foo")
 
     Where the test or the backend implementation relies on the Closed() method
     of the ImplSession, provide a callback to be invoked.

--- a/tests/templates/access.py
+++ b/tests/templates/access.py
@@ -9,7 +9,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Access"

--- a/tests/templates/account.py
+++ b/tests/templates/account.py
@@ -10,7 +10,7 @@ import dbus
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Account"

--- a/tests/templates/appchooser.py
+++ b/tests/templates/appchooser.py
@@ -9,7 +9,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.AppChooser"

--- a/tests/templates/background.py
+++ b/tests/templates/background.py
@@ -11,7 +11,7 @@ from gi.repository import GLib
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Background"

--- a/tests/templates/clipboard.py
+++ b/tests/templates/clipboard.py
@@ -12,7 +12,7 @@ from gi.repository import GLib
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Clipboard"

--- a/tests/templates/dynamiclauncher.py
+++ b/tests/templates/dynamiclauncher.py
@@ -9,7 +9,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.DynamicLauncher"

--- a/tests/templates/email.py
+++ b/tests/templates/email.py
@@ -9,7 +9,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Email"

--- a/tests/templates/filechooser.py
+++ b/tests/templates/filechooser.py
@@ -9,7 +9,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.FileChooser"

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -13,7 +13,7 @@ from gi.repository import GLib
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.GlobalShortcuts"

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -12,7 +12,7 @@ from dbusmock import MOCK_IFACE
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Inhibit"

--- a/tests/templates/inputcapture.py
+++ b/tests/templates/inputcapture.py
@@ -14,7 +14,7 @@ import dbus.service
 import socket
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.InputCapture"

--- a/tests/templates/lockdown.py
+++ b/tests/templates/lockdown.py
@@ -8,7 +8,7 @@ from tests.templates import init_logger
 import dbus.service
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Lockdown"

--- a/tests/templates/notification.py
+++ b/tests/templates/notification.py
@@ -9,7 +9,7 @@ import dbus.service
 from dbusmock import MOCK_IFACE
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Notification"

--- a/tests/templates/print.py
+++ b/tests/templates/print.py
@@ -9,7 +9,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Print"

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -13,7 +13,7 @@ from gi.repository import GLib
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.RemoteDesktop"

--- a/tests/templates/screenshot.py
+++ b/tests/templates/screenshot.py
@@ -9,7 +9,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Screenshot"

--- a/tests/templates/settings.py
+++ b/tests/templates/settings.py
@@ -10,7 +10,7 @@ from dbusmock import MOCK_IFACE
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Settings"

--- a/tests/templates/usb.py
+++ b/tests/templates/usb.py
@@ -11,7 +11,7 @@ from dbusmock import MOCK_IFACE
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Usb"

--- a/tests/templates/wallpaper.py
+++ b/tests/templates/wallpaper.py
@@ -10,7 +10,7 @@ import dbus.service
 from dataclasses import dataclass
 
 
-BUS_NAME = "org.freedesktop.impl.portal.Test"
+BUS_NAME = "org.freedesktop.impl.portal.desktop.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Wallpaper"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -78,13 +78,13 @@ SETTINGS_DATA = {
 @pytest.fixture
 def required_templates():
     return {
-        "settings:org.freedesktop.impl.portal.Test1": {
+        "settings:org.freedesktop.impl.portal.desktop.Test1": {
             "settings": SETTINGS_DATA_TEST1,
         },
-        "settings:org.freedesktop.impl.portal.Test2": {
+        "settings:org.freedesktop.impl.portal.desktop.Test2": {
             "settings": SETTINGS_DATA_TEST2,
         },
-        "settings:org.freedesktop.impl.portal.TestBad": {
+        "settings:org.freedesktop.impl.portal.desktop.TestBad": {
             "settings": SETTINGS_DATA_BAD,
         },
     }
@@ -93,22 +93,22 @@ def required_templates():
 PORTAL_CONFIG_FILES = {
     "test1.portal": b"""
 [portal]
-DBusName=org.freedesktop.impl.portal.Test1
+DBusName=org.freedesktop.impl.portal.desktop.Test1
 Interfaces=org.freedesktop.impl.portal.Settings;
 """,
     "test2.portal": b"""
 [portal]
-DBusName=org.freedesktop.impl.portal.Test2
+DBusName=org.freedesktop.impl.portal.desktop.Test2
 Interfaces=org.freedesktop.impl.portal.Settings;
 """,
     "test_bad.portal": b"""
 [portal]
-DBusName=org.freedesktop.impl.portal.TestBad
+DBusName=org.freedesktop.impl.portal.desktop.TestBad
 Interfaces=org.freedesktop.impl.portal.Settings;
 """,
     "test_noimpl.portal": b"""
 [portal]
-DBusName=org.freedesktop.impl.portal.TestBad
+DBusName=org.freedesktop.impl.portal.desktop.TestBad
 Interfaces=org.freedesktop.impl.portal.NonExistant;
 """,
 }
@@ -277,7 +277,9 @@ class TestSettings:
     )
     def test_config_twice(self, portals, dbus_con):
         settings_intf = xdp.get_portal_iface(dbus_con, "Settings")
-        mock_intf = xdp.get_mock_iface(dbus_con, "org.freedesktop.impl.portal.Test1")
+        mock_intf = xdp.get_mock_iface(
+            dbus_con, "org.freedesktop.impl.portal.desktop.Test1"
+        )
 
         value = settings_intf.ReadAll([])
         assert value == SETTINGS_DATA
@@ -313,7 +315,9 @@ class TestSettings:
 
     def test_changed(self, portals, dbus_con):
         settings_intf = xdp.get_portal_iface(dbus_con, "Settings")
-        mock_intf = xdp.get_mock_iface(dbus_con, "org.freedesktop.impl.portal.Test1")
+        mock_intf = xdp.get_mock_iface(
+            dbus_con, "org.freedesktop.impl.portal.desktop.Test1"
+        )
         changed_count = 0
 
         ns = "org.freedesktop.appearance"


### PR DESCRIPTION
All of portal backends follows the convention described in the documentation where the desktop portal implementation D-Bus names starts with `org.freedesktop.impl.portal.desktop.`, so we get `org.freedesktop.impl.portal.desktop.gtk`, `org.freedesktop.impl.portal.desktop.gnome`, `org.freedesktop.impl.portal.desktop.kde`, `org.freedesktop.impl.portal.desktop.wlr`.

All the tests ignore this convention but should follow it, unless I misundertood some expectations or made wrong assumptions.