### PR TITLE
print: Add two new options

### DIFF
--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -72,6 +72,14 @@
           File formats supported by the app to use for print-to-file. If not set, all formats
           are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
 
+        * ``has_current_page`` (``b``)
+
+          Whether it makes sense to return "current" for the ``print-pages`` setting.
+
+        * ``has_selected_pages`` (``b``)
+
+          Whether it makes sense to return "selection" for the ``print-pages`` setting.
+
         The :ref:`org.freedesktop.portal.Print.PreparePrint` documentation has details about
         the supported keys in settings and page-setup.
     -->

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -34,7 +34,7 @@
       to print the formatted document. It is expected that high-level toolkit
       APIs such as GtkPrintOperation will hide most of this complexity.
 
-      This documentation describes version 3 of this interface.
+      This documentation describes version 4 of this interface.
   -->
   <interface name="org.freedesktop.portal.Print">
     <!--
@@ -73,6 +73,18 @@
           are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
 
           This option was added in version 3.
+
+        * ``has_current_page`` (``b``)
+
+          Whether it makes sense to return "current" for the ``print-pages`` setting.
+
+          This option was added in version 4.
+
+        * ``has_selected_pages`` (``b``)
+
+          Whether it makes sense to return "selection" for the ``print-pages`` setting.
+
+          This option was added in version 4.
 
         The @settings and @page_setup vardict contain hints for the initial state of the print dialog.
 

--- a/src/print.c
+++ b/src/print.c
@@ -251,6 +251,8 @@ static XdpOptionKey prepare_print_options[] = {
   { "modal", G_VARIANT_TYPE_BOOLEAN },
   { "accept_label", G_VARIANT_TYPE_STRING },
   { "supported_output_file_formats", G_VARIANT_TYPE_STRING_ARRAY, validate_supported_output_file_formats },
+  { "has_current_page", G_VARIANT_TYPE_BOOLEAN },
+  { "has_selected_pages", G_VARIANT_TYPE_BOOLEAN },
 };
 
 static gboolean


### PR DESCRIPTION
Print dialogs can have a feature that lets the user select 'current page' or 'selection' for what pages to print.
This only makes sense if there *is* a current page or page selection.

This information needs to be provided by the caller, which is what the new options are about.

An implementation for the gnome backends is here: https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/229

And this MR makes gtk use the new options: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8866