### PR TITLE
documents: Log warning when getting the document fuse mountpoint fails

### DIFF
--- a/src/xdp-documents.c
+++ b/src/xdp-documents.c
@@ -45,6 +45,8 @@ gboolean
 xdp_init_document_proxy (GDBusConnection  *connection,
                          GError          **error)
 {
+  g_autoptr(GError) local_error = NULL;
+
   documents = xdp_dbus_documents_proxy_new_sync (connection, 0,
                                                  "org.freedesktop.portal.Documents",
                                                  "/org/freedesktop/portal/documents",
@@ -52,9 +54,14 @@ xdp_init_document_proxy (GDBusConnection  *connection,
   if (!documents)
     return FALSE;
 
-  xdp_dbus_documents_call_get_mount_point_sync (documents,
-                                                &documents_mountpoint,
-                                                NULL, NULL);
+  if (!xdp_dbus_documents_call_get_mount_point_sync (documents,
+                                                     &documents_mountpoint,
+                                                     NULL, &local_error))
+    {
+      g_warning ("Document portal fuse mount point unknown: %s",
+                 local_error->message);
+    }
+
   xdp_set_documents_mountpoint (documents_mountpoint);
 
   return TRUE;


### PR DESCRIPTION
When the document portal didn't start before desktop portals, the fuse mountpoint is unkown. That in turn can create some hard to debug issues, for example when some files in the document portal get reported as deleted when using other portal APIs.

Log a warning at least to make things a bit more obvious.