### PR TITLE
print: Update the impl interface description

### DIFF
--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -67,6 +67,11 @@
           Token that can be passed to a subsequent org.freedesktop.impl.portal.Print.Print() call to
           bypass the print dialog.
 
+        * ``supported_output_file_formats`` (``as``)
+
+          File formats supported by the app to use for print-to-file. If not set, all formats
+          are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
+
         The :ref:`org.freedesktop.portal.Print.Print` documentation has details about
         the supported keys in settings and page-setup.
     -->


### PR DESCRIPTION
Version 3 of the print portal api added a new option that is passed through to the backends.

Document it as part of the impl interface, like all the other options.