### PR TITLE
Replace PipeWire and WirePlumber modules with in-tree modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       packages: write
     with:
-      image: xdg-desktop-portal:2026-06-08.1
+      image: xdg-desktop-portal:2026-06-23.1
       containerfile: containerfiles/build.containerfile
 
   check-container:

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/containerfiles/build.containerfile
+++ b/containerfiles/build.containerfile
@@ -37,6 +37,8 @@ RUN apt install -y --no-install-recommends \
     libgudev-1.0-dev \
     libjson-glib-dev \
     libpipewire-0.3-dev \
+    libdbus-1-dev \
+    libwireplumber-0.5-dev \
     libsystemd-dev \
     libtool \
     llvm \

--- a/desktop-portal/camera.c
+++ b/desktop-portal/camera.c
@@ -219,8 +219,8 @@ open_pipewire_camera_remote (const char *app_id,
   struct pw_properties *pipewire_properties;
 
   pipewire_properties =
-    pw_properties_new ("pipewire.access.portal.app_id", app_id,
-                       "pipewire.access.portal.media_roles", "Camera",
+    pw_properties_new ("pipewire.access.xdg-desktop-portal.app_id", app_id,
+                       "pipewire.access.xdg-desktop-portal.media_roles", "Camera",
                        NULL);
   remote = pipewire_remote_new_sync (pipewire_properties,
                                      NULL, NULL, NULL, NULL,
@@ -416,8 +416,8 @@ create_pipewire_remote (Camera *camera,
       return FALSE;
     }
 
-  pipewire_properties = pw_properties_new ("pipewire.access.portal.is_portal", "true",
-                                           "portal.monitor", "Camera",
+  pipewire_properties = pw_properties_new ("pipewire.access.xdg-desktop-portal.is_portal", "true",
+                                           "xdg-desktop-portal.monitor", "Camera",
                                            NULL);
   camera->pipewire_remote = pipewire_remote_new_sync (pipewire_properties,
                                                       global_added_cb,

--- a/desktop-portal/screen-cast.c
+++ b/desktop-portal/screen-cast.c
@@ -691,8 +691,8 @@ open_pipewire_screen_cast_remote (const char *app_id,
   PipeWireRemote *remote;
   g_autoptr(GArray) permission_items = NULL;
 
-  pipewire_properties = pw_properties_new ("pipewire.access.portal.app_id", app_id,
-                                           "pipewire.access.portal.media_roles", "",
+  pipewire_properties = pw_properties_new ("pipewire.access.xdg-desktop-portal.app_id", app_id,
+                                           "pipewire.access.xdg-desktop-portal.media_roles", "",
                                            NULL);
   remote = pipewire_remote_new_sync (pipewire_properties,
                                      NULL, NULL, NULL, NULL,

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -12,3 +12,4 @@ of XDG Desktop Portal.
    :maxdepth: 1
 
    documents-and-fuse
+   pipewire

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -95,6 +95,7 @@ if build_documentation
     'impl-dbus-interfaces.rst',
     'index.rst',
     'merge-requirements.rst',
+    'pipewire.rst',
     'pull-requests.rst',
     'reasons-to-use-portals.rst',
     'requests.rst',

--- a/doc/pipewire.rst
+++ b/doc/pipewire.rst
@@ -1,0 +1,53 @@
+..
+   SPDX-License-Identifier: LGPL-2.1-or-later
+   SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+
+PipeWire
+========
+
+Some portals relies on giving access to PipeWire nodes to applications.
+
+xdg-desktop-portal provides configuration files to enable its PipeWire module and
+WirePlumber plugin.
+
+PipeWire module
+---------------
+
+This module performs access control management for clients created by
+xdg-desktop-portal.
+
+It connects to the session DBus and subscribes to ``NameOwnerChanged`` signals
+of the ``org.freedesktop.portal.Desktop`` name.
+The PID of the DBus name owner is xdg-desktop-portal.
+
+A client connection from xdg-desktop-portal PID to PipeWire gets assigned a
+``PW_KEY_ACCESS`` set to ``"xdg-desktop-portal"`` and set to permissions ``ALL``.
+
+It is the responsibility of a portal internal to limit the permissions before
+passing the connection on to the application. See `PipeWire Access Control
+<https://docs.pipewire.org/page_access.html>`_ for details on permissions.
+
+Clients connecting from other PIDs are ignored by this module.
+
+WirePlumber plugin
+------------------
+
+This plugin performs node access control for clients created by xdg-desktop-portal
+at the `session manager  <https://docs.pipewire.org/page_session_manager.html>`_
+level.
+
+An object manager watches for clients with ``PW_KEY_ACCESS`` set to
+``"xdg-desktop-portal"`` and ``PW_KEY_ACCESS_XDP_APP_ID`` assigned to a value.
+
+Camera
+""""""
+
+A node is considered a camera if ``PW_KEY_MEDIA_ROLE`` is set to ``"Camera"``
+and ``PW_KEY_MEDIA_CLASS`` to ``"Video/Source"``.
+
+If xdg-desktop-portal assigned ``PW_KEY_ACCESS_XDP_MEDIA_ROLES`` to ``"Camera"``
+to the PipeWire client, access to every node considered as camera will be
+granted to the client.
+
+An object manager is set to watch node considered as camera, to update allowed
+clients if a new matching node is added.

--- a/goblint.toml
+++ b/goblint.toml
@@ -5,5 +5,6 @@ min_glib_version = "2.76"
 ignore = [
   "subprojects/**",
   "document-portal/gvdb/**",
+  "pipewire/pw-module/**",
 ]
 default_level = "error"

--- a/meson.build
+++ b/meson.build
@@ -44,8 +44,18 @@ endif
 pipewire_dep_base_name = 'pipewire-0.3'
 pipewire_module_dir = libdir / pipewire_dep_base_name
 
+pipewire_conf_d_dir = get_option('pipewire-drop-in-conf-dir')
+if pipewire_conf_d_dir == ''
+  pipewire_conf_d_dir = prefix / datadir / 'pipewire' / 'pipewire.conf.d'
+endif
+
 wireplumber_dep_name = 'wireplumber-0.5'
 wireplumber_module_dir = libdir / wireplumber_dep_name
+
+wireplumber_conf_d_dir = get_option('wireplumber-conf-fragments-dir')
+if wireplumber_conf_d_dir == ''
+  wireplumber_conf_d_dir = prefix / datadir / 'wireplumber' / 'wireplumber.conf.d'
+endif
 
 dataroot_dir = get_option('datarootdir')
 if dataroot_dir == ''
@@ -61,7 +71,9 @@ summary({
 	'Flatpak interfaces dir': flatpak_intf_dir,
 	'systemd user unit dir': systemd_userunit_dir,
 	'PipeWire module dir': pipewire_module_dir,
+	'PipeWire drop-in configuration dir:': pipewire_conf_d_dir,
 	'WirePlumber module dir': wireplumber_module_dir,
+	'WirePlumber configuration fragments dir': wireplumber_conf_d_dir,
 	'Installed tests dir': installed_tests_dir,
 	},
 	section: 'Directories',
@@ -148,7 +160,7 @@ geoclue_dep = dependency(
   version: '>= 2.5.2',
   required: get_option('geoclue'),
 )
-pipewire_dep = dependency(f'lib@pipewire_dep_base_name@', version: '>= 1.0.2')
+pipewire_dep = dependency(f'lib@pipewire_dep_base_name@', version: '>= 1.3.81')
 libdbus_dep = dependency('dbus-1')
 wireplumber_dep = dependency(wireplumber_dep_name)
 libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,9 @@ if systemd_userunit_dir == ''
     systemd_userunit_dir = prefix / 'lib' / 'systemd' / 'user'
 endif
 
+pipewire_dep_base_name = 'pipewire-0.3'
+pipewire_module_dir = libdir / pipewire_dep_base_name
+
 dataroot_dir = get_option('datarootdir')
 if dataroot_dir == ''
     dataroot_dir = datadir
@@ -54,6 +57,7 @@ summary({
 	'DBus service dir': dbus_service_dir,
 	'Flatpak interfaces dir': flatpak_intf_dir,
 	'systemd user unit dir': systemd_userunit_dir,
+	'PipeWire module dir': pipewire_module_dir,
 	'Installed tests dir': installed_tests_dir,
 	},
 	section: 'Directories',
@@ -140,7 +144,8 @@ geoclue_dep = dependency(
   version: '>= 2.5.2',
   required: get_option('geoclue'),
 )
-pipewire_dep = dependency('libpipewire-0.3', version: '>= 0.2.90')
+pipewire_dep = dependency(f'lib@pipewire_dep_base_name@', version: '>= 0.2.90')
+libdbus_dep = dependency('dbus-1')
 libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))
 gudev_dep = dependency('gudev-1.0', required: get_option('gudev'))
 umockdev_dep = dependency('umockdev-1.0', required: get_option('tests'))
@@ -237,6 +242,7 @@ subdir('data')
 subdir('shared')
 subdir('desktop-portal')
 subdir('document-portal')
+subdir('pipewire')
 subdir('po')
 subdir('doc')
 

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,9 @@ endif
 pipewire_dep_base_name = 'pipewire-0.3'
 pipewire_module_dir = libdir / pipewire_dep_base_name
 
+wireplumber_dep_name = 'wireplumber-0.5'
+wireplumber_module_dir = libdir / wireplumber_dep_name
+
 dataroot_dir = get_option('datarootdir')
 if dataroot_dir == ''
     dataroot_dir = datadir
@@ -58,6 +61,7 @@ summary({
 	'Flatpak interfaces dir': flatpak_intf_dir,
 	'systemd user unit dir': systemd_userunit_dir,
 	'PipeWire module dir': pipewire_module_dir,
+	'WirePlumber module dir': wireplumber_module_dir,
 	'Installed tests dir': installed_tests_dir,
 	},
 	section: 'Directories',
@@ -144,8 +148,9 @@ geoclue_dep = dependency(
   version: '>= 2.5.2',
   required: get_option('geoclue'),
 )
-pipewire_dep = dependency(f'lib@pipewire_dep_base_name@', version: '>= 0.2.90')
+pipewire_dep = dependency(f'lib@pipewire_dep_base_name@', version: '>= 1.0.2')
 libdbus_dep = dependency('dbus-1')
+wireplumber_dep = dependency(wireplumber_dep_name)
 libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))
 gudev_dep = dependency('gudev-1.0', required: get_option('gudev'))
 umockdev_dep = dependency('umockdev-1.0', required: get_option('tests'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -57,3 +57,11 @@ option('sandboxed-sound-validation',
        type: 'feature',
        value: 'enabled',
        description: 'Use Bubblewrap to sandbox sound validation. Disabling this option may lead to security vulnerabilities.')
+option('pipewire-drop-in-conf-dir',
+       type: 'string',
+       value: '',
+       description: 'directory for PipeWire drop-in configuration files (default: PREFIX/share/pipewire/pipewire.conf.d)')
+option('wireplumber-conf-fragments-dir',
+       type: 'string',
+       value: '',
+       description: 'directory for WirePlumber configuration fragments (default: PREFIX/share/wireplumber/wireplumber.d)')

--- a/pipewire/meson.build
+++ b/pipewire/meson.build
@@ -3,3 +3,15 @@
 
 subdir('pw-module')
 subdir('wp-plugin')
+
+install_data(
+  'pipewire.conf',
+  rename: '10-xdg-desktop-portal.conf',
+  install_dir: pipewire_conf_d_dir,
+)
+
+install_data(
+  'wireplumber.conf',
+  rename: '10-xdg-desktop-portal.conf',
+  install_dir: wireplumber_conf_d_dir,
+)

--- a/pipewire/meson.build
+++ b/pipewire/meson.build
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+
+subdir('pw-module')

--- a/pipewire/meson.build
+++ b/pipewire/meson.build
@@ -2,3 +2,4 @@
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
 subdir('pw-module')
+subdir('wp-plugin')

--- a/pipewire/pipewire.conf
+++ b/pipewire/pipewire.conf
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+
+context.properties = {
+    # Disable first-party portal module to be replaced with xdg-desktop-portal
+    # own module
+    module.portal = false
+}
+
+context.modules = {
+    { name = libxdg-desktop-portal
+        flags = [ ifexists ]
+        condition = [ { module.xdp-desktop-portal = !false } ]
+    }
+
+}

--- a/pipewire/pw-module/meson.build
+++ b/pipewire/pw-module/meson.build
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+
+xdp_pipewire_module_sources = [
+  'module-portal.c',
+]
+
+xdp_pipewire_module = shared_library(
+  'xdg-desktop-portal',
+  xdp_pipewire_module_sources,
+  dependencies: [pipewire_dep, libdbus_dep],
+  install_dir: pipewire_module_dir,
+)

--- a/pipewire/pw-module/meson.build
+++ b/pipewire/pw-module/meson.build
@@ -9,5 +9,6 @@ xdp_pipewire_module = shared_library(
   'xdg-desktop-portal',
   xdp_pipewire_module_sources,
   dependencies: [pipewire_dep, libdbus_dep],
+  install: true,
   install_dir: pipewire_module_dir,
 )

--- a/pipewire/pw-module/module-portal.c
+++ b/pipewire/pw-module/module-portal.c
@@ -1,0 +1,320 @@
+/* PipeWire */
+/* SPDX-FileCopyrightText: Copyright © 2016 Wim Taymans <wim.taymans@gmail.com> */
+/* SPDX-FileCopyrightText: Copyright © 2019 Red Hat Inc. */
+/* SPDX-License-Identifier: MIT */
+
+#include "config.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <dbus/dbus.h>
+
+#include <spa/utils/string.h>
+#include <spa/utils/result.h>
+#include <spa/support/dbus.h>
+#include <spa-private/dbus-helpers.h>
+
+#include "pipewire/context.h"
+#include "pipewire/impl-client.h"
+#include "pipewire/log.h"
+#include "pipewire/module.h"
+#include "pipewire/utils.h"
+
+/** \page page_module_portal Portal
+ *
+ * The `portal` module performs access control management for clients started
+ * inside an XDG portal.
+ *
+ * The module connects to the session DBus and subscribes to
+ * `NameOwnerChanged` signals for the `org.freedesktop.portal.Desktop` name.
+ * The PID of the DBus name owner is the portal.
+ *
+ * A client connection from the portal PID to PipeWire gets assigned a \ref
+ * PW_KEY_ACCESS of `"portal"` and set to permissions ALL - it is the
+ * responsibility of the portal to limit the permissions before passing the
+ * connection on to the client. See \ref page_access for details on
+ * permissions.
+ *
+ * Clients connecting from other PIDs are ignored by this module.
+ *
+ * ## Module Name
+ *
+ * `libpipewire-module-portal`
+ *
+ * ## Module Options
+ *
+ * There are no module-specific options.
+ *
+ * ## General options
+ *
+ * There are no general options for this module.
+ *
+ * ## Example configuration
+ *\code{.unparsed}
+ * context.modules = [
+ *  {   name = libpipewire-module-portal }
+ * ]
+ *\endcode
+ *
+ */
+
+#define NAME "portal"
+
+#define PORTAL_SERVICE_NAME "org.freedesktop.portal.Desktop"
+
+PW_LOG_TOPIC_STATIC(mod_topic, "mod." NAME);
+#define PW_LOG_TOPIC_DEFAULT mod_topic
+
+struct impl {
+	struct pw_context *context;
+	struct pw_properties *properties;
+
+	struct spa_dbus_connection *conn;
+	DBusConnection *bus;
+
+	struct spa_hook context_listener;
+	struct spa_hook module_listener;
+
+	DBusPendingCall *portal_pid_pending;
+	pid_t portal_pid;
+};
+
+static void
+context_check_access(void *data, struct pw_impl_client *client)
+{
+	struct impl *impl = data;
+	const struct pw_properties *props;
+	struct pw_permission permissions[1];
+	struct spa_dict_item items[1];
+	pid_t pid;
+
+	if (impl->portal_pid == 0)
+		return;
+
+	if ((props = pw_impl_client_get_properties(client)) == NULL)
+		return;
+
+	if (pw_properties_fetch_int32(props, PW_KEY_SEC_PID, &pid) < 0)
+		return;
+
+	if (pid != impl->portal_pid)
+		return;
+
+	items[0] = SPA_DICT_ITEM_INIT(PW_KEY_ACCESS, "portal");
+	pw_impl_client_update_properties(client, &SPA_DICT_INIT(items, 1));
+
+	pw_log_info("%p: portal managed client %p added", impl, client);
+
+	/* portal makes this connection and will change the permissions before
+	 * handing this connection to the client */
+	permissions[0] = PW_PERMISSION_INIT(PW_ID_ANY, PW_PERM_ALL);
+	pw_impl_client_update_permissions(client, 1, permissions);
+	return;
+}
+
+static const struct pw_context_events context_events = {
+	PW_VERSION_CONTEXT_EVENTS,
+	.check_access = context_check_access,
+};
+
+static void module_destroy(void *data)
+{
+	struct impl *impl = data;
+
+	spa_hook_remove(&impl->context_listener);
+	spa_hook_remove(&impl->module_listener);
+
+	cancel_and_unref(&impl->portal_pid_pending);
+
+	if (impl->bus)
+		dbus_connection_unref(impl->bus);
+	spa_dbus_connection_destroy(impl->conn);
+
+	pw_properties_free(impl->properties);
+
+	free(impl);
+}
+
+static const struct pw_impl_module_events module_events = {
+	PW_VERSION_IMPL_MODULE_EVENTS,
+	.destroy = module_destroy,
+};
+
+static void on_portal_pid_received(DBusPendingCall *pending,
+				   void *user_data)
+{
+	struct impl *impl = user_data;
+	uint32_t portal_pid = 0;
+
+	spa_assert(impl->portal_pid_pending == pending);
+	spa_autoptr(DBusMessage) m = steal_reply_and_unref(&impl->portal_pid_pending);
+
+	if (!m) {
+		pw_log_error("Failed to receive portal pid");
+		return;
+	}
+	if (dbus_message_is_error(m, DBUS_ERROR_NAME_HAS_NO_OWNER)) {
+		pw_log_info("Portal is not running");
+		return;
+	}
+	if (dbus_message_get_type(m) == DBUS_MESSAGE_TYPE_ERROR) {
+		const char *message = "unknown";
+		dbus_message_get_args(m, NULL, DBUS_TYPE_STRING, &message, DBUS_TYPE_INVALID);
+		pw_log_warn("Failed to receive portal pid: %s: %s",
+				dbus_message_get_error_name(m), message);
+		return;
+	}
+
+	spa_auto(DBusError) error = DBUS_ERROR_INIT;
+	dbus_message_get_args(m, &error, DBUS_TYPE_UINT32, &portal_pid,
+			      DBUS_TYPE_INVALID);
+
+	if (dbus_error_is_set(&error)) {
+		impl->portal_pid = 0;
+		pw_log_warn("Could not get portal pid: %s", error.message);
+	} else {
+		pw_log_info("Got portal pid %d", portal_pid);
+		impl->portal_pid = portal_pid;
+	}
+}
+
+static void update_portal_pid(struct impl *impl)
+{
+	impl->portal_pid = 0;
+	cancel_and_unref(&impl->portal_pid_pending);
+
+	spa_autoptr(DBusMessage) m = dbus_message_new_method_call("org.freedesktop.DBus",
+								  "/org/freedesktop/DBus",
+								  "org.freedesktop.DBus",
+								  "GetConnectionUnixProcessID");
+	if (!m)
+		return;
+
+	if (!dbus_message_append_args(m,
+				      DBUS_TYPE_STRING, &(const char *){ PORTAL_SERVICE_NAME },
+				      DBUS_TYPE_INVALID))
+		return;
+
+	impl->portal_pid_pending = send_with_reply(impl->bus, m, on_portal_pid_received, impl);
+}
+
+static DBusHandlerResult name_owner_changed_handler(DBusConnection *connection,
+						    DBusMessage *message,
+						    void *user_data)
+{
+	struct impl *impl = user_data;
+	const char *name;
+	const char *old_owner;
+	const char *new_owner;
+
+	if (!dbus_message_is_signal(message, "org.freedesktop.DBus",
+				   "NameOwnerChanged"))
+		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+
+	if (!dbus_message_get_args(message, NULL,
+				   DBUS_TYPE_STRING, &name,
+				   DBUS_TYPE_STRING, &old_owner,
+				   DBUS_TYPE_STRING, &new_owner,
+				   DBUS_TYPE_INVALID)) {
+		pw_log_error("Failed to get OwnerChanged args");
+		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+	}
+
+	if (!spa_streq(name, PORTAL_SERVICE_NAME))
+		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+
+	if (spa_streq(new_owner, "")) {
+		impl->portal_pid = 0;
+		cancel_and_unref(&impl->portal_pid_pending);
+	}
+	else {
+		update_portal_pid(impl);
+	}
+
+	return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+static int init_dbus_connection(struct impl *impl)
+{
+	impl->bus = spa_dbus_connection_get(impl->conn);
+	if (impl->bus == NULL)
+		return -EIO;
+
+	/* XXX: we don't handle dbus reconnection yet, so ref the handle instead */
+	dbus_connection_ref(impl->bus);
+
+	spa_auto(DBusError) error = DBUS_ERROR_INIT;
+
+	dbus_bus_add_match(impl->bus,
+			   "type='signal',\
+			   sender='org.freedesktop.DBus',\
+			   interface='org.freedesktop.DBus',\
+			   member='NameOwnerChanged',\
+			   arg0='" PORTAL_SERVICE_NAME "'",
+			   &error);
+	if (dbus_error_is_set(&error)) {
+		pw_log_error("Failed to add name owner changed listener: %s",
+			     error.message);
+		return -EIO;
+	}
+
+	dbus_connection_add_filter(impl->bus, name_owner_changed_handler,
+				   impl, NULL);
+
+	update_portal_pid(impl);
+
+	return 0;
+}
+
+SPA_EXPORT
+int pipewire__module_init(struct pw_impl_module *module, const char *args)
+{
+	struct pw_context *context = pw_impl_module_get_context(module);
+	struct impl *impl;
+	struct spa_dbus *dbus;
+	const struct spa_support *support;
+	uint32_t n_support;
+	int res;
+
+	PW_LOG_TOPIC_INIT(mod_topic);
+
+	support = pw_context_get_support(context, &n_support);
+
+	dbus = spa_support_find(support, n_support, SPA_TYPE_INTERFACE_DBus);
+        if (dbus == NULL)
+                return -ENOTSUP;
+
+	impl = calloc(1, sizeof(struct impl));
+	if (impl == NULL)
+		return -ENOMEM;
+
+	pw_log_debug("module %p: new", impl);
+
+	impl->context = context;
+	impl->properties = args ? pw_properties_new_string(args) : NULL;
+
+	impl->conn = spa_dbus_get_connection(dbus, SPA_DBUS_TYPE_SESSION);
+	if (impl->conn == NULL) {
+		res = -errno;
+		goto error;
+	}
+
+	if ((res = init_dbus_connection(impl)) < 0)
+		goto error;
+
+	pw_context_add_listener(context, &impl->context_listener, &context_events, impl);
+	pw_impl_module_add_listener(module, &impl->module_listener, &module_events, impl);
+
+	return 0;
+
+      error:
+	free(impl);
+	pw_log_error("Failed to connect to session bus: %s", spa_strerror(res));
+	return res;
+}

--- a/pipewire/pw-module/module-portal.c
+++ b/pipewire/pw-module/module-portal.c
@@ -1,7 +1,11 @@
-/* PipeWire */
-/* SPDX-FileCopyrightText: Copyright © 2016 Wim Taymans <wim.taymans@gmail.com> */
-/* SPDX-FileCopyrightText: Copyright © 2019 Red Hat Inc. */
-/* SPDX-License-Identifier: MIT */
+/* Imported from PipeWire with the following license:
+ * SPDX-FileCopyrightText: Copyright © 2016 Wim Taymans <wim.taymans@gmail.com>
+ * SPDX-FileCopyrightText: Copyright © 2019 Red Hat Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * New contributions are under the follwing license:
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors */
 
 #include <string.h>
 #include <stdio.h>
@@ -21,45 +25,7 @@
 #include <spa/utils/result.h>
 #include <spa/support/dbus.h>
 
-/** \page page_module_portal Portal
- *
- * The `portal` module performs access control management for clients started
- * inside an XDG portal.
- *
- * The module connects to the session DBus and subscribes to
- * `NameOwnerChanged` signals for the `org.freedesktop.portal.Desktop` name.
- * The PID of the DBus name owner is the portal.
- *
- * A client connection from the portal PID to PipeWire gets assigned a \ref
- * PW_KEY_ACCESS of `"portal"` and set to permissions ALL - it is the
- * responsibility of the portal to limit the permissions before passing the
- * connection on to the client. See \ref page_access for details on
- * permissions.
- *
- * Clients connecting from other PIDs are ignored by this module.
- *
- * ## Module Name
- *
- * `libpipewire-module-portal`
- *
- * ## Module Options
- *
- * There are no module-specific options.
- *
- * ## General options
- *
- * There are no general options for this module.
- *
- * ## Example configuration
- *\code{.unparsed}
- * context.modules = [
- *  {   name = libpipewire-module-portal }
- * ]
- *\endcode
- *
- */
-
-#define NAME "portal"
+#define NAME "xdg-desktop-portal"
 
 #define PORTAL_SERVICE_NAME "org.freedesktop.portal.Desktop"
 
@@ -154,7 +120,7 @@ context_check_access(void *data, struct pw_impl_client *client)
 	if (pid != impl->portal_pid)
 		return;
 
-	items[0] = SPA_DICT_ITEM_INIT(PW_KEY_ACCESS, "portal");
+	items[0] = SPA_DICT_ITEM_INIT(PW_KEY_ACCESS, "xdg-desktop-portal");
 	pw_impl_client_update_properties(client, &SPA_DICT_INIT(items, 1));
 
 	pw_log_info("%p: portal managed client %p added", impl, client);

--- a/pipewire/pw-module/module-portal.c
+++ b/pipewire/pw-module/module-portal.c
@@ -3,8 +3,6 @@
 /* SPDX-FileCopyrightText: Copyright © 2019 Red Hat Inc. */
 /* SPDX-License-Identifier: MIT */
 
-#include "config.h"
-
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
@@ -14,17 +12,14 @@
 #include <unistd.h>
 
 #include <dbus/dbus.h>
-
+#include <pipewire/context.h>
+#include <pipewire/impl-client.h>
+#include <pipewire/log.h>
+#include <pipewire/module.h>
+#include <pipewire/utils.h>
 #include <spa/utils/string.h>
 #include <spa/utils/result.h>
 #include <spa/support/dbus.h>
-#include <spa-private/dbus-helpers.h>
-
-#include "pipewire/context.h"
-#include "pipewire/impl-client.h"
-#include "pipewire/log.h"
-#include "pipewire/module.h"
-#include "pipewire/utils.h"
 
 /** \page page_module_portal Portal
  *
@@ -84,6 +79,59 @@ struct impl {
 	DBusPendingCall *portal_pid_pending;
 	pid_t portal_pid;
 };
+
+/* SPA D-Bus helpers */
+
+static inline void cancel_and_unref(DBusPendingCall **pp)
+{
+	DBusPendingCall *pending_call = spa_steal_ptr(*pp);
+
+	if (pending_call) {
+		dbus_pending_call_cancel(pending_call);
+		dbus_pending_call_unref(pending_call);
+	}
+}
+
+static inline DBusMessage *steal_reply_and_unref(DBusPendingCall **pp)
+{
+	DBusPendingCall *pending_call = spa_steal_ptr(*pp);
+
+	DBusMessage *reply = dbus_pending_call_steal_reply(pending_call);
+	dbus_pending_call_unref(pending_call);
+
+	return reply;
+}
+
+SPA_DEFINE_AUTOPTR_CLEANUP(DBusMessage, DBusMessage, {
+	spa_clear_ptr(*thing, dbus_message_unref);
+})
+
+static inline DBusPendingCall *send_with_reply(DBusConnection *conn,
+					       DBusMessage *m,
+					       DBusPendingCallNotifyFunction callback, void *user_data)
+{
+	DBusPendingCall *pending_call;
+
+	if (!dbus_connection_send_with_reply(conn, m, &pending_call, DBUS_TIMEOUT_USE_DEFAULT))
+		return NULL;
+
+	if (!pending_call)
+		return NULL;
+
+	if (!dbus_pending_call_set_notify(pending_call, callback, user_data, NULL)) {
+		dbus_pending_call_cancel(pending_call);
+		dbus_pending_call_unref(pending_call);
+		return NULL;
+	}
+
+	return pending_call;
+}
+
+SPA_DEFINE_AUTO_CLEANUP(DBusError, DBusError, {
+	dbus_error_free(thing);
+})
+
+/*********************/
 
 static void
 context_check_access(void *data, struct pw_impl_client *client)

--- a/pipewire/wireplumber.conf
+++ b/pipewire/wireplumber.conf
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+
+wireplumber.profiles = {
+  # Disable by default first-party portal features to be replaced with
+  # xdg-desktop-portal own features
+  base = {
+    support.portal-permissionstore = disabled
+    script.client.access-portal = disabled
+  }
+
+  main = {
+    policy.xdg-desktop-portal = required
+  }
+
+  policy = {
+    policy.xdg-desktop-portal = required
+  }
+
+  # Disable xdg-desktop-portal features since those are only for user sessions
+  mixin.systemwide-session = {
+    support.xdg-desktop-portal = disabled
+  }
+}
+
+wireplumber.components = [
+  {
+    name = libxdg-desktop-portal, type = module
+    provides = support.xdg-desktop-portal
+    requires = [ support.dbus ]
+  }
+
+  # Policy to enabled xdg-desktop-portal alongside the standard policy
+  {
+    type = virtual, provides = policy.xdg-desktop-portal
+    requires = [ policy.standard,
+                 support.xdg-desktop-portal ]
+  }
+]

--- a/pipewire/wp-plugin/meson.build
+++ b/pipewire/wp-plugin/meson.build
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+
+xdp_wireplumber_module_sources = [
+  'xdp-wp-permission-manager.c',
+  'xdp-wp-plugin.c',
+]
+
+xdp_wireplumber_module_sources += gnome.gdbus_codegen(
+  'xdp-impl-dbus',
+  sources: portal_impl_sources,
+  interface_prefix: 'org.freedesktop.impl.portal',
+  namespace: 'XdpDbusImpl',
+  docbook: 'portal',
+)
+
+xdp_wireplumber_module = shared_library(
+  'xdg-desktop-portal',
+  xdp_wireplumber_module_sources,
+  dependencies: [wireplumber_dep, pipewire_dep],
+  install: true,
+  install_dir: wireplumber_module_dir,
+)

--- a/pipewire/wp-plugin/xdp-wp-permission-manager.c
+++ b/pipewire/wp-plugin/xdp-wp-permission-manager.c
@@ -1,0 +1,369 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors */
+
+#include "xdp-wp-permission-manager.h"
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <pipewire/core.h>
+#include <pipewire/keys.h>
+#include <pipewire/permission.h>
+#include <wp/wp.h>
+
+#include "xdp-impl-dbus.h"
+
+WP_DEFINE_LOCAL_LOG_TOPIC ("m-xdp-permission-manager");
+
+struct _XdpWpPermissionManager
+{
+  GObject parent_instance;
+
+  GDBusConnection *connection;
+  WpCore *core;
+
+  GCancellable *cancellable;
+
+  XdpDbusImplPermissionStore *permission_store;
+  gulong permission_changed_signal_id;
+
+  WpObjectManager *camera_manager;
+  gulong camera_added_signal_id;
+
+  WpObjectManager *client_manager;
+  gulong client_added_signal_id;
+};
+
+G_DEFINE_FINAL_TYPE (XdpWpPermissionManager, xdp_wp_permission_manager, G_TYPE_OBJECT);
+
+enum {
+  PROP_CORE,
+  PROP_CONNECTION,
+};
+
+static GParamSpec *props[PROP_CONNECTION + 1] = { NULL, };
+
+#define PW_KEY_ACCESS_XDP_APP_ID PW_KEY_ACCESS ".xdg-desktop-portal.app_id"
+#define PW_KEY_ACCESS_XDP_MEDIA_ROLES PW_KEY_ACCESS ".xdg-desktop-portal.media_roles"
+
+static void
+update_client_camera_permission (XdpWpPermissionManager *self,
+                                 WpClient               *client,
+                                 GVariantIter           *iter)
+{
+  g_autofree char *value = NULL;
+  gboolean allowed;
+  const char *roles = NULL;
+  g_auto(GStrv) rolesv = NULL;
+  g_autoptr (WpIterator) node_iter = NULL;
+  g_auto (GValue) node_value = G_VALUE_INIT;
+
+  allowed =
+    iter && g_variant_iter_next (iter, "s", &value) && (g_strcmp0 (value, "yes") == 0);
+
+  roles = wp_pipewire_object_get_property (WP_PIPEWIRE_OBJECT (client),
+                                           PW_KEY_ACCESS_XDP_MEDIA_ROLES);
+
+  if (!roles)
+    {
+      wp_warning_object (client, "Client has no media roles set");
+      return;
+    }
+
+  rolesv = g_strsplit (roles, ",", 0);
+
+  if (!g_strv_contains ((const gchar* const*) rolesv, "Camera"))
+    return;
+
+  wp_info_object (client, "Update camera permissions");
+
+  wp_client_update_permissions (client, 1, wp_proxy_get_bound_id (WP_PROXY (client)),
+                                allowed ? PW_PERM_ALL : 0);
+
+  node_iter = wp_object_manager_new_iterator (self->camera_manager);
+  while (wp_iterator_next (node_iter, &node_value))
+    {
+      WpNode *node = g_value_get_object (&node_value);
+
+      wp_client_update_permissions (client, 1, wp_proxy_get_bound_id (WP_PROXY (node)),
+                                    allowed ? PW_PERM_ALL : 0);
+
+      g_value_unset (&node_value);
+    }
+}
+
+static void
+update_camera_permissions (XdpWpPermissionManager *self,
+                           WpClient               *client,
+                           GVariant               *permissions)
+{
+  g_autoptr (GVariant) perms = NULL;
+  const char *app_id = NULL;
+
+  if (!permissions)
+    {
+      g_autoptr (GVariant) data = NULL;
+      g_autoptr (GError) error = NULL;
+
+      if (!xdp_dbus_impl_permission_store_call_lookup_sync (self->permission_store,
+                                                            "devices",
+                                                            "camera",
+                                                            &perms,
+                                                            &data,
+                                                            self->cancellable,
+                                                            &error))
+        {
+          wp_warning_object (self, "Failed to lookup camera permission: %s", error->message);
+          return;
+        }
+
+      permissions = perms;
+    }
+
+  g_assert (permissions != NULL);
+
+  if (client)
+    {
+      g_autoptr (GVariantIter) value = NULL;
+
+      app_id = wp_pipewire_object_get_property (WP_PIPEWIRE_OBJECT (client),
+                                                PW_KEY_ACCESS_XDP_APP_ID);
+
+      if (app_id)
+        {
+          g_variant_lookup (permissions, app_id, "as", &value);
+          update_client_camera_permission (self, client, value);
+          wp_info_object (client, "Camera permission for '%s' updated", app_id);
+        }
+      else
+        {
+          wp_warning_object (client, "Client has no app id set");
+        }
+    }
+  else
+    {
+      g_autoptr (WpIterator) iter = NULL;
+      g_auto (GValue) iter_value = G_VALUE_INIT;
+
+      iter = wp_object_manager_new_iterator (self->client_manager);
+      while (wp_iterator_next (iter, &iter_value))
+        {
+          WpClient *client = g_value_get_object (&iter_value);
+          g_autoptr (GVariantIter) value = NULL;
+
+          app_id = wp_pipewire_object_get_property (WP_PIPEWIRE_OBJECT (client),
+                                                    PW_KEY_ACCESS_XDP_APP_ID);
+
+          if (app_id)
+            {
+              g_variant_lookup (permissions, app_id, "as", &value);
+              update_client_camera_permission (self, client, value);
+              wp_info_object (client, "Camera permission for '%s' updated", app_id);
+            }
+          else
+            {
+              wp_warning_object (client, "Client has no app id set");
+            }
+
+          g_value_unset (&iter_value);
+        }
+    }
+}
+
+static void
+on_permission_changed_cb (XdpWpPermissionManager     *self,
+                          const char                 *arg_table,
+                          const char                 *arg_id,
+                          gboolean                    arg_deleted,
+                          GVariant                   *arg_data,
+                          GVariant                   *arg_permissions,
+                          XdpDbusImplPermissionStore *permission_store)
+{
+  if (g_strcmp0 (arg_table, "devices") != 0 || g_strcmp0 (arg_id, "camera") != 0)
+    return;
+
+  update_camera_permissions (self, NULL, arg_permissions);
+}
+
+static void
+on_camera_added_cb (XdpWpPermissionManager *self,
+                    WpNode                 *node,
+                    WpObjectManager        *manager)
+{
+  update_camera_permissions (self, NULL, NULL);
+}
+
+static void
+on_client_added_cb (XdpWpPermissionManager *self,
+                    WpClient               *client,
+                    WpObjectManager        *manager)
+{
+  if (!self->camera_manager)
+    {
+      wp_info_object (self,
+                      "Granting ALL access to client %u",
+                      wp_proxy_get_bound_id (WP_PROXY (client)));
+      wp_client_update_permissions (client, 1, PW_ID_ANY, PW_PERM_ALL);
+      return;
+    }
+
+  update_camera_permissions (self, client, NULL);
+}
+
+static void
+xdp_wp_permission_manager_set_property (GObject      *object,
+                                        guint         property_id,
+                                        const GValue *value,
+                                        GParamSpec   *pspec)
+{
+  XdpWpPermissionManager *self = XDP_WP_PERMISSION_MANAGER (object);
+
+  switch (property_id)
+    {
+    case PROP_CORE:
+      self->core = g_object_ref (g_value_get_object (value));
+      break;
+
+    case PROP_CONNECTION:
+      self->connection = g_object_ref (g_value_get_object (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+xdp_wp_permission_manager_constructed (GObject *object)
+{
+  XdpWpPermissionManager *self = XDP_WP_PERMISSION_MANAGER (object);
+  g_autoptr (GError) error = NULL;
+
+  G_OBJECT_CLASS (xdp_wp_permission_manager_parent_class)->constructed (object);
+
+  g_assert (WP_IS_CORE (self->core));
+  g_assert (G_IS_DBUS_CONNECTION (self->connection));
+
+  self->client_manager = wp_object_manager_new ();
+  wp_object_manager_add_interest (self->client_manager,
+                                  WP_TYPE_CLIENT,
+                                  WP_CONSTRAINT_TYPE_PW_PROPERTY,
+                                  PW_KEY_ACCESS,
+                                  "=s",
+                                  "xdg-desktop-portal",
+                                  WP_CONSTRAINT_TYPE_PW_PROPERTY,
+                                  PW_KEY_ACCESS_XDP_APP_ID,
+                                  "+",
+                                  NULL);
+
+  self->client_added_signal_id = g_signal_connect_swapped (self->client_manager,
+                                                           "object-added",
+                                                           G_CALLBACK (on_client_added_cb),
+                                                           self);
+
+  self->permission_store =
+    xdp_dbus_impl_permission_store_proxy_new_sync (self->connection,
+                                                   G_DBUS_PROXY_FLAGS_NONE,
+                                                   "org.freedesktop.impl.portal.PermissionStore",
+                                                   "/org/freedesktop/impl/portal/PermissionStore",
+                                                   NULL,
+                                                   &error);
+
+  if (!self->permission_store)
+    {
+      wp_warning_object (self,
+                         "Failed to create permission store proxy: %s",
+                         error->message);
+      wp_core_install_object_manager (self->core, self->client_manager);
+      return;
+    }
+
+  self->camera_manager = wp_object_manager_new ();
+  wp_object_manager_add_interest (self->camera_manager,
+                                  WP_TYPE_NODE,
+                                  WP_CONSTRAINT_TYPE_PW_PROPERTY, PW_KEY_MEDIA_ROLE, "=s", "Camera",
+                                  WP_CONSTRAINT_TYPE_PW_PROPERTY, PW_KEY_MEDIA_CLASS, "=s", "Video/Source",
+                                  NULL);
+
+  self->camera_added_signal_id = g_signal_connect_swapped (self->camera_manager,
+                                                           "object-added",
+                                                           G_CALLBACK (on_camera_added_cb),
+                                                           self);
+
+  wp_core_install_object_manager (self->core, self->camera_manager);
+  wp_core_install_object_manager (self->core, self->client_manager);
+
+  self->permission_changed_signal_id = g_signal_connect_swapped (self->permission_store,
+                                                                 "changed",
+                                                                 G_CALLBACK (on_permission_changed_cb),
+                                                                 self);
+}
+
+static void
+xdp_wp_permission_manager_dispose (GObject *object)
+{
+  XdpWpPermissionManager *self = XDP_WP_PERMISSION_MANAGER (object);
+
+  g_clear_signal_handler (&self->camera_added_signal_id, self->camera_manager);
+  g_clear_signal_handler (&self->client_added_signal_id, self->client_manager);
+
+  g_clear_signal_handler (&self->permission_changed_signal_id, self->permission_store);
+
+  g_cancellable_cancel (self->cancellable);
+
+  G_OBJECT_CLASS (xdp_wp_permission_manager_parent_class)->dispose (object);
+}
+
+static void
+xdp_wp_permission_manager_finalize (GObject *object)
+{
+  XdpWpPermissionManager *self = XDP_WP_PERMISSION_MANAGER (object);
+
+  g_clear_object (&self->client_manager);
+  g_clear_object (&self->camera_manager);
+
+  g_clear_object (&self->permission_store);
+
+  g_clear_object (&self->connection);
+  g_clear_object (&self->core);
+
+  g_clear_object (&self->cancellable);
+
+  G_OBJECT_CLASS (xdp_wp_permission_manager_parent_class)->finalize (object);
+}
+
+static void
+xdp_wp_permission_manager_class_init (XdpWpPermissionManagerClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = xdp_wp_permission_manager_set_property;
+  object_class->constructed = xdp_wp_permission_manager_constructed;
+  object_class->dispose = xdp_wp_permission_manager_dispose;
+  object_class->finalize = xdp_wp_permission_manager_finalize;
+
+  props[PROP_CORE] = g_param_spec_object ("core", NULL, NULL,
+                                          WP_TYPE_CORE,
+                                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  props[PROP_CONNECTION] = g_param_spec_object ("connection", NULL, NULL,
+                                                G_TYPE_DBUS_CONNECTION,
+                                                G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, G_N_ELEMENTS (props), props);
+}
+
+static void
+xdp_wp_permission_manager_init (XdpWpPermissionManager *self)
+{
+  self->cancellable = g_cancellable_new ();
+}
+
+XdpWpPermissionManager *
+xdp_wp_permission_manager_new (WpCore          *core,
+                               GDBusConnection *connection)
+{
+  return g_object_new (XDP_WP_TYPE_PERMISSION_MANAGER,
+                       "core", core,
+                       "connection", connection,
+                       NULL);
+}

--- a/pipewire/wp-plugin/xdp-wp-permission-manager.h
+++ b/pipewire/wp-plugin/xdp-wp-permission-manager.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <wp/wp.h>
+
+#define XDP_WP_TYPE_PERMISSION_MANAGER (xdp_wp_permission_manager_get_type())
+G_DECLARE_FINAL_TYPE (XdpWpPermissionManager, xdp_wp_permission_manager, XDP_WP, PERMISSION_MANAGER, GObject);
+
+XdpWpPermissionManager * xdp_wp_permission_manager_new (WpCore          *core,
+                                                        GDBusConnection *connection);

--- a/pipewire/wp-plugin/xdp-wp-plugin.c
+++ b/pipewire/wp-plugin/xdp-wp-plugin.c
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors */
+
+#include <wp/wp.h>
+
+#include "xdp-wp-permission-manager.h"
+
+WP_DEFINE_LOCAL_LOG_TOPIC ("m-xdp-plugin");
+
+/* Copied from dbus-connection-state.h */
+typedef enum {
+  WP_DBUS_CONNECTION_STATE_CLOSED = 0,
+  WP_DBUS_CONNECTION_STATE_CONNECTING,
+  WP_DBUS_CONNECTION_STATE_CONNECTED,
+} WpDBusConnectionState;
+
+G_DECLARE_FINAL_TYPE (XdpWpPlugin, xdp_wp_plugin, XDP_WP, PLUGIN, WpPlugin);
+
+struct _XdpWpPlugin
+{
+  WpPlugin parent_instance;
+
+  WpPlugin *dbus_connection_plugin;
+  gulong dbus_changed_signal_id;
+
+  XdpWpPermissionManager *permission_manager;
+};
+
+G_DEFINE_FINAL_TYPE (XdpWpPlugin, xdp_wp_plugin, WP_TYPE_PLUGIN);
+
+static void
+on_dbus_connection_plugin_state_changed (XdpWpPlugin *self,
+                                         GParamSpec  *pspec,
+                                         GObject     *object)
+{
+  WpDBusConnectionState state = -1;
+  g_autoptr (GDBusConnection) connection = NULL;
+  g_autoptr (WpCore) core = NULL;
+
+  g_object_get (self->dbus_connection_plugin, "state", &state, NULL);
+
+  if (state != WP_DBUS_CONNECTION_STATE_CONNECTED)
+    {
+      g_clear_object (&self->permission_manager);
+      return;
+    }
+
+  g_object_get (self->dbus_connection_plugin, "connection", &connection, NULL);
+  g_return_if_fail (connection != NULL);
+
+  core = wp_object_get_core (WP_OBJECT (self));
+
+  if (core)
+    {
+      self->permission_manager = xdp_wp_permission_manager_new (core, connection);
+      wp_debug_object (self, "Permission manager created");
+    }
+  else
+    {
+      wp_debug_object (self, "No core returned");
+    }
+}
+
+static void
+xdp_wp_plugin_enable (WpPlugin     *plugin,
+                      WpTransition *transition)
+{
+  XdpWpPlugin *self = XDP_WP_PLUGIN (plugin);
+  g_autoptr (WpCore) core = wp_object_get_core (WP_OBJECT (self));
+
+  self->dbus_connection_plugin = wp_plugin_find (core, "dbus-connection");
+  if (!self->dbus_connection_plugin)
+    {
+      wp_transition_return_error (transition, g_error_new (WP_DOMAIN_LIBRARY,
+                                                           WP_LIBRARY_ERROR_INVARIANT,
+                                                           "dbus-connection module must be loaded before xdp-desktop-portal"));
+      return;
+    }
+
+  self->dbus_changed_signal_id =
+    g_signal_connect_swapped (self->dbus_connection_plugin,
+                              "notify::state",
+                              G_CALLBACK (on_dbus_connection_plugin_state_changed),
+                              self);
+  on_dbus_connection_plugin_state_changed (self, NULL, NULL);
+
+  wp_object_update_features (WP_OBJECT (self), WP_PLUGIN_FEATURE_ENABLED, 0);
+}
+
+static void
+xdp_wp_plugin_disable (WpPlugin *plugin)
+{
+  XdpWpPlugin *self = XDP_WP_PLUGIN (plugin);
+
+  g_clear_object (&self->permission_manager);
+
+  g_signal_handler_disconnect (self->dbus_connection_plugin,
+                               self->dbus_changed_signal_id);
+  g_clear_object (&self->dbus_connection_plugin);
+
+  wp_object_update_features (WP_OBJECT (self), 0, WP_PLUGIN_FEATURE_ENABLED);
+}
+
+static void
+xdp_wp_plugin_class_init (XdpWpPluginClass *klass)
+{
+  WpPluginClass *plugin_class = WP_PLUGIN_CLASS (klass);
+
+  plugin_class->enable = xdp_wp_plugin_enable;
+  plugin_class->disable = xdp_wp_plugin_disable;
+}
+
+static void
+xdp_wp_plugin_init (XdpWpPlugin *self)
+{
+}
+
+WP_PLUGIN_EXPORT GObject *
+wireplumber__module_init (WpCore     *core,
+                          WpSpaJson  *args,
+                          GError    **error)
+{
+  return g_object_new (xdp_wp_plugin_get_type (),
+                       "name", "xdp-desktop-portal",
+                       "core", core,
+                       NULL);
+}


### PR DESCRIPTION
Implement of the first part of #1739 which consist  of replacing portal logic from PipeWire and WirePlumber in xdg-desktop-portal tree.

~~Sadly, this PR relies on WirePlumber 0.5 with its configuration fragment support which Ubuntu 24.04 does not have.~~

I plan to do some testing on real hardware with GNOME OS and sysext. DONE