### PR TITLE
ProxyResolver 2.0, with Proxy portal backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.buildconfig

--- a/data/meson.build
+++ b/data/meson.build
@@ -59,6 +59,7 @@ portal_impl_sources = files(
   'org.freedesktop.impl.portal.Notification.xml',
   'org.freedesktop.impl.portal.PermissionStore.xml',
   'org.freedesktop.impl.portal.Print.xml',
+  'org.freedesktop.impl.portal.Proxy.xml',
   'org.freedesktop.impl.portal.RemoteDesktop.xml',
   'org.freedesktop.impl.portal.Request.xml',
   'org.freedesktop.impl.portal.ScreenCast.xml',

--- a/data/org.freedesktop.impl.portal.Proxy.xml
+++ b/data/org.freedesktop.impl.portal.Proxy.xml
@@ -46,13 +46,7 @@
     <property name="pac_url" type="s" access="read"/>
     <property name="https_proxy" type="as" access="read"/>
     <property name="http_proxy" type="as" access="read"/>
-    <!--
-      socks_proxy:
-      An integer value of 0 is equivalent to SOCKS; of 4 is SOCKS4,
-      and 5 is SOCKS5. Any other value is invalid, but if present, can
-      be assumed to be equivalent to 0.
-    -->
-    <property name="socks_proxy" type="a(su)" access="read"/>
+    <property name="socks_proxy" type="as" access="read"/>
     <property name="ftp_proxy" type="as" access="read"/>
     <property name="ignored_hosts" type="as" access="read"/>
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.impl.portal.Proxy.xml
+++ b/data/org.freedesktop.impl.portal.Proxy.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2025 Dallas Strouse
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Dallas Strouse <dallas.strouse2007@gmail.com>
+-->
+<node xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd" name="/">
+  <!--
+      org.freedesktop.impl.portal.Proxy:
+      @short_description: Proxy information
+
+      The Proxy interface provides network proxy information to
+      xdg-desktop-portal, which then provides this information to sandboxed
+      applications.
+
+      All properties are allowed to exist at the same time; however, if pac_url
+      exists, other properties shouldn't be utilized without user intervention,
+      and aren't guaranteed to exist, or even match what pac_url would be
+      equivalent to.
+
+      This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.impl.portal.Proxy">
+    <!--
+    The following values are valid:
+      0: Proxy should not be used.
+      1: Automatic proxy mode; use pac_url.
+      2: Manual proxy mode; read associated settings manually.
+    -->
+    <property name="use_proxy" type="u" access="read"/>
+    <property name="pac_url" type="s" access="read"/>
+    <property name="https_proxy" type="as" access="read"/>
+    <property name="http_proxy" type="as" access="read"/>
+    <!--
+      socks_proxy:
+      An integer value of 0 is equivalent to SOCKS; of 4 is SOCKS4,
+      and 5 is SOCKS5. Any other value is invalid, but if present, can
+      be assumed to be equivalent to 0.
+    -->
+    <property name="socks_proxy" type="a(su)" access="read"/>
+    <property name="ftp_proxy" type="as" access="read"/>
+    <property name="ignored_hosts" type="as" access="read"/>
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>
+

--- a/data/org.freedesktop.impl.portal.Proxy.xml
+++ b/data/org.freedesktop.impl.portal.Proxy.xml
@@ -39,8 +39,8 @@
     <!--
     The following values are valid:
       0: Proxy should not be used.
-      1: Automatic proxy mode; use pac_url.
-      2: Manual proxy mode; read associated settings manually.
+      1: Manual proxy mode; read associated settings manually.
+      2: Automatic proxy mode; use pac_url
     -->
     <property name="use_proxy" type="u" access="read"/>
     <property name="pac_url" type="s" access="read"/>

--- a/data/org.freedesktop.portal.ProxyResolver.xml
+++ b/data/org.freedesktop.portal.ProxyResolver.xml
@@ -48,7 +48,9 @@
         protocol. ``direct://`` is used when no proxy is needed.
 
         This is a convenience wrapper over reading the PAC file or the other
-        portal settings, in that order of priority from highest to lowest.
+        portal settings, in that order of priority from highest to lowest. It
+        is provided to ensure backwards compatibility with older versions
+        of GLib.
     -->
     <method name="Lookup">
       <arg type="s" name="uri" direction="in"/>
@@ -76,14 +78,9 @@
     -->
     <property name="http_proxy" type="as" access="read"/>
     <!--
-      socks_proxy:
-      An integer value of 0 is equivalent to SOCKS; of 4 is SOCKS4,
-      and 5 is SOCKS5. Any other value is invalid, but if present, can
-      be assumed to be equivalent to 0.
-
       This property was added in version 2.
     -->
-    <property name="socks_proxy" type="a(su)" access="read"/>
+    <property name="socks_proxy" type="as" access="read"/>
     <!--
       This property was added in version 2.
     -->

--- a/data/org.freedesktop.portal.ProxyResolver.xml
+++ b/data/org.freedesktop.portal.ProxyResolver.xml
@@ -1,6 +1,7 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  Copyright (C) 2016 Red Hat, Inc.
+ Copyright (C) 2025 Dallas Strouse
 
  SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -18,8 +19,9 @@
  License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
  Author: Matthias Clasen <mclasen@redhat.com>
+ Author: Dallas Strouse @ v2 <dallas.strouse2007@mail.com>
 -->
-<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+<node xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd" name="/">
   <!--
       org.freedesktop.portal.ProxyResolver:
       @short_description: Proxy information
@@ -29,7 +31,10 @@
       user interaction. Applications are expected to use this interface indirectly,
       via a library API such as the GLib GProxyResolver interface.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes version 2 of this interface.
+
+      If pac_url exists, it should be the only setting read;
+      if it doesn't, the associated dbus properties should be utilized.
   -->
   <interface name="org.freedesktop.portal.ProxyResolver">
     <!--
@@ -41,11 +46,53 @@
         proxy uri are of the form ``protocol://[user[:password] AT host:port``.
         The protocol can be ``http``, ``rtsp``, ``socks`` or another proxying
         protocol. ``direct://`` is used when no proxy is needed.
+
+        This is a convenience wrapper over reading the PAC file or the other
+        portal settings, in that order of priority from highest to lowest.
     -->
     <method name="Lookup">
       <arg type="s" name="uri" direction="in"/>
       <arg type="as" name="proxies" direction="out"/>
     </method>
+    <!--
+    The following values are valid:
+      0: Proxy should not be used.
+      1: Automatic proxy mode; use pac_url.
+      2: Manual proxy mode; read associated settings manually.
+
+      This property was added in version 2.
+    -->
+    <property name="use_proxy" type="u" access="read"/>
+    <!--
+      This property was added in version 2.
+    -->
+    <property name="pac_url" type="s" access="read"/>
+    <!--
+      This property was added in version 2.
+    -->
+    <property name="https_proxy" type="as" access="read"/>
+    <!--
+      This property was added in version 2.
+    -->
+    <property name="http_proxy" type="as" access="read"/>
+    <!--
+      socks_proxy:
+      An integer value of 0 is equivalent to SOCKS; of 4 is SOCKS4,
+      and 5 is SOCKS5. Any other value is invalid, but if present, can
+      be assumed to be equivalent to 0.
+
+      This property was added in version 2.
+    -->
+    <property name="socks_proxy" type="a(su)" access="read"/>
+    <!--
+      This property was added in version 2.
+    -->
+    <property name="ftp_proxy" type="as" access="read"/>
+    <!--
+      This property was added in version 2.
+    -->
+    <property name="ignored_hosts" type="as" access="read"/>
     <property name="version" type="u" access="read"/>
   </interface>
 </node>
+

--- a/doc/impl-dbus-interfaces.rst
+++ b/doc/impl-dbus-interfaces.rst
@@ -23,6 +23,7 @@ accessible to sandboxed applications.
    doc-org.freedesktop.impl.portal.Notification.rst
    doc-org.freedesktop.impl.portal.PermissionStore.rst
    doc-org.freedesktop.impl.portal.Print.rst
+   doc-org.freedesktop.impl.portal.Proxy.rst
    doc-org.freedesktop.impl.portal.RemoteDesktop.rst
    doc-org.freedesktop.impl.portal.Request.rst
    doc-org.freedesktop.impl.portal.ScreenCast.rst

--- a/src/proxy-resolver.c
+++ b/src/proxy-resolver.c
@@ -22,13 +22,14 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <gio/gio.h>
+#include <string.h>
 
 #include "proxy-resolver.h"
-#include "xdp-call.h"
 #include "xdp-app-info.h"
+#include "xdp-call.h"
 #include "xdp-dbus.h"
+#include "xdp-impl-dbus.h"
 #include "xdp-utils.h"
 
 typedef struct _ProxyResolver ProxyResolver;
@@ -46,22 +47,21 @@ struct _ProxyResolverClass
   XdpDbusProxyResolverSkeletonClass parent_class;
 };
 
+static XdpDbusImplProxy *impl;
 static ProxyResolver *proxy_resolver;
+static guint32 proxy_resolver_version = 1;
 
 GType proxy_resolver_get_type (void) G_GNUC_CONST;
 static void proxy_resolver_iface_init (XdpDbusProxyResolverIface *iface);
 
-G_DEFINE_TYPE_WITH_CODE (ProxyResolver, proxy_resolver,
-                         XDP_DBUS_TYPE_PROXY_RESOLVER_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_PROXY_RESOLVER,
-                                                proxy_resolver_iface_init));
+G_DEFINE_TYPE_WITH_CODE (ProxyResolver, proxy_resolver, XDP_DBUS_TYPE_PROXY_RESOLVER_SKELETON, G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_PROXY_RESOLVER, proxy_resolver_iface_init));
 
 static gboolean
 proxy_resolver_handle_lookup (XdpDbusProxyResolver *object,
                               GDBusMethodInvocation *invocation,
                               const char *arg_uri)
 {
-  ProxyResolver *resolver = (ProxyResolver *)object;
+  ProxyResolver *resolver = (ProxyResolver *) object;
   XdpCall *call = xdp_call_from_invocation (invocation);
 
   if (!xdp_app_info_has_network (call->app_info))
@@ -88,9 +88,55 @@ proxy_resolver_handle_lookup (XdpDbusProxyResolver *object,
 }
 
 static void
+on_proxy_properties_changed (GObject *gobject,
+                             GParamSpec *pspec,
+                             ProxyResolver *resolver)
+{
+  const char *name = g_param_spec_get_name (pspec);
+  XdpDbusImplProxy *p = XDP_DBUS_IMPL_PROXY (gobject);
+  XdpDbusImplProxyIface *iface = XDP_DBUS_IMPL_PROXY_GET_IFACE (p);
+
+  if (g_strcmp0 (name, "use_proxy") == 0)
+    {
+      xdp_dbus_proxy_resolver_set_use_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                             iface->get_use_proxy (p));
+    }
+  else if (g_strcmp0 (name, "pac_url") == 0)
+    {
+      xdp_dbus_proxy_resolver_set_pac_url (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                           iface->get_pac_url (p));
+    }
+  else if (g_strcmp0 (name, "https_proxy") == 0)
+    {
+      xdp_dbus_proxy_resolver_set_https_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                               iface->get_https_proxy (p));
+    }
+  else if (g_strcmp0 (name, "http_proxy") == 0)
+    {
+      xdp_dbus_proxy_resolver_set_http_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                              iface->get_http_proxy (p));
+    }
+  else if (g_strcmp0 (name, "socks_proxy") == 0)
+    {
+      xdp_dbus_proxy_resolver_set_socks_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                               iface->get_socks_proxy (p));
+    }
+  else if (g_strcmp0 (name, "ftp_proxy") == 0)
+    {
+      xdp_dbus_proxy_resolver_set_ftp_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                             iface->get_ftp_proxy (p));
+    }
+  else if (g_strcmp0 (name, "ignored_hosts") == 0)
+    {
+      xdp_dbus_proxy_resolver_set_ignored_hosts (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                                 iface->get_ignored_hosts (p));
+    }
+}
+
+static void
 proxy_resolver_dispose (GObject *object)
 {
-  ProxyResolver *resolver = (ProxyResolver *)object;
+  ProxyResolver *resolver = (ProxyResolver *) object;
 
   g_clear_object (&resolver->resolver);
 }
@@ -106,7 +152,54 @@ proxy_resolver_init (ProxyResolver *resolver)
 {
   resolver->resolver = g_proxy_resolver_get_default ();
 
-  xdp_dbus_proxy_resolver_set_version (XDP_DBUS_PROXY_RESOLVER (resolver), 1);
+  xdp_dbus_proxy_resolver_set_version (XDP_DBUS_PROXY_RESOLVER (resolver), proxy_resolver_version);
+
+  if (impl)
+    {
+      g_signal_connect (impl, "notify::use_proxy",
+                        G_CALLBACK (on_proxy_properties_changed),
+                        resolver);
+      xdp_dbus_proxy_resolver_set_use_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                             XDP_DBUS_IMPL_PROXY_GET_IFACE (impl)->get_use_proxy (impl));
+
+      g_signal_connect (impl, "notify::pac_url",
+                        G_CALLBACK (on_proxy_properties_changed),
+                        resolver);
+      xdp_dbus_proxy_resolver_set_pac_url (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                           XDP_DBUS_IMPL_PROXY_GET_IFACE (impl)->get_pac_url (impl));
+
+      g_signal_connect (impl, "notify::https_proxy",
+                        G_CALLBACK (on_proxy_properties_changed),
+                        resolver);
+      xdp_dbus_proxy_resolver_set_https_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                               XDP_DBUS_IMPL_PROXY_GET_IFACE (impl)->get_https_proxy (impl));
+
+      g_signal_connect (impl, "notify::http_proxy",
+                        G_CALLBACK (on_proxy_properties_changed),
+                        resolver);
+      xdp_dbus_proxy_resolver_set_http_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                              XDP_DBUS_IMPL_PROXY_GET_IFACE (impl)->get_http_proxy (impl));
+
+      g_signal_connect (impl, "notify::socks_proxy",
+                        G_CALLBACK (on_proxy_properties_changed),
+                        resolver);
+      xdp_dbus_proxy_resolver_set_socks_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                               XDP_DBUS_IMPL_PROXY_GET_IFACE (impl)->get_socks_proxy (impl));
+
+      g_signal_connect (impl, "notify::ftp_proxy",
+                        G_CALLBACK (on_proxy_properties_changed),
+                        resolver);
+
+      xdp_dbus_proxy_resolver_set_ftp_proxy (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                             XDP_DBUS_IMPL_PROXY_GET_IFACE (impl)->get_ftp_proxy (impl));
+
+      g_signal_connect (impl, "notify::ignored_hosts",
+                        G_CALLBACK (on_proxy_properties_changed),
+                        resolver);
+
+      xdp_dbus_proxy_resolver_set_ignored_hosts (XDP_DBUS_PROXY_RESOLVER (resolver),
+                                                 XDP_DBUS_IMPL_PROXY_GET_IFACE (impl)->get_ignored_hosts (impl));
+    }
 }
 
 static void
@@ -118,8 +211,22 @@ proxy_resolver_class_init (ProxyResolverClass *klass)
 }
 
 GDBusInterfaceSkeleton *
-proxy_resolver_create (GDBusConnection *connection)
+proxy_resolver_create (GDBusConnection *connection,
+                       const char *dbus_name)
 {
+  g_autoptr (GError) error = NULL;
+
+  if (dbus_name)
+    impl = xdp_dbus_impl_proxy_proxy_new_sync (connection,
+                                               G_DBUS_PROXY_FLAGS_NONE,
+                                               dbus_name,
+                                               DESKTOP_PORTAL_OBJECT_PATH,
+                                               NULL, &error);
+  if (impl)
+    proxy_resolver_version = 2;
+  else if (error)
+    g_warning ("Failed to create proxy portal backend: %s, falling back to proxy resolver 1.0", error->message);
+
   proxy_resolver = g_object_new (proxy_resolver_get_type (), NULL);
 
   return G_DBUS_INTERFACE_SKELETON (proxy_resolver);

--- a/src/proxy-resolver.h
+++ b/src/proxy-resolver.h
@@ -20,9 +20,9 @@
  *       Matthias Clasen <mclasen@redhat.com>
  */
 
-
 #pragma once
 
 #include <gio/gio.h>
 
-GDBusInterfaceSkeleton * proxy_resolver_create (GDBusConnection *connection);
+GDBusInterfaceSkeleton *proxy_resolver_create (GDBusConnection *connection, const char *dbus_name);
+

--- a/src/xdp-context.c
+++ b/src/xdp-context.c
@@ -308,6 +308,11 @@ xdp_context_register (XdpContext *context,
     export_portal_implementation (connection,
                                   print_create (connection, impl_config->dbus_name, lockdown));
 
+  impl_config = xdp_portal_config_find (portal_config, "org.freedesktop.impl.portal.Notification");
+  if (impl_config != NULL)
+    export_portal_implementation (connection,
+                                  proxy_resolver_create (connection, impl_config->dbus_name));
+
   impl_config = xdp_portal_config_find (portal_config, "org.freedesktop.impl.portal.Proxy");
   if (impl_config != NULL)
     export_portal_implementation (connection,

--- a/src/xdp-context.c
+++ b/src/xdp-context.c
@@ -19,7 +19,6 @@
 
 #include "config.h"
 
-#include "xdp-utils.h"
 #include "xdp-call.h"
 #include "xdp-dbus.h"
 #include "xdp-documents.h"
@@ -27,6 +26,7 @@
 #include "xdp-method-info.h"
 #include "xdp-portal-config.h"
 #include "xdp-session-persistence.h"
+#include "xdp-utils.h"
 
 #include "account.h"
 #include "background.h"
@@ -44,14 +44,12 @@
 #include "network-monitor.h"
 #include "notification.h"
 #include "open-uri.h"
-#include "xdp-permissions.h"
 #include "power-profile-monitor.h"
 #include "print.h"
 #include "proxy-resolver.h"
 #include "realtime.h"
 #include "registry.h"
 #include "remote-desktop.h"
-#include "xdp-request.h"
 #include "screen-cast.h"
 #include "screenshot.h"
 #include "secret.h"
@@ -59,6 +57,8 @@
 #include "trash.h"
 #include "usb.h"
 #include "wallpaper.h"
+#include "xdp-permissions.h"
+#include "xdp-request.h"
 
 #include "xdp-context.h"
 
@@ -131,16 +131,16 @@ method_needs_request (GDBusMethodInvocation *invocation)
     g_warning ("Support for %s::%s missing in %s",
                interface, method, G_STRLOC);
 
-  return method_info ?  method_info->uses_request : TRUE;
+  return method_info ? method_info->uses_request : TRUE;
 }
 
 static gboolean
 authorize_callback (GDBusInterfaceSkeleton *interface,
-                    GDBusMethodInvocation  *invocation,
-                    gpointer                user_data)
+                    GDBusMethodInvocation *invocation,
+                    gpointer user_data)
 {
-  g_autoptr(XdpAppInfo) app_info = NULL;
-  g_autoptr(GError) error = NULL;
+  g_autoptr (XdpAppInfo) app_info = NULL;
+  g_autoptr (GError) error = NULL;
 
   app_info = xdp_invocation_ensure_app_info_sync (invocation, NULL, &error);
   if (app_info == NULL)
@@ -167,10 +167,10 @@ authorize_callback (GDBusInterfaceSkeleton *interface,
 }
 
 static void
-export_portal_implementation (GDBusConnection        *connection,
+export_portal_implementation (GDBusConnection *connection,
                               GDBusInterfaceSkeleton *skeleton)
 {
-  g_autoptr(GError) error = NULL;
+  g_autoptr (GError) error = NULL;
 
   if (skeleton == NULL)
     {
@@ -196,7 +196,7 @@ export_portal_implementation (GDBusConnection        *connection,
 }
 
 static void
-export_host_portal_implementation (GDBusConnection        *connection,
+export_host_portal_implementation (GDBusConnection *connection,
                                    GDBusInterfaceSkeleton *skeleton)
 {
   /* Host portal dbus method invocations run in the main thread without yielding
@@ -207,7 +207,7 @@ export_host_portal_implementation (GDBusConnection        *connection,
    * method calls must see the modified value.
    */
 
-  g_autoptr(GError) error = NULL;
+  g_autoptr (GError) error = NULL;
 
   if (skeleton == NULL)
     {
@@ -239,9 +239,9 @@ on_peer_died (const char *name)
 }
 
 gboolean
-xdp_context_register (XdpContext       *context,
-                      GDBusConnection  *connection,
-                      GError          **error)
+xdp_context_register (XdpContext *context,
+                      GDBusConnection *connection,
+                      GError **error)
 {
   XdpPortalConfig *portal_config = context->portal_config;
   XdpImplConfig *impl_config;
@@ -284,7 +284,6 @@ xdp_context_register (XdpContext       *context,
   export_portal_implementation (connection, memory_monitor_create (connection));
   export_portal_implementation (connection, power_profile_monitor_create (connection));
   export_portal_implementation (connection, network_monitor_create (connection));
-  export_portal_implementation (connection, proxy_resolver_create (connection));
   export_portal_implementation (connection, trash_create (connection));
   export_portal_implementation (connection, game_mode_create (connection));
   export_portal_implementation (connection, realtime_create (connection));
@@ -309,10 +308,13 @@ xdp_context_register (XdpContext       *context,
     export_portal_implementation (connection,
                                   print_create (connection, impl_config->dbus_name, lockdown));
 
-  impl_config = xdp_portal_config_find (portal_config, "org.freedesktop.impl.portal.Notification");
+  impl_config = xdp_portal_config_find (portal_config, "org.freedesktop.impl.portal.Proxy");
   if (impl_config != NULL)
     export_portal_implementation (connection,
-                                  notification_create (connection, impl_config->dbus_name));
+                                  proxy_resolver_create (connection, impl_config->dbus_name));
+  else
+    export_portal_implementation (connection,
+                                  proxy_resolver_create (connection, NULL));
 
   impl_config = xdp_portal_config_find (portal_config, "org.freedesktop.impl.portal.Inhibit");
   if (impl_config != NULL)


### PR DESCRIPTION
This is a skeleton to test the waters to resolve https://github.com/flatpak/xdg-desktop-portal/issues/554.

I experimented with implementing this full API in libproxy, and determined that it would be easier to have portal backends provide the information via the Proxy backend portal, and have libproxy build on top of that. Browsers and other semi-advanced use cases can read the Portal properties directly if necessary.