### PR TITLE
global-shortcuts: use typed array builder for BindShortcuts

### DIFF
--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -384,7 +384,7 @@ handle_bind_shortcuts (XdpDbusGlobalShortcuts *object,
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GVariant) shortcuts = NULL;
   g_auto(GVariantBuilder) shortcuts_builder =
-    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("a(sa{sv})"));
   g_auto(GVariantBuilder) options_builder =
     G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 

--- a/tests/test_globalshortcuts.py
+++ b/tests/test_globalshortcuts.py
@@ -137,6 +137,51 @@ class TestGlobalShortcuts:
         session.close()
         xdp.wait_for(lambda: session.closed)
 
+    def test_bind_no_shortcuts(self, portals, dbus_con):
+        globalshortcuts_intf = xdp.get_portal_iface(dbus_con, "GlobalShortcuts")
+
+        request = xdp.Request(dbus_con, globalshortcuts_intf)
+        options = {
+            "session_handle_token": "session_token0",
+        }
+        response = request.call(
+            "CreateSession",
+            options=options,
+        )
+
+        assert response
+        assert response.response == 0
+
+        session = xdp.Session.from_response(dbus_con, response)
+
+        request = xdp.Request(dbus_con, globalshortcuts_intf)
+        response = request.call(
+            "BindShortcuts",
+            session_handle=session.handle,
+            shortcuts=[],
+            parent_window="",
+            options={},
+        )
+
+        assert response
+        assert response.response == 0
+
+        request = xdp.Request(dbus_con, globalshortcuts_intf)
+        options = {}
+        response = request.call(
+            "ListShortcuts",
+            session_handle=session.handle,
+            options=options,
+        )
+
+        assert response
+        assert response.response == 0
+
+        assert len(list(response.results["shortcuts"])) == 0
+
+        session.close()
+        xdp.wait_for(lambda: session.closed)
+
     def test_trigger(self, portals, dbus_con):
         globalshortcuts_intf = xdp.get_portal_iface(dbus_con, "GlobalShortcuts")
         mock_intf = xdp.get_mock_iface(dbus_con)


### PR DESCRIPTION
`shortcuts_builder` only obtains a definite array type when `xdp_verify_shortcuts` add an element to it, but this only happens if a non-empty list of shortcuts has been passed to `BindShortcuts` dbus call. In case an empty list was passed, xdg-desktop-portal would crash when the (empty and untyped) shortcut array is serialized.

This commit switch `shortcuts_builder` to be initialized with a definite array type, making sure that the built `GVariant` would have the correct type even if no entry was added to it.