### PR TITLE
xdp-app-info-snap: Use the desktop ID as app ID and snap ID for permissions

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1367,7 +1367,7 @@ portal_list (GDBusMethodInvocation *invocation,
              GVariant *parameters,
              XdpAppInfo *app_info)
 {
-  const char *app_id = xdp_app_info_get_id (app_info);
+  const char *app_id;
   g_auto(GStrv) ids = NULL;
   GVariantBuilder builder;
   int i;

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -647,8 +647,13 @@ app_has_file_access (const char *target_permissions_id,
 
   if (g_str_has_prefix (target_permissions_id, "snap."))
     {
+      g_auto (GStrv) parts = NULL;
+
+      parts = g_strsplit (target_permissions_id + strlen ("snap."), "_", -1);
+
+      /* Snap does not support permission check for sub-applications */
       res = xdp_spawn (&error, "snap", "routine", "file-access",
-                        target_permissions_id + strlen ("snap."), path, NULL);
+                       parts[0], path, NULL);
 
       if (!res)
         {

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -657,6 +657,7 @@ app_has_file_access (const char *target_permissions_id,
 
       if (!res)
         {
+          g_debug ("snap file-access check failed: %s", error->message);
           /* Fallback access method has no support for snaps. */
           return FALSE;
         }
@@ -666,6 +667,9 @@ app_has_file_access (const char *target_permissions_id,
       /* First we try flatpak info --file-access=PATH APPID, which is supported on new versions */
       arg = g_strdup_printf ("--file-access=%s", path);
       res = xdp_spawn (&error, "flatpak", "info", arg, target_permissions_id, NULL);
+
+      if (!res)
+        g_debug ("flatpak file-access check failed: %s", error->message);
     }
 
   if (res)

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -649,6 +649,12 @@ app_has_file_access (const char *target_permissions_id,
     {
       res = xdp_spawn (&error, "snap", "routine", "file-access",
                         target_permissions_id + strlen ("snap."), path, NULL);
+
+      if (!res)
+        {
+          /* Fallback access method has no support for snaps. */
+          return FALSE;
+        }
     }
   else
     {

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -137,7 +137,7 @@ portal_grant_permissions (GDBusMethodInvocation *invocation,
                           XdpAppInfo            *app_info)
 {
   const char *target_app_id;
-  const char *target_permissions_id;
+  g_autofree char *target_permissions_id = NULL;
   const char *id;
   g_autofree const char **permissions = NULL;
   DocumentPermissionFlags perms;
@@ -159,7 +159,7 @@ portal_grant_permissions (GDBusMethodInvocation *invocation,
         return;
       }
 
-    target_permissions_id = target_app_id;
+    target_permissions_id = permissions_id_for_app_id (target_app_id);
     if (!xdp_is_valid_permissions_id (target_permissions_id))
       {
         g_dbus_method_invocation_return_error (invocation,
@@ -202,7 +202,7 @@ portal_revoke_permissions (GDBusMethodInvocation *invocation,
 {
   const char *permissions_id = xdp_app_info_get_permissions_id (app_info);
   const char *target_app_id;
-  const char *target_permissions_id;
+  g_autofree char *target_permissions_id = NULL;
   const char *id;
   g_autofree const char **permissions = NULL;
   GError *error = NULL;
@@ -224,7 +224,7 @@ portal_revoke_permissions (GDBusMethodInvocation *invocation,
         return;
       }
 
-    target_permissions_id = target_app_id;
+    target_permissions_id = permissions_id_for_app_id (target_app_id);
     if (!xdp_is_valid_permissions_id (target_permissions_id))
       {
         g_dbus_method_invocation_return_error (invocation,
@@ -699,7 +699,7 @@ portal_add_full (GDBusMethodInvocation *invocation,
   g_autoptr(GVariant) array = NULL;
   guint32 flags;
   const char *target_app_id;
-  const char *target_permissions_id;
+  g_autofree char *target_permissions_id = NULL;
   g_autofree const char **permissions = NULL;
   DocumentPermissionFlags target_perms;
   gsize n_args;
@@ -759,7 +759,7 @@ portal_add_full (GDBusMethodInvocation *invocation,
         fd[i] = -1;
     }
 
-  target_permissions_id = target_app_id;
+  target_permissions_id = permissions_id_for_app_id (target_app_id);
   ids = document_add_full (fd, NULL, NULL, documents_flags, n_args, app_info,
                            target_permissions_id, target_perms, &error);
 
@@ -978,7 +978,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
   guint32 flags = 0;
   const char *filename;
   const char *target_app_id;
-  const char *target_permissions_id;
+  g_autofree char *target_permissions_id = NULL;
   g_autofree const char **permissions = NULL;
   g_autofree char *id = NULL;
   g_autofree char *path = NULL;
@@ -1072,7 +1072,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
 
     XDP_AUTOLOCK (db);
 
-    target_permissions_id = target_app_id;
+    target_permissions_id = permissions_id_for_app_id (target_app_id);
 
     if (as_needed_by_app &&
         app_has_file_access (target_permissions_id, target_perms, path))

--- a/document-portal/document-store.c
+++ b/document-portal/document-store.c
@@ -85,8 +85,10 @@ document_entry_has_permissions_by_app_id (PermissionDbEntry       *entry,
                                           DocumentPermissionFlags  perms)
 {
   DocumentPermissionFlags current_perms;
+  g_autofree char *permissions_id = NULL;
 
-  current_perms = document_entry_get_permissions_by_app_permissions_id (entry, app_id);
+  permissions_id = permissions_id_for_app_id (app_id);
+  current_perms = document_entry_get_permissions_by_app_permissions_id (entry, permissions_id);
 
   return (current_perms & perms) == perms;
 }

--- a/document-portal/document-store.c
+++ b/document-portal/document-store.c
@@ -71,12 +71,12 @@ DocumentPermissionFlags
 document_entry_get_permissions (PermissionDbEntry *entry,
                                 XdpAppInfo        *app_info)
 {
-  const char *app_id = xdp_app_info_get_id (app_info);
+  const char *permissions_id = xdp_app_info_get_permissions_id (app_info);
 
   if (xdp_app_info_is_host (app_info))
     return DOCUMENT_PERMISSION_FLAGS_ALL;
 
-  return document_entry_get_permissions_by_app_id (entry, app_id);
+  return document_entry_get_permissions_by_app_id (entry, permissions_id);
 }
 
 gboolean

--- a/document-portal/document-store.c
+++ b/document-portal/document-store.c
@@ -55,15 +55,15 @@ xdp_parse_permissions (const char **permissions,
 }
 
 DocumentPermissionFlags
-document_entry_get_permissions_by_app_id (PermissionDbEntry *entry,
-                                          const char        *app_id)
+document_entry_get_permissions_by_app_permissions_id (PermissionDbEntry *entry,
+                                                      const char        *permissions_id)
 {
   g_autofree const char **permissions = NULL;
 
-  if (strcmp (app_id, "") == 0)
+  if (strcmp (permissions_id, "") == 0)
     return DOCUMENT_PERMISSION_FLAGS_ALL;
 
-  permissions = permission_db_entry_list_permissions (entry, app_id);
+  permissions = permission_db_entry_list_permissions (entry, permissions_id);
   return xdp_parse_permissions (permissions, NULL);
 }
 
@@ -76,7 +76,7 @@ document_entry_get_permissions (PermissionDbEntry *entry,
   if (xdp_app_info_is_host (app_info))
     return DOCUMENT_PERMISSION_FLAGS_ALL;
 
-  return document_entry_get_permissions_by_app_id (entry, permissions_id);
+  return document_entry_get_permissions_by_app_permissions_id (entry, permissions_id);
 }
 
 gboolean
@@ -86,7 +86,7 @@ document_entry_has_permissions_by_app_id (PermissionDbEntry       *entry,
 {
   DocumentPermissionFlags current_perms;
 
-  current_perms = document_entry_get_permissions_by_app_id (entry, app_id);
+  current_perms = document_entry_get_permissions_by_app_permissions_id (entry, app_id);
 
   return (current_perms & perms) == perms;
 }

--- a/document-portal/document-store.h
+++ b/document-portal/document-store.h
@@ -16,8 +16,8 @@ const char **      xdg_unparse_permissions (DocumentPermissionFlags permissions)
 DocumentPermissionFlags xdp_parse_permissions (const char **permissions,
                                                GError     **error);
 
-DocumentPermissionFlags document_entry_get_permissions_by_app_id (PermissionDbEntry *entry,
-                                                                  const char        *app_id);
+DocumentPermissionFlags document_entry_get_permissions_by_app_permissions_id (PermissionDbEntry *entry,
+                                                                              const char        *permissions_id);
 DocumentPermissionFlags document_entry_get_permissions (PermissionDbEntry *entry,
                                                         XdpAppInfo        *app_info);
 gboolean           document_entry_has_permissions (PermissionDbEntry       *entry,

--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -263,7 +263,7 @@ file_transfer_execute (FileTransfer  *transfer,
 {
   DocumentAddFullFlags common_flags;
   DocumentPermissionFlags perms;
-  const char *target_app_id;
+  const char *target_permissions_id;
   int n_fds;
   g_autofree int *fds = NULL;
   g_autofree int *parent_devs = NULL;
@@ -298,7 +298,7 @@ file_transfer_execute (FileTransfer  *transfer,
   if (transfer->writable)
     perms |= DOCUMENT_PERMISSION_FLAGS_WRITE;
 
-  target_app_id = xdp_app_info_get_id (target_app_info);
+  target_permissions_id = xdp_app_info_get_permissions_id (target_app_info);
 
   n_fds = transfer->files->len;
   fds = g_new (int, n_fds);
@@ -323,7 +323,8 @@ file_transfer_execute (FileTransfer  *transfer,
       parent_inos[i] = file->parent_ino;
     }
 
-  ids = document_add_full (fds, parent_devs, parent_inos, documents_flags, n_fds, transfer->app_info, target_app_id, perms, error);
+  ids = document_add_full (fds, parent_devs, parent_inos, documents_flags, n_fds,
+                           transfer->app_info, target_permissions_id, perms, error);
 
   for (i = 0; i < n_fds; i++)
     close (fds[i]);

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -49,11 +49,11 @@ struct PermissionDb
 
   gboolean   dirty;
 
-  /* Map id => GVariant (data, sorted-dict[appid->perms]) */
+  /* Map id => GVariant (data, sorted-dict[app_permissions_id->perms]) */
   GvdbTable  *main_table;
   GHashTable *main_updates;
 
-  /* (reverse) Map app id => [ id ]*/
+  /* (reverse) Map app permissions id => [ id ]*/
   GvdbTable  *app_table;
   GHashTable *app_additions;
   GHashTable *app_removals;

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -1070,37 +1070,6 @@ permission_db_entry_list_permissions (PermissionDbEntry *entry,
     return g_new0 (const char *, 1);
 }
 
-gboolean
-permission_db_entry_has_permission (PermissionDbEntry *entry,
-                                    const char     *app,
-                                    const char     *permission)
-{
-  g_autofree const char **app_permissions = NULL;
-
-  app_permissions = permission_db_entry_list_permissions (entry, app);
-
-  return g_strv_contains (app_permissions, permission);
-}
-
-gboolean
-permission_db_entry_has_permissions (PermissionDbEntry *entry,
-                                     const char     *app,
-                                     const char    **permissions)
-{
-  g_autofree const char **app_permissions = NULL;
-  int i;
-
-  app_permissions = permission_db_entry_list_permissions (entry, app);
-
-  for (i = 0; permissions[i] != NULL; i++)
-    {
-      if (!g_strv_contains (app_permissions, permissions[i]))
-        return FALSE;
-    }
-
-  return TRUE;
-}
-
 static GVariant *
 make_entry (GVariant *data,
             GVariant *app_permissions)

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -25,6 +25,7 @@
 
 #include <string.h>
 #include <fcntl.h>
+#include <gio/gdesktopappinfo.h>
 #include <stdio.h>
 #include <stdlib.h>
 #if HAVE_SYS_STATFS_H
@@ -1247,4 +1248,41 @@ permission_db_entry_print_string (PermissionDbEntry *entry,
                                   GString        *string)
 {
   return g_variant_print_string ((GVariant *) entry, string, FALSE);
+}
+
+char *
+permissions_id_for_app_id (const char *app_id)
+{
+  g_autoptr (GDesktopAppInfo) app_info = NULL;
+  g_autofree char *desktop_id = NULL;
+
+  if (app_id == NULL || *app_id == '\0' || g_str_has_prefix (app_id, "snap."))
+    return g_strdup (app_id);
+
+  /* We could optimize the case for flatpak's, by something like
+   *   !g_str_has_prefix (app_id, "snap.") && strchr (app_id, '.')
+   * but snaps are going to support normal desktop IDs, and so it's better
+   * not to optimize something that we need to drop soon.
+   */
+
+  g_debug ("Looking for app ID for %s", app_id);
+  desktop_id = g_strconcat (app_id, ".desktop", NULL);
+  app_info = g_desktop_app_info_new (desktop_id);
+
+  if (!app_info)
+    return g_strdup (app_id);
+
+  if (g_desktop_app_info_has_key (app_info, "X-SnapInstanceName"))
+    {
+      g_autofree char *snap_instance_name = NULL;
+
+      g_debug ("App ID for %s is provided by snap desktop ID", desktop_id);
+
+      snap_instance_name = g_desktop_app_info_get_string (app_info,
+                                                          "X-SnapInstanceName");
+      g_return_val_if_fail (snap_instance_name != NULL, g_strdup (app_id));
+      return g_strconcat ("snap.", snap_instance_name, NULL);
+    }
+
+  return g_strdup (app_id);
 }

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -1275,13 +1275,22 @@ permissions_id_for_app_id (const char *app_id)
   if (g_desktop_app_info_has_key (app_info, "X-SnapInstanceName"))
     {
       g_autofree char *snap_instance_name = NULL;
+      g_autofree char *snap_app_name = NULL;
 
       g_debug ("App ID for %s is provided by snap desktop ID", desktop_id);
 
       snap_instance_name = g_desktop_app_info_get_string (app_info,
                                                           "X-SnapInstanceName");
       g_return_val_if_fail (snap_instance_name != NULL, g_strdup (app_id));
-      return g_strconcat ("snap.", snap_instance_name, NULL);
+
+      snap_app_name = g_desktop_app_info_get_string (app_info, "X-SnapAppName");
+      if (snap_app_name && g_str_equal (snap_instance_name, snap_app_name))
+        {
+          /* We optimize the main case so that the old permissions are preserved. */
+          return g_strconcat ("snap.", snap_instance_name, NULL);
+        }
+
+      return g_strconcat ("snap.", snap_instance_name, "_", snap_app_name, NULL);
     }
 
   return g_strdup (app_id);

--- a/document-portal/permission-db.h
+++ b/document-portal/permission-db.h
@@ -92,6 +92,8 @@ PermissionDbEntry  *permission_db_entry_set_app_permissions (PermissionDbEntry *
 PermissionDbEntry  *permission_db_entry_remove_app_permissions (PermissionDbEntry *entry,
                                                                 const char        *app_permissions_id);
 
+char *permissions_id_for_app_id (const char *app_id);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (PermissionDb, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (PermissionDbEntry, permission_db_entry_unref)
 

--- a/document-portal/permission-db.h
+++ b/document-portal/permission-db.h
@@ -45,7 +45,7 @@ PermissionDb *     permission_db_new (const char *path,
 char **        permission_db_list_ids (PermissionDb *self);
 char **        permission_db_list_apps (PermissionDb *self);
 char **        permission_db_list_ids_by_app (PermissionDb  *self,
-                                              const char *app);
+                                              const char *app_permissions_id);
 char **        permission_db_list_ids_by_value (PermissionDb *self,
                                                 GVariant  *data);
 PermissionDbEntry *permission_db_lookup (PermissionDb  *self,
@@ -79,7 +79,7 @@ void            permission_db_entry_unref (PermissionDbEntry *entry);
 GVariant *      permission_db_entry_get_data (PermissionDbEntry *entry);
 const char **   permission_db_entry_list_apps (PermissionDbEntry *entry);
 const char **   permission_db_entry_list_permissions (PermissionDbEntry *entry,
-                                                      const char     *app);
+                                                      const char     *app_permissions_id);
 GString *       permission_db_entry_print_string (PermissionDbEntry *entry,
                                                   GString        *string);
 
@@ -87,10 +87,10 @@ PermissionDbEntry  *permission_db_entry_new (GVariant *data);
 PermissionDbEntry  *permission_db_entry_modify_data (PermissionDbEntry *entry,
                                                      GVariant       *data);
 PermissionDbEntry  *permission_db_entry_set_app_permissions (PermissionDbEntry *entry,
-                                                             const char     *app,
+                                                             const char     *app_permissions_id,
                                                              const char    **permissions);
 PermissionDbEntry  *permission_db_entry_remove_app_permissions (PermissionDbEntry *entry,
-                                                                const char        *app);
+                                                                const char        *app_permissions_id);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (PermissionDb, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (PermissionDbEntry, permission_db_entry_unref)

--- a/document-portal/permission-db.h
+++ b/document-portal/permission-db.h
@@ -80,12 +80,6 @@ GVariant *      permission_db_entry_get_data (PermissionDbEntry *entry);
 const char **   permission_db_entry_list_apps (PermissionDbEntry *entry);
 const char **   permission_db_entry_list_permissions (PermissionDbEntry *entry,
                                                       const char     *app);
-gboolean        permission_db_entry_has_permission (PermissionDbEntry *entry,
-                                                    const char     *app,
-                                                    const char     *permission);
-gboolean        permission_db_entry_has_permissions (PermissionDbEntry *entry,
-                                                     const char     *app,
-                                                     const char    **permissions);
 GString *       permission_db_entry_print_string (PermissionDbEntry *entry,
                                                   GString        *string);
 

--- a/document-portal/xdg-permission-store.c
+++ b/document-portal/xdg-permission-store.c
@@ -300,7 +300,7 @@ handle_delete_permission (XdgPermissionStore     *object,
                           const char             *app)
 {
   Table *table;
-  const char *permissions_id = NULL;
+  g_autofree char *permissions_id = NULL;
   g_autoptr(PermissionDbEntry) entry = NULL;
   g_autoptr(PermissionDbEntry) new_entry = NULL;
 
@@ -317,7 +317,7 @@ handle_delete_permission (XdgPermissionStore     *object,
       return TRUE;
     }
 
-  permissions_id = app;
+  permissions_id = permissions_id_for_app_id (app);
   new_entry = permission_db_entry_remove_app_permissions (entry, permissions_id);
   permission_db_set_entry (table->db, id, new_entry);
   emit_changed (object, table_name, id, new_entry);
@@ -338,7 +338,7 @@ handle_get_permission (XdgPermissionStore     *object,
 
   g_autoptr(PermissionDbEntry) entry = NULL;
   g_autofree const char **permission = NULL;
-  const char *permissions_id;
+  g_autofree char *permissions_id = NULL;
 
   table = lookup_table (table_name, invocation);
   if (table == NULL)
@@ -353,7 +353,7 @@ handle_get_permission (XdgPermissionStore     *object,
       return TRUE;
     }
 
-  permissions_id = app;
+  permissions_id = permissions_id_for_app_id (app);
   permission = permission_db_entry_list_permissions (entry, permissions_id);
 
   xdg_permission_store_complete_get_permission (object, invocation, permission);
@@ -433,7 +433,7 @@ handle_set_permission (XdgPermissionStore     *object,
                        const gchar *const     *permissions)
 {
   Table *table;
-  const char *permissions_id;
+  g_autofree char *permissions_id = NULL;
   g_autoptr(PermissionDbEntry) entry = NULL;
   g_autoptr(PermissionDbEntry) new_entry = NULL;
 
@@ -457,7 +457,7 @@ handle_set_permission (XdgPermissionStore     *object,
         }
     }
 
-  permissions_id = app;
+  permissions_id = permissions_id_for_app_id (app);
   new_entry = permission_db_entry_set_app_permissions (entry, permissions_id,
                                                        (const char **) permissions);
   permission_db_set_entry (table->db, id, new_entry);

--- a/src/camera.c
+++ b/src/camera.c
@@ -225,7 +225,7 @@ handle_access_camera (XdpDbusCamera *object,
 }
 
 static PipeWireRemote *
-open_pipewire_camera_remote (const char *app_id,
+open_pipewire_camera_remote (const char *permissions_id,
                              GError **error)
 {
   PipeWireRemote *remote;
@@ -233,7 +233,7 @@ open_pipewire_camera_remote (const char *app_id,
   struct pw_properties *pipewire_properties;
 
   pipewire_properties =
-    pw_properties_new ("pipewire.access.portal.app_id", app_id,
+    pw_properties_new ("pipewire.access.portal.app_id", permissions_id,
                        "pipewire.access.portal.media_roles", "Camera",
                        NULL);
   remote = pipewire_remote_new_sync (pipewire_properties,
@@ -297,7 +297,7 @@ handle_open_pipewire_remote (XdpDbusCamera *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  remote = open_pipewire_camera_remote (xdp_app_info_get_id (app_info), &error);
+  remote = open_pipewire_camera_remote (xdp_app_info_get_permissions_id (app_info), &error);
   if (!remote)
     {
       g_dbus_method_invocation_return_error (invocation,

--- a/src/xdp-app-info-private.h
+++ b/src/xdp-app-info-private.h
@@ -34,6 +34,9 @@ struct _XdpAppInfoClass
 {
   GObjectClass parent_class;
 
+
+  const char * (*get_permissions_id) (XdpAppInfo *app_info);
+
   gboolean (*is_valid_sub_app_id) (XdpAppInfo *app_info,
                                    const char *sub_app_id);
 

--- a/src/xdp-app-info-private.h
+++ b/src/xdp-app-info-private.h
@@ -54,7 +54,5 @@ struct _XdpAppInfoClass
   gboolean (*validate_dynamic_launcher) (XdpAppInfo  *app_info,
                                          GKeyFile    *key_file,
                                          GError     **error);
-
-  GAppInfo * (*create_gappinfo) (XdpAppInfo *app_info);
 };
 

--- a/src/xdp-app-info-snap.c
+++ b/src/xdp-app-info-snap.c
@@ -31,6 +31,7 @@
 
 #define SNAP_METADATA_GROUP_INFO "Snap Info"
 #define SNAP_METADATA_KEY_INSTANCE_NAME "InstanceName"
+#define SNAP_METADATA_KEY_APP_NAME "AppName"
 #define SNAP_METADATA_KEY_DESKTOP_FILE "DesktopFile"
 #define SNAP_METADATA_KEY_NETWORK "HasNetworkStatus"
 
@@ -242,6 +243,7 @@ parse_snap_metadata (GKeyFile         *metadata,
                      GError          **error)
 {
   g_autofree char *snap_name = NULL;
+  g_autofree char *snap_app_name = NULL;
   g_autofree char *app_id = NULL;
   g_autofree char *permissions_id = NULL;
   g_autofree char *desktop_id = NULL;
@@ -255,7 +257,19 @@ parse_snap_metadata (GKeyFile         *metadata,
   if (snap_name == NULL)
     return FALSE;
 
-  permissions_id = g_strconcat ("snap.", snap_name, NULL);
+  snap_app_name = g_key_file_get_string (metadata,
+                                         SNAP_METADATA_GROUP_INFO,
+                                         SNAP_METADATA_KEY_APP_NAME,
+                                         NULL);
+
+  if (snap_app_name == NULL || g_str_equal (snap_app_name, snap_name))
+    {
+      permissions_id = g_strconcat ("snap.", snap_name, NULL);
+    }
+  else
+    {
+      permissions_id = g_strconcat ("snap.", snap_name, "_", snap_app_name, NULL);
+    }
 
   desktop_id = g_key_file_get_string (metadata,
                                       SNAP_METADATA_GROUP_INFO,

--- a/src/xdp-app-info-snap.c
+++ b/src/xdp-app-info-snap.c
@@ -308,7 +308,6 @@ xdp_app_info_snap_new (const char  *sender,
                        GError     **error)
 {
   g_autoptr (XdpAppInfoSnap) app_info_snap = NULL;
-
   g_autoptr(GError) local_error = NULL;
   g_autofree char *pid_str = NULL;
   g_autofree char *output = NULL;

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -469,6 +469,9 @@ xdp_app_info_get_permissions_id (XdpAppInfo *app_info)
 
   g_return_val_if_fail (app_info != NULL, NULL);
 
+  if (XDP_APP_INFO_GET_CLASS (app_info)->get_permissions_id)
+    return XDP_APP_INFO_GET_CLASS (app_info)->get_permissions_id (app_info);
+
   priv = xdp_app_info_get_instance_private (app_info);
   return priv->id;
 }

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -463,6 +463,17 @@ xdp_app_info_get_id (XdpAppInfo *app_info)
 }
 
 const char *
+xdp_app_info_get_permissions_id (XdpAppInfo *app_info)
+{
+  XdpAppInfoPrivate *priv;
+
+  g_return_val_if_fail (app_info != NULL, NULL);
+
+  priv = xdp_app_info_get_instance_private (app_info);
+  return priv->id;
+}
+
+const char *
 xdp_app_info_get_instance (XdpAppInfo *app_info)
 {
   XdpAppInfoPrivate *priv;

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -77,6 +77,7 @@ typedef struct _XdpAppInfoPrivate
 } XdpAppInfoPrivate;
 
 static void g_initable_init_iface (GInitableIface *iface);
+static GAppInfo * xdp_app_info_create_gappinfo (XdpAppInfo *app_info);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_CODE (XdpAppInfo, xdp_app_info, G_TYPE_OBJECT,
                                   G_ADD_PRIVATE (XdpAppInfo)
@@ -105,8 +106,7 @@ xdp_app_info_initable_init (GInitable     *initable,
   XdpAppInfo *app_info = XDP_APP_INFO (initable);
   XdpAppInfoPrivate *priv = xdp_app_info_get_instance_private (app_info);
 
-  priv->gappinfo =
-    XDP_APP_INFO_GET_CLASS (app_info)->create_gappinfo (app_info);
+  priv->gappinfo = xdp_app_info_create_gappinfo (app_info);
 
   if ((priv->flags & XDP_APP_INFO_FLAG_REQUIRE_GAPPINFO) && !priv->gappinfo)
     {
@@ -125,7 +125,7 @@ g_initable_init_iface (GInitableIface *iface)
 }
 
 static GAppInfo *
-xdp_app_info_real_create_gappinfo (XdpAppInfo *app_info)
+xdp_app_info_create_gappinfo (XdpAppInfo *app_info)
 {
   XdpAppInfoPrivate *priv = xdp_app_info_get_instance_private (app_info);
   g_autoptr(GAppInfo) gappinfo = NULL;
@@ -255,8 +255,6 @@ xdp_app_info_class_init (XdpAppInfoClass *klass)
   object_class->dispose = xdp_app_info_dispose;
   object_class->get_property = xdp_app_info_get_property;
   object_class->set_property = xdp_app_info_set_property;
-
-  klass->create_gappinfo = xdp_app_info_real_create_gappinfo;
 
   properties[PROP_ENGINE] =
     g_param_spec_string ("engine", NULL, NULL,

--- a/src/xdp-app-info.h
+++ b/src/xdp-app-info.h
@@ -57,6 +57,8 @@ gboolean xdp_app_info_is_host (XdpAppInfo *app_info);
 
 const char * xdp_app_info_get_id (XdpAppInfo *app_info);
 
+const char * xdp_app_info_get_permissions_id (XdpAppInfo *app_info);
+
 const char * xdp_app_info_get_instance (XdpAppInfo *app_info);
 
 const char * xdp_app_info_get_engine (XdpAppInfo *app_info);

--- a/src/xdp-permissions.c
+++ b/src/xdp-permissions.c
@@ -40,7 +40,7 @@ xdp_get_permissions_sync (XdpAppInfo *app_info,
   g_autoptr(GVariant) out_perms = NULL;
   g_autoptr(GVariant) out_data = NULL;
   g_autofree char **permissions = NULL;
-  const char *app_id;
+  const char *permissions_id;
 
   if (!xdp_dbus_impl_permission_store_call_lookup_sync (permission_store,
                                                         table,
@@ -55,10 +55,10 @@ xdp_get_permissions_sync (XdpAppInfo *app_info,
       return NULL;
     }
 
-  app_id = xdp_app_info_get_id (app_info);
-  if (!g_variant_lookup (out_perms, app_id, "^a&s", &permissions))
+  permissions_id = xdp_app_info_get_permissions_id (app_info);
+  if (!g_variant_lookup (out_perms, permissions_id, "^a&s", &permissions))
     {
-      g_debug ("No permissions stored for: %s %s, app %s", table, id, app_id);
+      g_debug ("No permissions stored for: %s %s, app %s", table, id, permissions_id);
 
       return NULL;
     }
@@ -133,7 +133,7 @@ xdp_set_permissions_sync (XdpAppInfo         *app_info,
                                                                 table,
                                                                 TRUE,
                                                                 id,
-                                                                xdp_app_info_get_id (app_info),
+                                                                xdp_app_info_get_permissions_id (app_info),
                                                                 permissions,
                                                                 NULL,
                                                                 &error))

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -511,6 +511,12 @@ xdp_is_valid_app_id (const char *string)
 }
 
 gboolean
+xdp_is_valid_permissions_id (const char *string)
+{
+  return xdp_is_valid_app_id (string);
+}
+
+gboolean
 xdp_is_valid_token (const char *string)
 {
   g_autofree char *path = NULL;

--- a/src/xdp-utils.c
+++ b/src/xdp-utils.c
@@ -513,6 +513,9 @@ xdp_is_valid_app_id (const char *string)
 gboolean
 xdp_is_valid_permissions_id (const char *string)
 {
+  if (g_str_has_prefix (string, "snap."))
+    return TRUE;
+
   return xdp_is_valid_app_id (string);
 }
 

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -42,6 +42,7 @@ gint xdp_mkstempat (int    dir_fd,
                     int    mode);
 
 gboolean xdp_is_valid_app_id (const char *string);
+gboolean xdp_is_valid_permissions_id (const char *string);
 gboolean xdp_is_valid_token (const char *string);
 
 char *xdp_get_app_id_from_desktop_id (const char *desktop_id);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,10 @@ def xdp_mocked_executables(xdp_app_info: xdp.AppInfo) -> list[xdp.ExecutableMock
     exe = None
     if xdp_app_info.kind == xdp.AppInfoKind.FLATPAK:
         exe = "flatpak"
-    elif xdp_app_info.kind == xdp.AppInfoKind.SNAP:
+    elif (
+        xdp_app_info.kind == xdp.AppInfoKind.SNAP
+        or xdp_app_info.kind == xdp.AppInfoKind.SNAP_SUB_APP
+    ):
         exe = "snap"
     else:
         return []
@@ -447,6 +450,7 @@ def xdp_overwrite_env() -> dict[str, str]:
         xdp.AppInfoKind.HOST,
         xdp.AppInfoKind.FLATPAK,
         xdp.AppInfoKind.SNAP,
+        xdp.AppInfoKind.SNAP_SUB_APP,
         xdp.AppInfoKind.LINYAPS,
     ]
 )
@@ -472,6 +476,13 @@ def xdp_app_info(request) -> xdp.AppInfo:
         )
 
     if app_info_kind == xdp.AppInfoKind.SNAP:
+        return xdp.AppInfo.new_snap(
+            common_id=app_id,
+            snap_name="test",
+            app_name="test",
+        )
+
+    if app_info_kind == xdp.AppInfoKind.SNAP_SUB_APP:
         return xdp.AppInfo.new_snap(
             common_id=app_id,
             snap_name="example",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -474,7 +474,7 @@ def xdp_app_info(request) -> xdp.AppInfo:
     if app_info_kind == xdp.AppInfoKind.SNAP:
         return xdp.AppInfo.new_snap(
             common_id=app_id,
-            snap_name="test",
+            snap_name="example",
             app_name="test",
         )
 

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -89,7 +89,11 @@ class TestBackground:
         assert response.results["background"]
 
         # Unsupported on snap and linyaps
-        if xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}:
+        if xdp_app_info.kind in {
+            xdp.AppInfoKind.SNAP,
+            xdp.AppInfoKind.SNAP_SUB_APP,
+            xdp.AppInfoKind.LINYAPS,
+        }:
             assert not response.results["autostart"]
             return
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -7,8 +7,14 @@ import tests.xdp_doc_utils as xdp_doc
 
 import pytest
 import dbus
+from enum import Enum
 from pathlib import Path
 import os
+
+
+class PermissionsIDType(Enum):
+    PERMISSIONS_ID = 1
+    APP_ID = 2
 
 
 class TestDocuments:
@@ -32,20 +38,25 @@ class TestDocuments:
         documents_intf = xdp.get_document_portal_iface(dbus_con)
         xdp_doc.get_mountpoint(documents_intf)
 
-    def test_create_doc(self, xdg_document_portal, dbus_con, xdp_app_info):
+    @pytest.mark.parametrize("permission_id_type", [*PermissionsIDType])
+    def test_create_doc(
+        self, xdg_document_portal, dbus_con, xdp_app_info, permission_id_type
+    ):
         documents_intf = xdp.get_document_portal_iface(dbus_con)
         mountpoint = xdp_doc.get_mountpoint(documents_intf)
 
         content = b"content"
         file_name = "a-file"
         permissions_id = xdp_app_info.permissions_id
+        if permission_id_type == PermissionsIDType.APP_ID:
+            permissions_id = xdp_app_info.app_id
 
         file_path = Path(os.environ["TMPDIR"]) / file_name
         xdp_doc.write_bytes_atomic(file_path, content)
         doc_id = xdp_doc.export_file(documents_intf, file_path)
 
         doc_path = mountpoint / doc_id
-        doc_app1_path = mountpoint / "by-app" / permissions_id / doc_id
+        doc_app1_path = mountpoint / "by-app" / xdp_app_info.permissions_id / doc_id
         doc_app2_path = mountpoint / "by-app" / "com.test.App2" / doc_id
 
         # Make sure it got exported
@@ -124,20 +135,25 @@ class TestDocuments:
         doc_id5 = xdp_doc.export_file(documents_intf, file_path, unique=True)
         assert doc_id5 != doc_id
 
-    def test_recursive_doc(self, xdg_document_portal, dbus_con, xdp_app_info):
+    @pytest.mark.parametrize("permission_id_type", [*PermissionsIDType])
+    def test_recursive_doc(
+        self, xdg_document_portal, dbus_con, xdp_app_info, permission_id_type
+    ):
         documents_intf = xdp.get_document_portal_iface(dbus_con)
         mountpoint = xdp_doc.get_mountpoint(documents_intf)
 
         content = b"content"
         file_name = "recursive-file"
         permissions_id = xdp_app_info.permissions_id
+        if permission_id_type == PermissionsIDType.APP_ID:
+            permissions_id = xdp_app_info.app_id
 
         file_path = Path(os.environ["TMPDIR"]) / file_name
         xdp_doc.write_bytes_atomic(file_path, content)
         doc_id = xdp_doc.export_file(documents_intf, file_path)
 
         doc_path = mountpoint / doc_id
-        doc_app1_path = mountpoint / "by-app" / permissions_id / doc_id
+        doc_app1_path = mountpoint / "by-app" / xdp_app_info.permissions_id / doc_id
 
         assert (doc_path / file_name).read_bytes() == content
 
@@ -149,11 +165,16 @@ class TestDocuments:
         doc_id3 = xdp_doc.export_file(documents_intf, doc_app1_path / file_name)
         assert doc_id3 == doc_id
 
-    def test_create_docs(self, xdg_document_portal, dbus_con, xdp_app_info):
+    @pytest.mark.parametrize("permission_id_type", [*PermissionsIDType])
+    def test_create_docs(
+        self, xdg_document_portal, dbus_con, xdp_app_info, permission_id_type
+    ):
         documents_intf = xdp.get_document_portal_iface(dbus_con)
         mountpoint = xdp_doc.get_mountpoint(documents_intf)
 
         permissions_id = xdp_app_info.permissions_id
+        if permission_id_type == PermissionsIDType.APP_ID:
+            permissions_id = xdp_app_info.app_id
         files = {
             "doc1": b"doc1-content",
             "doc2": b"doc2-content",
@@ -179,8 +200,12 @@ class TestDocuments:
             assert (Path(os.environ["TMPDIR"]) / file_name).read_bytes() == file_content
             app1_path = mountpoint / "by-app" / permissions_id / doc_id / file_name
             app2_path = mountpoint / "by-app" / "com.test.App2" / doc_id / file_name
+            app1_other_path = (
+                mountpoint / "by-app" / xdp_app_info.permissions_id / doc_id / file_name
+            )
             assert not app1_path.exists()
             assert not app2_path.exists()
+            assert not app1_other_path.exists()
             assert not (mountpoint / doc_id / "another-file").exists()
             assert not (mountpoint / "anotherid" / file_name).exists()
 
@@ -191,20 +216,25 @@ class TestDocuments:
             with pytest.raises(PermissionError):
                 other_app_path.write_bytes(b"new-content")
 
-    def test_add_named(self, xdg_document_portal, dbus_con, xdp_app_info):
+    @pytest.mark.parametrize("permission_id_type", [*PermissionsIDType])
+    def test_add_named(
+        self, xdg_document_portal, dbus_con, xdp_app_info, permission_id_type
+    ):
         documents_intf = xdp.get_document_portal_iface(dbus_con)
         mountpoint = xdp_doc.get_mountpoint(documents_intf)
 
         content = b"content"
         file_name = "add-named-1"
         permissions_id = xdp_app_info.permissions_id
+        if permission_id_type == PermissionsIDType.APP_ID:
+            permissions_id = xdp_app_info.app_id
 
         folder_path = Path(os.environ["TMPDIR"])
         doc_id = xdp_doc.export_file_named(documents_intf, folder_path, file_name)
         assert doc_id
 
         doc_path = mountpoint / doc_id
-        doc_app1_path = mountpoint / "by-app" / permissions_id / doc_id
+        doc_app1_path = mountpoint / "by-app" / xdp_app_info.permissions_id / doc_id
         doc_app2_path = mountpoint / "by-app" / "com.test.App2" / doc_id
 
         assert doc_path.exists()
@@ -288,7 +318,8 @@ class TestDocuments:
         assert (doc_app1_path / file_name).read_bytes() == content
         assert not (doc_app2_path / file_name).exists()
 
-    def test_get_host_paths(self, xdg_document_portal, dbus_con):
+    @pytest.mark.parametrize("permission_id_type", [*PermissionsIDType])
+    def test_get_host_paths(self, xdg_document_portal, dbus_con, permission_id_type):
         documents_intf = xdp.get_document_portal_iface(dbus_con)
 
         content = b"content"

--- a/tests/test_dynamiclauncher.py
+++ b/tests/test_dynamiclauncher.py
@@ -94,9 +94,17 @@ class TestDynamicLauncher:
         except dbus.exceptions.DBusException as e:
             # Unsupported on snap and linyaps
             assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
-            assert xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}
+            assert xdp_app_info.kind in {
+                xdp.AppInfoKind.SNAP,
+                xdp.AppInfoKind.SNAP_SUB_APP,
+                xdp.AppInfoKind.LINYAPS,
+            }
             return
-        assert xdp_app_info.kind not in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}
+        assert xdp_app_info.kind not in {
+            xdp.AppInfoKind.SNAP,
+            xdp.AppInfoKind.SNAP_SUB_APP,
+            xdp.AppInfoKind.LINYAPS,
+        }
 
         file = Path(os.environ["XDG_DATA_HOME"]) / "applications" / desktop_file_name
         assert file.exists()

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -262,6 +262,7 @@ class AppInfo:
 
     kind: AppInfoKind
     app_id: str
+    permissions_id: str
     desktop_file: str
     env: dict[str, str] = field(default_factory=dict)
     files: dict[Path, bytes] = field(default_factory=dict)
@@ -302,6 +303,7 @@ class AppInfo:
         return cls(
             kind=kind,
             app_id=app_id,
+            permissions_id=app_id,
             desktop_file=desktop_file,
             env=env,
             files=files,
@@ -372,6 +374,7 @@ enumerable-devices={usb_queries}
         return cls(
             kind=kind,
             app_id=app_id,
+            permissions_id=app_id,
             desktop_file=desktop_file,
             env=env,
             files=files,
@@ -428,6 +431,7 @@ DesktopFile={desktop_file}
         return cls(
             kind=kind,
             app_id=app_id,
+            permissions_id=app_id,
             desktop_file=desktop_file,
             env=env,
             files=files,
@@ -490,6 +494,7 @@ Network=shared
         return cls(
             kind=kind,
             app_id=app_id,
+            permissions_id=app_id,
             desktop_file=desktop_file,
             env=env,
             files=files,

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -247,7 +247,8 @@ class AppInfoKind(Enum):
     HOST = 1
     FLATPAK = 2
     SNAP = 3
-    LINYAPS = 4
+    SNAP_SUB_APP = 4
+    LINYAPS = 5
 
 
 @dataclass
@@ -392,7 +393,9 @@ enumerable-devices={usb_queries}
         kind = AppInfoKind.SNAP
         app_id = f"{snap_name}_{app_name}"
         desktop_file = f"{app_id}.desktop"
-        permissions_id = f"snap.{snap_name}"
+        permissions_id = f"snap.{snap_name}" + (
+            f"_{app_name}" if app_name != snap_name else ""
+        )
         env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "snap",
         }
@@ -402,7 +405,7 @@ enumerable-devices={usb_queries}
             desktop_entry_str = f"""
 [Desktop Entry]
 Version=1.0
-Name=Example Snap App
+Name=Example Snap App ({app_name})
 Exec=true %u
 Type=Application
 X-SnapInstanceName={snap_name}

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -390,8 +390,9 @@ enumerable-devices={usb_queries}
         metadata: bytes | None = None,
     ):
         kind = AppInfoKind.SNAP
-        app_id = f"snap.{snap_name}"
-        desktop_file = f"{snap_name}_{app_name}.desktop"
+        app_id = f"{snap_name}_{app_name}"
+        desktop_file = f"{app_id}.desktop"
+        permissions_id = f"snap.{snap_name}"
         env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "snap",
         }
@@ -401,7 +402,7 @@ enumerable-devices={usb_queries}
             desktop_entry_str = f"""
 [Desktop Entry]
 Version=1.0
-Name=Example App
+Name=Example Snap App
 Exec=true %u
 Type=Application
 X-SnapInstanceName={snap_name}
@@ -431,7 +432,7 @@ DesktopFile={desktop_file}
         return cls(
             kind=kind,
             app_id=app_id,
-            permissions_id=app_id,
+            permissions_id=permissions_id,
             desktop_file=desktop_file,
             env=env,
             files=files,


### PR DESCRIPTION
From the main commit:

When using snap applications the permissions are saved using a common ID
that is not matching the desktop ID, since they are per-snap, not per
application.

While that is fine,  we were using the very same ID also as the
app ID, which is instead expected to be matching the desktop-ID (without
extension).

To prevent this to happen, use the desktop ID as the app ID and the snap
ID for permission purposes only.

As per this, we can now use the snap desktop ID as the handle that we
expose everywhere, since that's what all the components (shells, and
portal implementations) are expecting to receive.

This fixes an issue existing for long time, that was causing some
portals not to work at all (like the access one) or to misbehave (like
the notification one), while preserving the permission behavior that we
used to have.

Closes: #769