### PR TITLE
main: Initialize option booleans

### DIFF
--- a/src/xdp-main.c
+++ b/src/xdp-main.c
@@ -131,9 +131,9 @@ main (int argc, char *argv[])
   g_autoptr(GSource) signal_handler_source = NULL;
   g_autoptr(GOptionContext) option_context = NULL;
 
-  gboolean opt_verbose;
-  gboolean opt_replace;
-  gboolean opt_show_version;
+  gboolean opt_verbose = FALSE;
+  gboolean opt_replace = FALSE;
+  gboolean opt_show_version = FALSE;
 
   GOptionEntry entries[] = {
     { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print debug information during command processing", NULL },


### PR DESCRIPTION
Otherwise, if the uninitialized memory isn't zero'd out for whatever reason, these booleans will magically become true!

On my system, opt_show_version consistently initializes to something non-zero and thus xdg-desktop-portal just prints its version number and exits