### PR TITLE
app-chooser: Relax app-id requirement for `choices`

### DIFF
--- a/data/org.freedesktop.impl.portal.AppChooser.xml
+++ b/data/org.freedesktop.impl.portal.AppChooser.xml
@@ -43,6 +43,10 @@
 
         Presents a list of applications to the user to choose one.
 
+        Note: To be able to handle legacy system apps the ids in `choices` are
+        in practice the base name of the desktop file without the `.desktop`
+        extension.
+
         Supported keys in the @options vardict include:
 
         * ``last_choice`` (``s``)
@@ -108,6 +112,10 @@
         This method can be called between the time of a ChooseApplication call
         and receiving the Response signal, to update the list of applications
         that are offered by the backend.
+
+        Note: To be able to handle legacy system apps the ids in `choices` are
+        in practice the base name of the desktop file without the `.desktop`
+        extension.
     -->
     <method name="UpdateChoices">
       <arg type="o" name="handle" direction="in"/>


### PR DESCRIPTION
This is a follow up from a discussion in the matrix room coming from ashdp requiring an actual app-id where as other current portal backends don't:

Many system apps still use a desktop file name that isn't an app-id as they don't contain a dot. Popular examples are firefox, emacs and vim.

Thus relax the app-id requirement allowing for the base name of the desktop file.

/cc @bilelmoussaoui @arun-mani-j