### PR TITLE
github: Remove the disfunc open collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-open_collective: flatpak


### PR DESCRIPTION
It is no more so we should not point to it.