### PR TITLE
validate-{icon,sound}: mount tmpfs,proc,dev first

### DIFF
--- a/src/validate-icon.c
+++ b/src/validate-icon.c
@@ -276,6 +276,9 @@ rerun_in_sandbox (int input_fd)
             "--unshare-ipc",
             "--unshare-net",
             "--unshare-pid",
+            "--tmpfs", "/tmp",
+            "--proc", "/proc",
+            "--dev", "/dev",
             "--ro-bind", "/usr", "/usr",
             "--ro-bind-try", "/etc/ld.so.cache", "/etc/ld.so.cache",
             "--ro-bind", validate_icon, validate_icon,
@@ -306,9 +309,6 @@ rerun_in_sandbox (int input_fd)
     }
 
   add_args (args,
-            "--tmpfs", "/tmp",
-            "--proc", "/proc",
-            "--dev", "/dev",
             "--chdir", "/",
             "--setenv", "GIO_USE_VFS", "local",
             "--unsetenv", "TMPDIR",

--- a/src/validate-sound.c
+++ b/src/validate-sound.c
@@ -255,6 +255,9 @@ rerun_in_sandbox (int input_fd)
             "--unshare-ipc",
             "--unshare-net",
             "--unshare-pid",
+            "--tmpfs", "/tmp",
+            "--proc", "/proc",
+            "--dev", "/dev",
             "--ro-bind", "/usr", "/usr",
             "--ro-bind-try", "/etc/ld.so.cache", "/etc/ld.so.cache",
             "--ro-bind", validate_sound, validate_sound,
@@ -285,9 +288,6 @@ rerun_in_sandbox (int input_fd)
     }
 
   add_args (args,
-            "--tmpfs", "/tmp",
-            "--proc", "/proc",
-            "--dev", "/dev",
             "--chdir", "/",
             "--setenv", "GIO_USE_VFS", "local",
             "--unsetenv", "TMPDIR",


### PR DESCRIPTION
otherwise running from /tmp (e.g. for tests) will fail