### PR TITLE
subprojects: add a conftest.py so we don't run pytests

### DIFF
--- a/subprojects/conftest.py
+++ b/subprojects/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore_glob = ["*"]


### PR DESCRIPTION
cc @swick - not sure if running the subproject pytests was intentional