### PR TITLE
doc: Clarify file persistence on related portals

### DIFF
--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -33,6 +33,10 @@
       (which may involve adding it to the :ref:`Documents
       portal<org.freedesktop.portal.Documents>`).
 
+      Files added to the :ref:`Documents
+      portal<org.freedesktop.portal.Documents>` by this portal stay
+      accessible across sessions.
+
       This documentation describes version 4 of this interface.
   -->
   <interface name="org.freedesktop.portal.FileChooser">

--- a/data/org.freedesktop.portal.FileTransfer.xml
+++ b/data/org.freedesktop.portal.FileTransfer.xml
@@ -41,6 +41,10 @@
        files in the document store as necessary to make them accessible to the
        target.
 
+       Files added to the :ref:`Documents
+       portal<org.freedesktop.portal.Documents>` by this portal do not stay
+       accessible across sessions.
+
        The D-Bus interface for the this portal is available under the
        bus name org.freedesktop.portal.Documents and the object path
        ``/org/freedesktop/portal/documents``.


### PR DESCRIPTION
Just adds a line about whether or not files added to the document portal by a given portal are persistent or not.

Feel free to say if I missed anything.