### PR TITLE
app-info-registry: Only ever create one app info per connection

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -1227,7 +1227,7 @@ on_peer_disconnect (XdpContext *context,
   const char *sender_app_id;
 
   registry = xdp_context_get_app_info_registry (context);
-  sender_app_info = xdp_app_info_registry_lookup_sender (registry, sender);
+  sender_app_info = xdp_app_info_registry_lookup (registry, sender);
   if (!sender_app_info)
     return;
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -618,7 +618,7 @@ handle_session_event (XdpUsb        *self,
   g_assert (g_strcmp0 (g_udev_device_get_subsystem (device), "usb") == 0);
 
   registry = xdp_context_get_app_info_registry (self->context);
-  app_info = xdp_app_info_registry_lookup_sender (registry, session->sender);
+  app_info = xdp_app_info_registry_lookup (registry, session->sender);
   g_assert (app_info != NULL);
   sender_info = usb_sender_info_from_app_info (app_info);
   g_assert (sender_info != NULL);

--- a/src/xdp-app-info-registry.c
+++ b/src/xdp-app-info-registry.c
@@ -23,17 +23,70 @@
 
 #include "xdp-app-info-registry.h"
 
+typedef struct _XdpAppInfoRegistryItem
+{
+  gatomicrefcount ref_count;
+  XdpAppInfo *app_info;
+  GMutex mutex;
+} XdpAppInfoRegistryItem;
+
 struct _XdpAppInfoRegistry
 {
   GObject parent_instance;
 
-  GHashTable *app_infos; /* unique dbus name -> app info */
+  GHashTable *app_infos; /* unique dbus name -> XdpAppInfoRegistryItem */
   GMutex app_infos_mutex;
 };
 
 G_DEFINE_FINAL_TYPE (XdpAppInfoRegistry,
                      xdp_app_info_registry,
                      G_TYPE_OBJECT)
+
+static XdpAppInfoRegistryItem *
+xdp_app_info_registry_item_new (void)
+{
+  XdpAppInfoRegistryItem *item;
+
+  item = g_new0 (XdpAppInfoRegistryItem, 1);
+  g_mutex_init (&item->mutex);
+  g_atomic_ref_count_init (&item->ref_count);
+
+  return item;
+}
+
+static XdpAppInfoRegistryItem *
+xdp_app_info_registry_item_ref (XdpAppInfoRegistryItem *item)
+{
+  g_atomic_ref_count_inc (&item->ref_count);
+
+  return item;
+}
+
+static void
+xdp_app_info_registry_item_unref (XdpAppInfoRegistryItem *item)
+{
+  if (g_atomic_ref_count_dec (&item->ref_count))
+    {
+      g_clear_object (&item->app_info);
+      g_mutex_clear (&item->mutex);
+      g_free (item);
+    }
+}
+
+static void
+xdp_app_info_registry_item_lock (XdpAppInfoRegistryItem *item)
+{
+  g_mutex_lock (&item->mutex);
+}
+
+static void
+xdp_app_info_registry_item_unlock (XdpAppInfoRegistryItem *item)
+{
+  g_mutex_unlock (&item->mutex);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpAppInfoRegistryItem,
+                               xdp_app_info_registry_item_unref)
 
 static void
 xdp_app_info_registry_dispose (GObject *object)
@@ -69,70 +122,90 @@ xdp_app_info_registry_new (void)
 
   registry->app_infos = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                g_free,
-                                               g_object_unref);
+                                               (GDestroyNotify) xdp_app_info_registry_item_unref);
   g_mutex_init (&registry->app_infos_mutex);
 
   return registry;
 }
 
-XdpAppInfo *
-xdp_app_info_registry_lookup_sender (XdpAppInfoRegistry *registry,
-                                     const char         *sender)
+static XdpAppInfoRegistryItem *
+xdp_app_info_registry_ensure_item (XdpAppInfoRegistry *registry,
+                                   const char         *sender)
 {
-  XdpAppInfo *app_info = NULL;
+  g_autoptr(XdpAppInfoRegistryItem) item = NULL;
+  XdpAppInfoRegistryItem *match;
 
   G_MUTEX_AUTO_LOCK (&registry->app_infos_mutex, locker);
 
-  app_info = g_hash_table_lookup (registry->app_infos, sender);
-  if (!app_info)
-    return NULL;
+  match = g_hash_table_lookup (registry->app_infos, sender);
+  if (match)
+    return xdp_app_info_registry_item_ref (match);
 
-  return g_object_ref (app_info);
+  item = xdp_app_info_registry_item_new ();
+  g_hash_table_insert (registry->app_infos,
+                       g_strdup (sender),
+                       xdp_app_info_registry_item_ref (item));
+
+  return g_steal_pointer (&item);
 }
 
-gboolean
-xdp_app_info_registry_has_sender (XdpAppInfoRegistry *registry,
-                                  const char         *sender)
+XdpAppInfoRegistryLocker *
+xdp_app_info_registry_lock (XdpAppInfoRegistry *registry,
+                            const char         *sender)
 {
-  G_MUTEX_AUTO_LOCK (&registry->app_infos_mutex, locker);
+  g_autoptr(XdpAppInfoRegistryItem) item =
+    xdp_app_info_registry_ensure_item (registry, sender);
 
-  return g_hash_table_contains (registry->app_infos, sender);
+  xdp_app_info_registry_item_lock (item);
+  return (XdpAppInfoRegistryLocker *) g_steal_pointer (&item);
 }
 
 void
-xdp_app_info_registry_insert (XdpAppInfoRegistry *registry,
-                              XdpAppInfo         *app_info)
+xdp_app_info_registry_locker_free (XdpAppInfoRegistryLocker *locker)
+{
+  XdpAppInfoRegistryItem *item = (XdpAppInfoRegistryItem *) locker;
+
+  xdp_app_info_registry_item_unlock (item);
+  xdp_app_info_registry_item_unref (item);
+}
+
+void
+xdp_app_info_registry_insert_unlocked (XdpAppInfoRegistry *registry,
+                                       XdpAppInfo         *app_info)
 {
   const char *sender = xdp_app_info_get_sender (app_info);
+  g_autoptr(XdpAppInfoRegistryItem) item =
+    xdp_app_info_registry_ensure_item (registry, sender);
 
-  G_MUTEX_AUTO_LOCK (&registry->app_infos_mutex, locker);
+  g_set_object (&item->app_info, app_info);
+}
 
-  g_debug ("Adding XdpAppInfo: %s app '%s' for %s",
-           xdp_app_info_get_engine_display_name (app_info),
-           xdp_app_info_get_id (app_info),
-           sender);
+XdpAppInfo *
+xdp_app_info_registry_lookup_unlocked (XdpAppInfoRegistry *registry,
+                                       const char         *sender)
+{
+  g_autoptr(XdpAppInfoRegistryItem) item =
+    xdp_app_info_registry_ensure_item (registry, sender);
 
-  g_hash_table_insert (registry->app_infos,
-                       g_strdup (sender),
-                       g_object_ref (app_info));
+  return item->app_info ? g_object_ref (item->app_info) : NULL;
+}
+
+XdpAppInfo *
+xdp_app_info_registry_lookup (XdpAppInfoRegistry *registry,
+                              const char         *sender)
+{
+  g_autoptr(XdpAppInfoRegistryItem) item =
+    xdp_app_info_registry_ensure_item (registry, sender);
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&item->mutex);
+
+  return item->app_info ? g_object_ref (item->app_info) : NULL;
 }
 
 void
 xdp_app_info_registry_delete (XdpAppInfoRegistry *registry,
                               const char         *sender)
 {
-  XdpAppInfo *app_info = NULL;
-
   G_MUTEX_AUTO_LOCK (&registry->app_infos_mutex, locker);
-
-  app_info = g_hash_table_lookup (registry->app_infos, sender);
-  if (!app_info)
-    return;
-
-  g_debug ("Deleting XdpAppInfo: %s app '%s' for %s",
-           xdp_app_info_get_engine_display_name (app_info),
-           xdp_app_info_get_id (app_info),
-           sender);
 
   g_hash_table_remove (registry->app_infos, sender);
 }
@@ -144,27 +217,20 @@ xdp_app_info_registry_ensure_for_invocation_sync (XdpAppInfoRegistry     *regist
                                                   GError                **error)
 {
   g_autoptr(XdpAppInfo) app_info = NULL;
-  const char *sender;
+  g_autoptr(XdpAppInfoRegistryLocker) locker = NULL;
+  const char *sender = g_dbus_method_invocation_get_sender (invocation);
 
-  sender = g_dbus_method_invocation_get_sender (invocation);
-  app_info = xdp_app_info_registry_lookup_sender (registry, sender);
+  locker = xdp_app_info_registry_lock (registry, sender);
+
+  app_info = xdp_app_info_registry_lookup_unlocked (registry, sender);
   if (app_info)
-    {
-      g_debug ("Found XdpAppInfo in cache: %s app '%s' for %s",
-               xdp_app_info_get_engine_display_name (app_info),
-               xdp_app_info_get_id (app_info),
-               sender);
-
-      return g_steal_pointer (&app_info);
-    }
+    return g_steal_pointer (&app_info);
 
   app_info = xdp_app_info_new_for_invocation_sync (invocation,
                                                    cancellable,
                                                    error);
-  if (!app_info)
-    return NULL;
-
-  xdp_app_info_registry_insert (registry, app_info);
+  if (app_info)
+    xdp_app_info_registry_insert_unlocked (registry, app_info);
 
   return g_steal_pointer (&app_info);
 }

--- a/src/xdp-app-info-registry.h
+++ b/src/xdp-app-info-registry.h
@@ -30,16 +30,26 @@ G_DECLARE_FINAL_TYPE (XdpAppInfoRegistry,
                       XDP, APP_INFO_REGISTRY,
                       GObject)
 
+typedef void XdpAppInfoRegistryLocker;
+
+void xdp_app_info_registry_locker_free (XdpAppInfoRegistryLocker *locker);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (XdpAppInfoRegistryLocker,
+                               xdp_app_info_registry_locker_free)
+
 XdpAppInfoRegistry * xdp_app_info_registry_new (void);
 
-XdpAppInfo * xdp_app_info_registry_lookup_sender (XdpAppInfoRegistry *registry,
-                                                  const char         *sender);
-
-gboolean xdp_app_info_registry_has_sender (XdpAppInfoRegistry *registry,
+XdpAppInfo * xdp_app_info_registry_lookup (XdpAppInfoRegistry *registry,
                                            const char         *sender);
 
-void xdp_app_info_registry_insert (XdpAppInfoRegistry *registry,
-                                   XdpAppInfo         *app_info);
+XdpAppInfoRegistryLocker * xdp_app_info_registry_lock (XdpAppInfoRegistry *registry,
+                                                       const char         *sender);
+
+void xdp_app_info_registry_insert_unlocked (XdpAppInfoRegistry *registry,
+                                            XdpAppInfo         *app_info);
+
+XdpAppInfo * xdp_app_info_registry_lookup_unlocked (XdpAppInfoRegistry *registry,
+                                                    const char         *sender);
 
 void xdp_app_info_registry_delete (XdpAppInfoRegistry *registry,
                                    const char         *sender);


### PR DESCRIPTION

We dispatch invocations in threads, including the authorize-method which creates the app info for a connection. A call to
xdp_app_info_registry_ensure_for_invocation_sync however is only locking the hashtable when reading or writing to it; this means that the sequence of lookup, create new, insert is racy, and another thread can create and insert a new app info between our lookup and insert.

So far this has not been a problem because there was nothing hanging off the app info and equality checks went via the app id.

This will change, so we really have to make sure the whole lookup, create, insert sequence is atomic.

We could just hold the global lock for it, but it would mean any other method invocation, even from other connection, will block until the app info has been created. Creating it requires a roundtrip through the dbus broker.

So this takes another approach and uses a lock per connection.

---

I'm not very happy with the implementation, so if anyone has good ideas, I'm all ears.