### PR TITLE
secret: Init asynchronously

### DIFF
--- a/src/secret.c
+++ b/src/secret.c
@@ -192,26 +192,50 @@ secret_class_init (SecretClass *klass)
 }
 
 GDBusInterfaceSkeleton *
-secret_create (GDBusConnection *connection,
-	       const char      *dbus_name)
+secret_create_finish (GAsyncResult  *result,
+                      GError       **error)
 {
+  GTask *task = G_TASK (result);
+
+  return g_task_propagate_pointer (task, error);
+}
+
+static void
+proxy_created_cb (GObject      *source_object,
+                  GAsyncResult *result,
+                  gpointer      user_data)
+{
+  g_autoptr(GTask) task = G_TASK (user_data);
   g_autoptr(GError) error = NULL;
 
-  impl = xdp_dbus_impl_secret_proxy_new_sync (connection,
-                                              G_DBUS_PROXY_FLAGS_NONE,
-                                              dbus_name,
-                                              DESKTOP_PORTAL_OBJECT_PATH,
-                                              NULL,
-                                              &error);
-  if (impl == NULL)
+  impl = xdp_dbus_impl_secret_proxy_new_finish (result, &error);
+  if (!impl)
     {
-      g_warning ("Failed to create secret proxy: %s", error->message);
-      return NULL;
+      g_task_return_error (task, g_steal_pointer (&error));
+      return;
     }
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl), G_MAXINT);
 
   secret = g_object_new (secret_get_type (), NULL);
+  g_task_return_pointer (task, secret, g_object_unref);
+}
 
-  return G_DBUS_INTERFACE_SKELETON (secret);
+void
+secret_create_async (GDBusConnection     *connection,
+                     const char          *dbus_name,
+                     GCancellable        *cancellable,
+                     GAsyncReadyCallback  callback,
+                     gpointer             user_data)
+{
+  g_autoptr(GTask) task = NULL;
+
+  task = g_task_new (NULL, cancellable, callback, user_data);
+  xdp_dbus_impl_secret_proxy_new (connection,
+                                  G_DBUS_PROXY_FLAGS_NONE,
+                                  dbus_name,
+                                  DESKTOP_PORTAL_OBJECT_PATH,
+                                  cancellable,
+                                  proxy_created_cb,
+                                  g_steal_pointer (&task));
 }

--- a/src/secret.h
+++ b/src/secret.h
@@ -24,5 +24,11 @@
 
 #include <gio/gio.h>
 
-GDBusInterfaceSkeleton * secret_create (GDBusConnection *connection,
-					const char *dbus_name);
+GDBusInterfaceSkeleton * secret_create_finish (GAsyncResult  *result,
+                                               GError       **error);
+
+void secret_create_async (GDBusConnection     *connection,
+                          const char          *dbus_name,
+                          GCancellable        *cancellable,
+                          GAsyncReadyCallback  callback,
+                          gpointer             user_data);

--- a/src/xdp-context.c
+++ b/src/xdp-context.c
@@ -69,6 +69,8 @@ struct _XdpContext
   gboolean verbose;
 
   XdpPortalConfig *portal_config;
+
+  GCancellable *cancellable;
 };
 
 G_DEFINE_FINAL_TYPE (XdpContext,
@@ -80,6 +82,8 @@ xdp_context_dispose (GObject *object)
 {
   XdpContext *context = XDP_CONTEXT (object);
 
+  g_cancellable_cancel (context->cancellable);
+  g_clear_object (&context->cancellable);
   g_clear_object (&context->portal_config);
 
   G_OBJECT_CLASS (xdp_context_parent_class)->dispose (object);
@@ -96,6 +100,7 @@ xdp_context_class_init (XdpContextClass *klass)
 static void
 xdp_context_init (XdpContext *context)
 {
+  context->cancellable = g_cancellable_new ();
 }
 
 XdpContext *
@@ -238,6 +243,27 @@ on_peer_died (const char *name)
   xdp_session_persistence_delete_transient_permissions_for_sender (name);
 }
 
+static void
+secret_impl_created_cb (GObject      *source_object,
+                        GAsyncResult *result,
+                        gpointer      user_data)
+{
+  GDBusConnection *connection;
+  g_autoptr(GDBusInterfaceSkeleton) skeleton = NULL;
+  g_autoptr(GError) error = NULL;
+
+  skeleton = secret_create_finish (result, &error);
+  if (!skeleton)
+    {
+      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        g_warning ("Failed to create secret proxy: %s", error->message);
+      return;
+    }
+
+  connection = G_DBUS_CONNECTION (user_data);
+  export_portal_implementation (connection, g_steal_pointer (&skeleton));
+}
+
 gboolean
 xdp_context_register (XdpContext       *context,
                       GDBusConnection  *connection,
@@ -368,8 +394,8 @@ xdp_context_register (XdpContext       *context,
 
   impl_config = xdp_portal_config_find (portal_config, "org.freedesktop.impl.portal.Secret");
   if (impl_config != NULL)
-    export_portal_implementation (connection,
-                                  secret_create (connection, impl_config->dbus_name));
+    secret_create_async (connection, impl_config->dbus_name,
+                         context->cancellable, secret_impl_created_cb, connection);
 
   impl_config = xdp_portal_config_find (portal_config, "org.freedesktop.impl.portal.GlobalShortcuts");
   if (impl_config != NULL)


### PR DESCRIPTION
When run in a nested D-Bus session, the secret portal backend tends to fail to launch due to another secret service running within the same $XDG_RUNTIME_DIR. Handle this without blocking by initializing the secret portal asynchronously.

-----

Not sure we want to do this, but currently the secret portal is causing annoyingly long timeouts causing when the portal is run in a nested D-Bus session using dbus-run-session.

Might be sensible to eventually initialize all portal backends asynchronously, but I suspect that is more feasible with libdex.

I'm not sure it's feasible to fix the secret backend (gnome-keyring), without significantly changing how it works (i.e. without `$XDG_RUNTIME_DIR/keyring`, or muliple ones, I imagine), or switching to a completely different backend.