### PR TITLE
global-shortcuts: Allow passing activation tokens in (de)actiavated

### DIFF
--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -136,6 +136,13 @@
         @options: Vardict with optional further information
 
         Emitted when a shortcut is activated.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate a window in response to the
+          shortcut getting activated.
     -->
     <signal name="Activated">
       <arg type="o" name="session_handle" direction="out"/>
@@ -153,6 +160,13 @@
         @options: Vardict with optional further information
 
         Emitted when a shortcut is deactivated.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate a window in response to the
+          shortcut getting deactivated.
     -->
     <signal name="Deactivated">
       <arg type="o" name="session_handle" direction="out"/>

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -214,6 +214,13 @@
         @options: Vardict with optional further information
 
         Notifies about a shortcut becoming active.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate a window in response to the
+          shortcut getting activated.
     -->
     <signal name="Activated">
       <arg type="o" name="session_handle" direction="out"/>
@@ -231,6 +238,13 @@
         @options: Vardict with optional further information
 
         Notifies that a shortcut is not active anymore.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate a window in response to the
+          shortcut getting deactivated.
     -->
     <signal name="Deactivated">
       <arg type="o" name="session_handle" direction="out"/>


### PR DESCRIPTION
There is no implementation required in the portal as the options are passed through from the backend to the app.

Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1678