### PR TITLE
xdp-utils: Try PIDFD_GET_PID_NAMESPACE ioctl first to get pidns

### DIFF
--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -393,7 +393,7 @@ xdp_app_info_get_pidns (XdpAppInfo  *app_info,
       return FALSE;
     }
 
-  if (!xdp_pid_dirfd_get_pidns (priv->pidfd, &ns, error))
+  if (!xdp_pidfd_get_pidns (priv->pidfd, &ns, error))
     return FALSE;
 
   priv->pidns_id = ns;

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -393,7 +393,7 @@ xdp_app_info_get_pidns (XdpAppInfo  *app_info,
       return FALSE;
     }
 
-  if (!xdp_pidfd_get_namespace (priv->pidfd, &ns, error))
+  if (!xdp_pid_dirfd_get_pidns (priv->pidfd, &ns, error))
     return FALSE;
 
   priv->pidns_id = ns;

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -130,7 +130,7 @@ gboolean xdp_pidfds_to_pids (const int  *pidfds,
                              gint        count,
                              GError    **error);
 
-gboolean xdp_pidfd_get_namespace (int      pidfd,
+gboolean xdp_pid_dirfd_get_pidns (int      pid_dirfd,
                                   ino_t   *ns,
                                   GError **error);
 

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -130,9 +130,9 @@ gboolean xdp_pidfds_to_pids (const int  *pidfds,
                              gint        count,
                              GError    **error);
 
-gboolean xdp_pid_dirfd_get_pidns (int      pid_dirfd,
-                                  ino_t   *ns,
-                                  GError **error);
+gboolean xdp_pidfd_get_pidns (int      pidfd,
+                              ino_t   *ns,
+                              GError **error);
 
 gboolean xdp_map_pids_full (DIR     *proc,
                             ino_t    pidns,


### PR DESCRIPTION
The ioctl is the less brittle path to get the pid namespace from a pidfd, so let's try it first, and if the kernel doesn't support it, fall back to the previous code path.