### PR TITLE
Launch service after graphical session

### DIFF
--- a/src/xdg-desktop-portal.service.in
+++ b/src/xdg-desktop-portal.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=Portal service
 PartOf=graphical-session.target
-Requires=dbus.service
-After=dbus.service
+Requisite=graphical-session.target
+After=graphical-session.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
This means e.g. $WAYLAND_DISPLAY and/or $DISPLAY will reliably be something valid, which is necessary to make e.g. OpenURI work when launching non-dbus-activated apps.

This fixes an issue where Firefox would not open links due to no display environment variable being set, if xdg-desktop-portal launched before the display server.