### PR TITLE
document/fuse: Give up trying to unmount an existing fuse mount

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -3615,18 +3615,17 @@ xdp_fuse_init (GError **error)
   path = xdp_fuse_get_mountpoint ();
 
   if ((stat (path, &st) == -1 && errno == ENOTCONN) ||
-      (((statfs_res = statfs (path, &stfs)) == -1 && errno == ENOTCONN) ||
-       (statfs_res == 0 && stfs.f_type == 0x65735546 /* fuse */)))
+      ((statfs_res = statfs (path, &stfs)) == -1 && errno == ENOTCONN) ||
+      (statfs_res == 0 && stfs.f_type == 0x65735546 /* fuse */))
     {
-      int count;
+      int count = 0;
       char *umount_argv[] = { "fusermount3", "-u", "-z", (char *) path, NULL };
 
       g_spawn_sync (NULL, umount_argv, NULL, G_SPAWN_SEARCH_PATH,
                     NULL, NULL, NULL, NULL, NULL, NULL);
 
       g_usleep (10000); /* 10ms */
-      count = 0;
-      while (stat (path, &st) == -1 && count < 10)
+      while (stat (path, &st) == -1 && count++ < 10)
         g_usleep (10000); /* 10ms */
     }
 


### PR DESCRIPTION
This was clearly the intention, but not incrementing `count` makes it an infinite loop if fusermount3 -u doesn't manage to do its job.

Also slightly clean up the if condition before.