### PR TITLE
data: Clarify the usage of the notification ActionInvoked parameter

### DIFF
--- a/data/org.freedesktop.impl.portal.Notification.xml
+++ b/data/org.freedesktop.impl.portal.Notification.xml
@@ -92,11 +92,14 @@
         Send to the application when a non-exported action is
         activated.
 
-        The @parameter contains the following values in order:
+        The @parameter is an array of variants that contains
+        the following values in order:
 
-        #. The `target` for the action, if one was specified.
+        #. The `target` for the action (``v``) (the value may
+           be unset, but the variant must be always present).
 
-        #. The `platform-data` as vardict containing an ``activation-token`` (``s``) for
+        #. The `platform-data` as vardict (``a{sv}``) containing
+           an ``activation-token`` (``s``) for
            `XDG Activation
            <https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/xdg-activation/xdg-activation-v1.xml>`_
     -->

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -408,11 +408,14 @@
         Send to the application when a non-exported action is
         activated.
 
-        The @parameter contains the following values in order:
+        The @parameter is an array of variants that contains
+        the following values in order:
 
-        #. The `target` for the action, if one was specified.
+        #. The `target` for the action (``v``) (the value may
+           be unset, but the variant must be always present).
 
-        #. The `platform-data` as vardict (``a{sv}``) containing an ``activation-token`` (``s``) for
+        #. The `platform-data` as vardict (``a{sv}``) containing
+           an ``activation-token`` (``s``) for
            `XDG Activation
            <https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/xdg-activation/xdg-activation-v1.xml>`_
 


### PR DESCRIPTION
It's not very clear how the target value is used with the platform data, so at least avoid the potential misunderstanding, by clarifying that the target value is a variant that must be always present, even if unset

/cc @swick @jsparber 