### PR TITLE
app-info: Adjust to xdp_app_info_new consuming the pidfd in

### DIFF
--- a/src/xdp-app-info-host-private.h
+++ b/src/xdp-app-info-host-private.h
@@ -36,7 +36,7 @@ XdpAppInfo * xdp_app_info_host_new (int  pid,
                                     int *pidfd);
 
 XdpAppInfo *
-xdp_app_info_host_new_registered (int         *pidfd,
+xdp_app_info_host_new_registered (int          pidfd,
                                   const char  *app_id,
                                   GError     **error);
 

--- a/src/xdp-app-info-host-private.h
+++ b/src/xdp-app-info-host-private.h
@@ -36,7 +36,8 @@ XdpAppInfo * xdp_app_info_host_new (int  pid,
                                     int *pidfd);
 
 XdpAppInfo *
-xdp_app_info_host_new_registered (int          pidfd,
+xdp_app_info_host_new_registered (int          pid,
+                                  int          pidfd,
                                   const char  *app_id,
                                   GError     **error);
 

--- a/src/xdp-app-info-host.c
+++ b/src/xdp-app-info-host.c
@@ -185,24 +185,20 @@ get_appid_from_pid (pid_t pid)
 #endif /* HAVE_LIBSYSTEMD */
 }
 
-/*
- * @pidfd: (inout) (not nullable): Pointer to process ID file descriptor.
- *  This function may take ownership of the fd. If it does, it will
- *  set `*pidfd` to -1.
- */
 XdpAppInfo *
-xdp_app_info_host_new_registered (int         *pidfd,
+xdp_app_info_host_new_registered (int          pidfd,
                                   const char  *app_id,
                                   GError     **error)
 {
   g_autoptr(XdpAppInfoHost) app_info_host = NULL;
+  g_autofd int pidfd_owned = pidfd;
 
   app_info_host = g_initable_new (XDP_TYPE_APP_INFO_HOST,
                                   NULL,
                                   error,
                                   "engine", NULL,
                                   "id", app_id,
-                                  "pidfd", g_steal_fd (pidfd),
+                                  "pidfd", g_steal_fd (&pidfd_owned),
                                   "flags", XDP_APP_INFO_FLAG_HAS_NETWORK |
                                            XDP_APP_INFO_FLAG_SUPPORTS_OPATH |
                                            XDP_APP_INFO_FLAG_REQUIRE_GAPPINFO,

--- a/src/xdp-app-info-host.c
+++ b/src/xdp-app-info-host.c
@@ -185,13 +185,36 @@ get_appid_from_pid (pid_t pid)
 #endif /* HAVE_LIBSYSTEMD */
 }
 
+static void
+maybe_get_pidfd_from_pid (int  pid,
+                          int *pidfd)
+{
+  g_autoptr(GError) error = NULL;
+
+  if (*pidfd >= 0)
+    return;
+
+  /* There are no security guarantees for host apps, so let's just make sure
+   * we get the pidfd from the pid. It is racy (pid could be recycled) but it
+   * doesn't matter here.
+   */
+  if (!xdp_pid_to_pidfd (pid, pidfd, &error))
+    {
+      g_warning ("Failed to get pidfd for host process %d: %s",
+                 pid, error->message);
+    }
+}
+
 XdpAppInfo *
-xdp_app_info_host_new_registered (int          pidfd,
+xdp_app_info_host_new_registered (int          pid,
+                                  int          pidfd,
                                   const char  *app_id,
                                   GError     **error)
 {
   g_autoptr(XdpAppInfoHost) app_info_host = NULL;
   g_autofd int pidfd_owned = pidfd;
+
+  maybe_get_pidfd_from_pid (pid, &pidfd_owned);
 
   app_info_host = g_initable_new (XDP_TYPE_APP_INFO_HOST,
                                   NULL,
@@ -233,20 +256,7 @@ xdp_app_info_host_new (int  pid,
       app_id = get_appid_from_pid (pid);
     }
 
-  /* There are no security guarantees for host apps, so let's just make sure
-   * we get the pidfd from the pid. It is racy (pid could be recycled) but it
-   * doesn't matter here.
-   */
-  if (*pidfd == -1)
-    {
-      g_autoptr(GError) local_error = NULL;
-
-      if (!xdp_pid_to_pidfd (pid, pidfd, &local_error))
-        {
-          g_warning ("Failed to get pidfd for host process %d: %s",
-                     pid, local_error->message);
-        }
-    }
+  maybe_get_pidfd_from_pid (pid, pidfd);
 
   app_info_host = g_initable_new (XDP_TYPE_APP_INFO_HOST,
                                   NULL,

--- a/src/xdp-app-info.c
+++ b/src/xdp-app-info.c
@@ -1072,7 +1072,7 @@ xdp_invocation_register_host_app_info_sync (GDBusMethodInvocation  *invocation,
       return NULL;
     }
 
-  app_info = xdp_app_info_host_new_registered (g_steal_fd (&pidfd_dup),
+  app_info = xdp_app_info_host_new_registered (pid, g_steal_fd (&pidfd_dup),
                                                app_id, error);
   if (!app_info)
     return NULL;


### PR DESCRIPTION
Let's steal the fd so it becomes absolutely clear what's going on there, and then get a new fd for xdp_app_info_host_new_registered.