### PR TITLE
print: add two new capabilities (n-copies and number-up)

### DIFF
--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -34,7 +34,7 @@
       to print the formatted document. It is expected that high-level toolkit
       APIs such as GtkPrintOperation will hide most of this complexity.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes version 5 of this interface.
   -->
   <interface name="org.freedesktop.portal.Print">
     <!--
@@ -85,6 +85,19 @@
           Whether it makes sense to return "selection" for the ``print-pages`` setting.
 
           This option was added in version 4.
+
+        * ``has_n_copies`` (``b``)
+
+          Whether the app is able to manually implement the ``n-copies`` and ``collate`` settings.
+
+          This option was added in version 5.
+
+        * ``has_number_up`` (``b``)
+
+          Whether the app is able to manually implement the ``number-up`` and ``number-up-layout`` setting.
+
+          This option was added in version 5.
+
 
         The @settings and @page_setup vardict contain hints for the initial state of the print dialog.
 
@@ -255,6 +268,23 @@
           Print settings as set up by the user in the print dialog. The same keys as in @settings
           are supported (see above).
 
+        * ``printer-info`` (``a{sv}``)
+
+          Printer information with the following keys:
+
+          * ``has-n-copies`` (``b``)
+
+            Whether the printer has the n-copies capability. In this case, the app should not provide
+            a document with multiple copies, even if it has set has_n_copies to true in @options since it
+            is going to be handled directly by the printer.
+           
+          * ``has-number-up`` (``b``)
+
+            Whether the printer has the n-up capability. In this case, the app should not provide
+            a document with pages per side if it has set has_n_up to true in @options.
+            
+          This option was added in version 5.
+           
         * ``page-setup`` (``a{sv}``)
 
           Page setup as set up by the user in the print dialog. The same keys as in @page_setup

--- a/src/print.c
+++ b/src/print.c
@@ -210,6 +210,7 @@ handle_print (XdpDbusPrint *object,
 static XdpOptionKey response_options[] = {
   { "settings", G_VARIANT_TYPE_VARDICT, NULL },
   { "page-setup", G_VARIANT_TYPE_VARDICT, NULL },
+  { "printer-info", G_VARIANT_TYPE_VARDICT, NULL },
   { "token", G_VARIANT_TYPE_UINT32, NULL }
 };
 
@@ -259,6 +260,8 @@ static XdpOptionKey prepare_print_options[] = {
   { "supported_output_file_formats", G_VARIANT_TYPE_STRING_ARRAY, validate_supported_output_file_formats },
   { "has_current_page", G_VARIANT_TYPE_BOOLEAN },
   { "has_selected_pages", G_VARIANT_TYPE_BOOLEAN },
+  { "has_n_copies", G_VARIANT_TYPE_BOOLEAN },
+  { "has_number_up", G_VARIANT_TYPE_BOOLEAN },
 };
 
 static gboolean
@@ -364,7 +367,7 @@ print_new (XdpDbusImplPrint    *impl,
   print->impl = g_object_ref (impl);
   print->lockdown_impl = g_object_ref (lockdown_impl);
 
-  xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 3);
+  xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 5);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (print->impl), G_MAXINT);
 

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -29,7 +29,7 @@ def required_templates():
 
 class TestPrint:
     def test_version(self, portals, dbus_con):
-        xdp.check_version(dbus_con, "Print", 3)
+        xdp.check_version(dbus_con, "Print", 5)
 
     def test_prepare_print_basic(self, portals, dbus_con, xdp_app_info):
         app_id = xdp_app_info.app_id


### PR DESCRIPTION
Both the app and the printer may be able to do copies. If the printer can do it, then it is likely more efficient and it should not be done in the app, so the app needs to know that the printer will do it.

Since the app may save print settings, we cannot just hide number-up and n-copies from the app, so we need both the app and the printer to advertise such capabilities if they are available.

Currently, this is not handled and n-copies is applied twice (so in GNOME documents are printed n-copies^2 times).

Related GNOME MR: https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/233