### PR TITLE
app-info: Don't require a .desktop file for Flatpak and Snap apps

### DIFF
--- a/src/xdp-app-info-flatpak.c
+++ b/src/xdp-app-info-flatpak.c
@@ -811,7 +811,6 @@ xdp_app_info_flatpak_new (int      pid,
 
   /* TODO: we can use pidfd to make sure we didn't race for sure */
 
-  flags |= XDP_APP_INFO_FLAG_REQUIRE_GAPPINFO;
   flags |= XDP_APP_INFO_FLAG_SUPPORTS_OPATH;
   if (has_network)
     flags |= XDP_APP_INFO_FLAG_HAS_NETWORK;

--- a/src/xdp-app-info-snap.c
+++ b/src/xdp-app-info-snap.c
@@ -58,7 +58,6 @@ xdp_app_info_snap_create_gappinfo (XdpAppInfo *app_info)
 
   gappinfo =
     G_APP_INFO (g_desktop_app_info_new (app_info_snap->desktop_file));
-  g_assert (G_IS_APP_INFO (gappinfo));
 
   return g_steal_pointer (&gappinfo);
 }
@@ -310,7 +309,6 @@ xdp_app_info_snap_new (int      pid,
                                         SNAP_METADATA_KEY_NETWORK,
                                         NULL);
 
-  flags = XDP_APP_INFO_FLAG_REQUIRE_GAPPINFO;
   if (has_network)
     flags |= XDP_APP_INFO_FLAG_HAS_NETWORK;
 


### PR DESCRIPTION
* app-info: Don't require a .desktop file for Flatpak apps
    
    Several portal interfaces like Background, Location and Wallpaper
    try to use a "main" .desktop file from the sandboxed app to provide
    a "friendly name" and/or an icon. However, not all Flatpak apps export
    a .desktop file of the same name as their app-ID, as demonstrated by
    org.gnome.NautilusPreviewer. Portal interfaces like Background are
    expected to fall back to displaying the app-ID if they cannot derive a
    "friendly name" from the .desktop file.
    
    Restore the 1.20.0 functionality by not requiring a GAppInfo
    (.desktop file)
    
    Resolves: https://github.com/flatpak/xdg-desktop-portal/issues/1718

* app-info: Don't require a .desktop file for Snap apps
    
    It isn't clear to me whether Snap apps can lack a "main" .desktop file,
    but before 1.20.0 we didn't require it, and we need to be able to cope
    with absence of a .desktop file *anyway* (for host and Flatpak apps),
    so the conservative thing to do here is to not require it.
    
    I've made this its own commit, so that it can be reverted if a Snap
    expert tells us that this is a "can't happen" situation.

----

The practical result of this branch is that the only apps that require a .desktop file are host apps that call into `org.freedesktop.host.portal.Registry`, which is inherently opt-in.