### PR TITLE
app-info/flatpak: Steal bwrap pidfd because AppInfo doesn't dup anymore

### DIFF
--- a/src/xdp-app-info-flatpak.c
+++ b/src/xdp-app-info-flatpak.c
@@ -823,7 +823,7 @@ xdp_app_info_flatpak_new (int      pid,
                                      "flags", flags,
                                      "id", id,
                                      "instance", instance,
-                                     "pidfd", bwrap_pidfd,
+                                     "pidfd", g_steal_fd (&bwrap_pidfd),
                                      NULL);
 
   app_info_flatpak->flatpak_info = g_steal_pointer (&metadata);


### PR DESCRIPTION
Fixes: 2d8c2472 ("app-info: Steal pidfd when constructing a XdpAppInfo")
Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1719