### PR TITLE
configuration: Allow fallbacks from XDG_DESKTOP_PORTAL_DIR.

### DIFF
--- a/src/xdp-portal-impl.c
+++ b/src/xdp-portal-impl.c
@@ -501,9 +501,8 @@ load_portal_configuration (gboolean opt_verbose)
 
   if (portal_dir != NULL)
     {
-      load_config_directory (portal_dir, desktops, opt_verbose);
-      /* All other config directories are ignored when this is set */
-      return;
+      if (load_config_directory (portal_dir, desktops, opt_verbose))
+        return;
     }
 
   /* $XDG_CONFIG_HOME/xdg-desktop-portal/(DESKTOP-)portals.conf */


### PR DESCRIPTION
When XDG_DESKTOP_PORTAL_DIR is set, it causes the rest of the search mechanism to be aborted.  Instead allow the search to continue.

* src/xdp-portal-impl.c (load_portal_configuration): Return only in case a match was found from XDG_DESKTOP_PORTAL_DIR.