### PR TITLE
Add reduced motion setting to the portal

### DIFF
--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -58,6 +58,16 @@
 
       Unknown values should be treated as 0 (no preference).
 
+    * ``org.freedesktop.appearance``  ``reduced-motion`` (``u``)
+
+      Indicates the system's preferred reduced motion setting.
+      Supported values are:
+
+      - ``0``: No preference
+      - ``1``: Reduced motion
+
+      Unknown values should be treated as 0 (no preference).
+
     Implementations can provide other keys; they are entirely
     implementation details that are undocumented. If you are a
     toolkit and want to use this please open an issue.

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -62,6 +62,16 @@
 
       Unknown values should be treated as ``0`` (no preference).
 
+    * ``org.freedesktop.appearance``  ``reduced-motion`` (``u``)
+
+      Indicates the system's preferred reduced motion setting.
+      Supported values are:
+
+        * ``0``: No preference
+        * ``1``: Reduced motion
+
+      Unknown values should be treated as ``0`` (no preference).
+
     This documentation describes version 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Settings">


### PR DESCRIPTION
A setting for minimising the amount of non-essential motion in animations, to avoid discomfort for people with vestibular motion disorders, or distraction for those with attention deficits.

The setting key is modelled on the contrast key: an unsigned value with two states.

See also: https://www.w3.org/TR/mediaqueries-5/#prefers-reduced-motion