### PR TITLE
doc: Fix typos in numerous files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -189,7 +189,7 @@ Released: 2023-10-26
 
 - Communicate better when the Background portal kills an app
 - Properly quote Flatpak command in the Background portal
-- Improve documentation of the "cursor_mode" propery of the ScreenCast
+- Improve documentation of the "cursor_mode" property of the ScreenCast
   backend D-Bus interface
 - Fix ScreenCast portal removing transient restore permissions too early.
   This fixes screen sharing dialogs on Chromium asking for the screen multiple
@@ -244,7 +244,7 @@ Released: 2023-08-27
   system components (e.g. MIME types).
 - Various small visual tweaks to the generated documentation
 - Document a new 'accent-color' key in the Settings portal. This key represents
-  an arbitrary color in sRGB colorspace. How implementations of the portal
+  an arbitrary color in sRGB color space. How implementations of the portal
   provide this key is entirely dependent on their internal policies and design.
 - Translation updates
 
@@ -365,7 +365,7 @@ Released: 2021-12-21
 - Place portals in the systemd session.slice
 - settings: Add color-scheme key
 - open-uri: Avoid a sync call to org.freedesktop.FileManager
-- screncast: Allow restoring previous sessions
+- screencast: Allow restoring previous sessions
 - Add a portal for requesting realtime permissions
 - ci: Many improvements
 - Publish the docs from a ci job
@@ -399,7 +399,7 @@ Changes in 1.8.1
 Changes in 1.8.0
 ================
 
-- openuri: Allow skipping the chooser for more URL tyles
+- openuri: Allow skipping the chooser for more URL types
 - openuri: Robustness fixes
 - filechooser: Return the current filter
 - camera: Make the client node visible
@@ -587,7 +587,7 @@ xdg-desktop-portal 0.11
 * Include docs for the session, remote desktop and screencast portals.
 * document-portal: Be more flexible validating apps' IDs.
 * document-portal: Be more strict when checking & granting file access.
-* file-chooser: Fix crash with unitialized data in the save dialog.
+* file-chooser: Fix crash with uninitialized data in the save dialog.
 * open-uri: Don't ever skip showing the dialog if a threshold is set.
 * open-uri: Don't register http: URIs for sandboxed handlers.
 * remote-desktop: Use the correct device type values.

--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ and others.
 Documentation about the Common Conventions, as well as documentation for
 App Developers, Desktop Developers and Contributors can be found
 [here](https://flatpak.github.io/xdg-desktop-portal/docs/).
-
-

--- a/data/org.freedesktop.impl.portal.Account.xml
+++ b/data/org.freedesktop.impl.portal.Account.xml
@@ -46,7 +46,7 @@
 
         * ``reason`` (``s``)
 
-          A string that can be shown in the dialog to expain why the information is needed.
+          A string that can be shown in the dialog to explain why the information is needed.
           This should be a complete sentence that explains what the application will do with
           the returned information, for example: Allows your personal information to be included
           with recipes you share with your friends.

--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -112,7 +112,7 @@
         @parent_window: Identifier for the application window, see :doc:`window-identifiers`
         @options: Vardict with optional further information
 
-        Request showing a configuration UI so the user is able to conigure all shortcuts of this session.
+        Request showing a configuration UI so the user is able to configure all shortcuts of this session.
 
         Supported keys in the @options vardict include:
 

--- a/data/org.freedesktop.impl.portal.InputCapture.xml
+++ b/data/org.freedesktop.impl.portal.InputCapture.xml
@@ -378,7 +378,7 @@
         SupportedCapabilities:
 
         A bitmask of supported capabilities. This list is constant, it is not the list of
-        capabilities currently available but rather which capabilies are
+        capabilities currently available but rather which capabilities are
         implemented by the portal.
 
         Applications must ignore unknown capabilities.

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -39,7 +39,7 @@
 
       The #org.freedesktop.portal.GlobalShortcuts::Activated and
       #org.freedesktop.portal.GlobalShortcuts::Deactivated signals are emitted,
-      respecitvely, whenever a shortcut is activated and deactivated.
+      respectively, whenever a shortcut is activated and deactivated.
 
       This documentation describes version 2 of this interface.
   -->
@@ -189,7 +189,7 @@
         @parent_window: Identifier for the application window, see :doc:`window-identifiers`
         @options: Vardict with optional further information
 
-        Request showing a configuration UI so the user is able to conigure all shortcuts of this session.
+        Request showing a configuration UI so the user is able to configure all shortcuts of this session.
 
         Supported keys in the @options vardict include:
 

--- a/data/org.freedesktop.portal.InputCapture.xml
+++ b/data/org.freedesktop.portal.InputCapture.xml
@@ -208,7 +208,7 @@
         - right edge of right screen: `x1=3840, y1=0, x2=3840, y1=1079`
 
         A pointer barrier is considered triggered when the pointer would
-        logically move off that zone, even if the actual cusor movement is
+        logically move off that zone, even if the actual cursor movement is
         clipped to the zone.
 
         A zero-sized array of pointer barriers removes all existing pointer barriers

--- a/data/org.freedesktop.portal.Usb.xml
+++ b/data/org.freedesktop.portal.Usb.xml
@@ -204,7 +204,7 @@
         @options: Vardict with optional further information
 
         Releases previously acquired devices. The file descriptors of
-        thoses devices might become unusable as a result of this.
+        those devices might become unusable as a result of this.
 
         Each element of the @devices array contains the device ID of the device.
 
@@ -219,7 +219,7 @@
     <!--
         DeviceEvents:
         @session_handle: Object path for the :ref:`org.freedesktop.portal.Session` object
-        @events: A list of events which occured.
+        @events: A list of events which occurred.
 
         The DeviceEvents signal is emitted when one or more USB devices have
         been added, changed, or removed. This signal is only emitted for active

--- a/doc/for-desktop-developers.rst
+++ b/doc/for-desktop-developers.rst
@@ -77,7 +77,7 @@ Background Apps Monitor
 -----------------------
 
 In addition to managing the regular interfaces that sandboxed applications
-use to interfact with the host system, XDG Desktop Portal also monitors
+use to interface with the host system, XDG Desktop Portal also monitors
 running applications without an active window - if the portal backend
 provides an implementation of the Background portal.
 

--- a/doc/usb-portal.md
+++ b/doc/usb-portal.md
@@ -26,7 +26,7 @@ and `--nousb` arguments against `flatpak build-finish` and `flatpak
 run`. Neither `--devices=all` nor `--device=usb` do influence the
 portal.
 
-Hidding a device always take precedence over making them enumerable,
+Hiding a device always take precedence over making them enumerable,
 even when a blanket permission (`--usb=all`) is set.
 
 However out of the sandbox we assume all devices are allowed as there
@@ -91,7 +91,7 @@ In the case of libusb 1.0.23 and later, use `libusb_wrap_sys_device()`
 and pass the file descriptor as the `sys_dev` argument.  It should be
 noted that libusb must be compiled with udev support (it is the
 default) in order to be able to work. Without this it looks for the
-non existant `/dev/usb` that is not present.
+nonexistent `/dev/usb` that is not present.
 
 If you use libhidapi, you need to use the function
 `hid_libusb_wrap_sys_device()` provided by libhidapi-usb.
@@ -107,7 +107,7 @@ possible to hard-cut app access right when the app permission changes.
 to influence which other udev properties are fetched. This approach is
 open to suggestions - it may be necessary to expose more information
 more liberally through the portal. The initial attempt has been made
-to provide sensible information usefull for display in a user
+to provide sensible information useful for display in a user
 interface.
 
 [^3]: This is clearly not ideal. The ideal approach is to go through


### PR DESCRIPTION
Took the liberty of fixing more typos throughout the repo and removing newlines in the README.

Some typos were in NEWS, I looked if they corresponded to commit messages, but it seemed like they didn't, so I corrected those typos. If these are undesired changes, I'll remove them.