### PR TITLE
background: Rely on the app id being available to use autostart

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -701,23 +701,18 @@ enable_autostart_sync (XdpAppInfo          *app_info,
   g_autofree char *path = NULL;
   g_autoptr(GKeyFile) keyfile = NULL;
   const char *appid = xdp_app_info_get_id (app_info);
-  GAppInfo *info;
+  GAppInfo *info = xdp_app_info_get_gappinfo (app_info);
 
-  if (!appid)
+  if (g_strcmp0 (appid, "") == 0)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
-                   "Autostart not supported");
+                   "Autostart not supported (no AppId detected)");
       return FALSE;
     }
 
-  info = xdp_app_info_get_gappinfo (app_info);
   file = g_strconcat (appid, ".desktop", NULL);
   dir = g_build_filename (g_get_user_config_dir (), "autostart", NULL);
-
-  if (info)
-    path = g_build_filename (dir, g_app_info_get_id (info), NULL);
-  else
-    path = g_build_filename (dir, file, NULL);
+  path = g_build_filename (dir, file, NULL);
 
   if (!enable)
     {


### PR DESCRIPTION
This was the intent anyway, but the check for the app id was wrong (comparing against NULL instead of "").

If apps want to use this, they have to ensure an app id is detected for them, which might require using the host registry portal for host apps.

Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1742