### PR TITLE
tests: Only run tests with the host and flatpak app info by default

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
           meson compile -C _build
 
       - name: Run xdg-desktop-portal tests
-        run: timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C _build
+        run: XDP_TEST_RUN_LONG=1 timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C _build
 
       - name: Install xdg-desktop-portal
         run: meson install -C _build

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -399,9 +399,15 @@ def xdp_overwrite_env() -> dict[str, str]:
     params=[
         xdp.AppInfoKind.HOST,
         xdp.AppInfoKind.FLATPAK,
-        xdp.AppInfoKind.SNAP,
-        xdp.AppInfoKind.LINYAPS,
     ]
+    + (
+        [
+            xdp.AppInfoKind.SNAP,
+            xdp.AppInfoKind.LINYAPS,
+        ]
+        if xdp.run_long_tests()
+        else []
+    )
 )
 def xdp_app_info(request) -> xdp.AppInfo:
     """


### PR DESCRIPTION
Every AppInfo kind multiplies the number of tests. Let's run the tests with the two which will give us the biggest coverage by default.

By setting `XDP_TEST_RUN_LONG`, all tests run with all AppInfo kinds.

In CI, we run the tests 3 times (test in the build dir, installed tests, dist). Let's run "main" tests with XDP_TEST_RUN_LONG=1 to get the full coverage while keeping the other tests short.