### PR TITLE
file-chooser: Enable asking for both files and dirs simultaneously.

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -63,6 +63,11 @@
 
           Whether to select for folders instead of files. Default is to select files.
 
+        * ``file_directory`` (``b``)
+
+          Whether to select for both files and folders. Default is to select files.
+          If this option is ``true``, the ``directory`` option is ignored.
+
         * ``filters`` (``a(sa(us))``)
 
           A list of serialized file filters.

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -75,6 +75,11 @@
 
         This option was added in version 3.
 
+      * ``file_directory`` (``b``)
+
+        Whether to select for both files and folders. Default is to select files.
+        If this option is ``true``, the ``directory`` option is ignored.
+
       * ``filters`` (``a(sa(us))``)
 
         List of serialized file filters.


### PR DESCRIPTION
Resolves: https://github.com/flatpak/xdg-desktop-portal/discussions/1419

Leaving this as a draft because 1. I need to find out if this is all that's needed on the xdp side, and 2. there needs to be a draft implementation in a portal backend.

---

Mostly opening this for discussion on the topic and to see if anyone has advice, since it's my first time looking at the xdp codebase :P