### PR TITLE
app-info: Clarify pid file descriptor ownership transfers

### DIFF
--- a/src/xdp-app-info-flatpak.c
+++ b/src/xdp-app-info-flatpak.c
@@ -717,6 +717,11 @@ xdp_is_flatpak (int        pid,
   return TRUE;
 }
 
+/*
+ * @pidfd: (inout) (not nullable): Pointer to process ID file descriptor.
+ *  This function may take ownership of the fd. If it does, it will
+ *  set `*pidfd` to -1.
+ */
 XdpAppInfo *
 xdp_app_info_flatpak_new (int      pid,
                           int     *pidfd,

--- a/src/xdp-app-info-host.c
+++ b/src/xdp-app-info-host.c
@@ -185,6 +185,11 @@ get_appid_from_pid (pid_t pid)
 #endif /* HAVE_LIBSYSTEMD */
 }
 
+/*
+ * @pidfd: (inout) (not nullable): Pointer to process ID file descriptor.
+ *  This function may take ownership of the fd. If it does, it will
+ *  set `*pidfd` to -1.
+ */
 XdpAppInfo *
 xdp_app_info_host_new_registered (int         *pidfd,
                                   const char  *app_id,
@@ -206,6 +211,11 @@ xdp_app_info_host_new_registered (int         *pidfd,
   return XDP_APP_INFO (g_steal_pointer (&app_info_host));
 }
 
+/*
+ * @pidfd: (inout) (not nullable): Pointer to process ID file descriptor.
+ *  This function may take ownership of the fd. If it does, it will
+ *  set `*pidfd` to -1.
+ */
 XdpAppInfo *
 xdp_app_info_host_new (int  pid,
                        int *pidfd)

--- a/src/xdp-app-info-snap.c
+++ b/src/xdp-app-info-snap.c
@@ -251,6 +251,11 @@ xdp_is_snap (int        pid,
     }
 }
 
+/*
+ * @pidfd: (inout) (not nullable): Pointer to process ID file descriptor.
+ *  This function may take ownership of the fd. If it does, it will
+ *  set `*pidfd` to -1.
+ */
 XdpAppInfo *
 xdp_app_info_snap_new (int      pid,
                        int     *pidfd,

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -224,6 +224,7 @@ xdp_app_info_set_property (GObject      *object,
 
     case PROP_PIDFD:
       g_assert (priv->pidfd == -1);
+      /* Steals ownership from the GValue */
       priv->pidfd = g_value_get_int (value);
       break;
 
@@ -277,6 +278,8 @@ xdp_app_info_class_init (XdpAppInfoClass *klass)
                          G_PARAM_CONSTRUCT_ONLY |
                          G_PARAM_STATIC_STRINGS);
 
+  /* Note that setting this property at construct-time takes ownership
+   * of the fd from the caller */
   properties[PROP_PIDFD] =
     g_param_spec_int ("pidfd", NULL, NULL,
                       -1, G_MAXINT, -1,


### PR DESCRIPTION
Follow-up for #1721.