### PR TITLE
tests/location: Move GeoClue client mocking to GeoClueClient class

### DIFF
--- a/.github/workflows/Containerfile
+++ b/.github/workflows/Containerfile
@@ -48,7 +48,6 @@ RUN apt install -y --no-install-recommends meson
 RUN apt install -y --no-install-recommends \
     python3-pytest \
     python3-pytest-xdist \
-    python3-dbusmock \
     python3-dbus \
     libumockdev0 \
     libumockdev-dev \
@@ -61,6 +60,9 @@ RUN apt install -y --no-install-recommends python3-pip
 # Install doc dependencies
 RUN pip install --user --break-system-packages furo">=2024.04.27" \
     sphinx-copybutton sphinxext-opengraph matplotlib
+
+# Install latest a newer python-dbusmock required for our pytest setup
+RUN pip install --user --break-system-packages python-dbusmock
 
 # Install pre-commit
 RUN pip install --user --break-system-packages pre-commit

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,5 +1,5 @@
 env:
-  IMAGE_TAG: 20250213-1
+  IMAGE_TAG: 2025-04-17.2
 
 on:
   workflow_call:


### PR DESCRIPTION
```
dbusmock now supports subclassing DBusMockObject and passing that class as parameter to AddObject. This means we can implement methods and properties for the client object only.

It also makes the implementation a bit better by storing the data in appropriet places.
```

Requires an up-to-date dbusmock, so not sure if we want to merge this right now or wait a bit.