### PR TITLE
camera: Revert using an empty app id for all host apps

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -186,16 +186,6 @@ handle_access_camera_in_thread_func (GTask *task,
     }
 }
 
-static const char *
-app_id_from_app_info (XdpAppInfo *app_info)
-{
-  /* Automatically grant camera access to unsandboxed apps. */
-  if (xdp_app_info_is_host (app_info))
-    return "";
-
-  return xdp_app_info_get_id (app_info);
-}
-
 static gboolean
 handle_access_camera (XdpDbusCamera *object,
                       GDBusMethodInvocation *invocation,
@@ -217,7 +207,7 @@ handle_access_camera (XdpDbusCamera *object,
 
   REQUEST_AUTOLOCK (request);
 
-  app_id = app_id_from_app_info (request->app_info);
+  app_id = xdp_app_info_get_id (request->app_info);
   g_object_set_data_full (G_OBJECT (request), "app-id", g_strdup (app_id), g_free);
 
   xdp_request_export (request, g_dbus_method_invocation_get_connection (invocation));
@@ -292,7 +282,7 @@ handle_open_pipewire_remote (XdpDbusCamera *object,
     }
 
   app_info = xdp_invocation_ensure_app_info_sync (invocation, NULL, &error);
-  app_id = app_id_from_app_info (app_info);
+  app_id = xdp_app_info_get_id (app_info);
   permission = xdp_get_permission_sync (app_id, PERMISSION_TABLE, PERMISSION_DEVICE_CAMERA);
   if (permission != XDP_PERMISSION_YES)
     {

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -16,14 +16,6 @@ def required_templates():
     }
 
 
-@pytest.fixture
-def app_id():
-    # x-d-p currently defaults to the empty app id for the camera portal for
-    # host XdpAppInfos (which the XdpAppInfoTest is). So use the empty app_id
-    # for now.
-    return ""
-
-
 class TestCamera:
     def set_permissions(self, dbus_con, appid, permissions):
         perm_store_intf = xdp.get_permission_store_iface(dbus_con)


### PR DESCRIPTION
This effectively reverts 6cd99b04 ("Camera: use an empty app id for host apps").

We now have the org.freedesktop.host.portal.Registry portal which allows apps to register their app id instead of relying on the currently somewhat broken auto-detection. The commit this is reverting was introduced to deal with the broken auto-detection in firefox. Firefox now uses the Registry in ESR 140, so it should be safe to revert the behavior here.