### PR TITLE
Introduce Credentials portal (experimental)

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -43,6 +43,7 @@ portal_sources = files(
 )
 
 portal_experimental_sources = files(
+  'org.freedesktop.portal.experimental.Credential.xml',
 )
 
 portal_host_sources = files(
@@ -77,8 +78,10 @@ portal_impl_sources = files(
 )
 
 portal_impl_experimental_sources = files(
+  'org.freedesktop.impl.portal.experimental.Credential.xml',
 )
 portal_handler_experimental_sources = files(
+  'org.freedesktop.handler.portal.experimental.Credential.xml',
 )
 
 background_monitor_sources = files(

--- a/data/meson.build
+++ b/data/meson.build
@@ -78,6 +78,8 @@ portal_impl_sources = files(
 
 portal_impl_experimental_sources = files(
 )
+portal_handler_experimental_sources = files(
+)
 
 background_monitor_sources = files(
   'org.freedesktop.background.Monitor.xml',

--- a/data/meson.build
+++ b/data/meson.build
@@ -42,6 +42,9 @@ portal_sources = files(
   'org.freedesktop.portal.Wallpaper.xml',
 )
 
+portal_experimental_sources = files(
+)
+
 portal_host_sources = files(
   'org.freedesktop.host.portal.Registry.xml',
 )
@@ -73,10 +76,19 @@ portal_impl_sources = files(
   'org.freedesktop.impl.portal.Wallpaper.xml',
 )
 
+portal_impl_experimental_sources = files(
+)
+
 background_monitor_sources = files(
   'org.freedesktop.background.Monitor.xml',
 )
 
-install_data([portal_sources, portal_host_sources, portal_impl_sources],
+install_data([
+    portal_sources,
+    portal_experimental_sources,
+    portal_host_sources,
+    portal_impl_sources,
+    portal_impl_experimental_sources,
+  ],
     install_dir: datadir / 'dbus-1' / 'interfaces',
 )

--- a/data/org.freedesktop.handler.portal.experimental.Credential.xml
+++ b/data/org.freedesktop.handler.portal.experimental.Credential.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2025 Isaiah Inuwa <dev@iinuwa.xyz>
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Isaiah Inuwa <dev@iinuwa.xyz>
+-->
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.handler.portal.experimental.Credential:
+      @short_description: Credential portal frontend handler interface
+
+      The Credential portal allows sandboxed applications to retrieve
+      web credentials. The frontend implementation is delegates to a separate
+      handler, `credentialsd <https://github.com/linux-credentials/credentialsd>`_,
+      that implements the interface described in this document.
+  -->
+  <interface name="org.freedesktop.handler.portal.experimental.Credential">
+    <!--
+        CreateCredential:
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`.
+        @origin: The origin of the request. Must be a valid HTTPS origin.
+        @type: Type of the credential to create.  Currently, ``publicKey`` is the only supported type.
+        @options: The credential request context and parameters.
+        @app_id: App id of the application.
+        @response: Numeric response. The values allowed match the values allowed for :ref:`org.freedesktop.portal.Request::Response` signal.
+        @results: Vardict with the results of the call.
+
+        Requests a credential of a particular type to be created for a particular origin.
+
+        Supported keys in the @options vardict:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate the credential selection dialog.
+
+        * ``@public_key`` (``a{sv}``):
+
+          A string of JSON that corresponds to the WebAuthn
+          `PublicKeyCredentialCreationOptions`_ type.
+          Required if @type is ``publicKey``.
+
+        * ``top_origin`` (``s``)
+
+          The top-level origin of the client window for cross-origin requests.
+          Pass an empty string to denote a same-origin request.
+
+        The following keys are returned in the @results vardict:
+
+        * ``type`` (``s``)
+
+          Type of the created credential.
+          Currently, ``publicKey`` is the only supported type.
+
+        * ``registration_response_json`` (``s``)
+
+          If ``type`` is ``publicKey``, a string of JSON that corresonds to the WebAuthn
+          `PublicKeyCredential`_ type with the ``response`` field set as
+          an `AuthenticatorAttestationResponse`_.
+
+        .. _AuthenticatorAttestationResponse: https://www.w3.org/TR/webauthn-3/#authenticatorattestationresponse
+        .. _PublicKeyCredential: https://www.w3.org/TR/webauthn-3/#publickeycredential
+        .. _PublicKeyCredentialCreationOptions: https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialcreationoptions
+    -->
+    <method name="CreateCredential">
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="s" name="origin" direction="in"/>
+      <arg type="s" name="type" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+
+    <!--
+        GetCredential:
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
+        @origin: The origin of the request. Must be a valid HTTPS origin.
+        @options: Vardict with optional further information.
+        @app_id: App id of the application
+        @response: Numeric response. The values allowed match the values allowed for :ref:`org.freedesktop.portal.Request::Response` signal.
+        @results: Vardict with the results of the call.
+
+        Requests a credential for a particular origin.
+
+        Supported keys in the @options vardict:
+
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate the credential selection dialog.
+
+        * ``@public_key`` (``s``):
+
+           A string of JSON that corresponds to the WebAuthn
+           `PublicKeyCredentialRequestOptions`_ type.
+
+        * ``top_origin`` (``s``)
+
+          The top-level origin of the client window for cross-origin requests.
+          Pass an empty string to denote a same-origin request.
+
+        Parameters for at least one credential request type must be included in
+        @options. Currently, the only supported type is `public_key`.
+
+        The following keys are returned in the @results vardict:
+
+        * ``type`` (``s``)
+
+          Type of the returned credential.
+          Currently, ``publicKey`` is the only supported type.
+
+        * ``authentication_response_json`` (``s``)
+
+          If ``type`` is ``publicKey``, a string of JSON that corresonds to the
+          WebAuthn `PublicKeyCredential`_ type with the ``response`` field set as
+          an `AuthenticatorAssertionResponse`_.
+
+      .. _AuthenticationAssertionResponse: https://www.w3.org/TR/webauthn-3/#authenticatorassertionresponse
+      .. _PublicKeyCredential: https://www.w3.org/TR/webauthn-3/#publickeycredential
+      .. _PublicKeyCredentialAssertionOptions: https://www.w3.org/TR/webauthn-3/#dictionary-assertion-options
+    -->
+    <method name="GetCredential">
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="s" name="origin" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="a{sv}" name="results" direction="out"/>
+    </method>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/data/org.freedesktop.impl.portal.experimental.Credential.xml
+++ b/data/org.freedesktop.impl.portal.experimental.Credential.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2026 Isaiah Inuwa <dev@iinuwa.xyz>
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Isaiah Inuwa <dev@iinuwa.xyz>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.impl.portal.experimental.Credential:
+      @short_description: Credential portal backend interface
+      @stability: Unstable
+
+      **Interface**: ``org.freedesktop.impl.portal.experimental.Credential``
+
+      **Version**: Experimental 🧪
+
+      The Credential portal allows sandboxed applications to retrieve
+      application-scoped web credentials. The backend interface guides the user
+      through the interactive authentication ceremony.
+
+  -->
+  <interface name="org.freedesktop.impl.portal.experimental.Credential">
+
+    <!--
+        CreateSession:
+        @since: 1
+        @session_handle: Object path for the :ref:`org.freedesktop.impl.portal.Session` to create.
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`.
+        @origin: The origin of the request.
+        @type: Type of the credential to create. Current supported types are ``PublicKeyCreate = 0``, and ``PublicKeyGet = 1``.
+        @sources: Initial list of credential sources. Map from source ID to transport. Valid transports are ``Ble``, ``HybridLinked``, ``HybridQr``, ``Internal``, ``Nfc``, ``Usb``. Sources may be added or removed during the ceremony.
+        @app_id: App ID of the application.
+        @app_pid: PID of the application.
+        @options: Vardict with optional further information.
+
+        Creates a session for an authentication ceremony with the client context
+        and an initial list of credential sources. During the ceremony, the
+        backend sends user interaction events to the frontend via signals in
+        response to background events sent from the frontend via the other
+        methods on this interface.
+
+        Before calling this method, the frontend MUST subscribe to all
+        signals on this interface, filtering for the given @session_handle
+        argument. A :ref:`org.freedesktop.impl.portal.Session` object will be
+        exported on the @session_handle path, which can be used by the frontend
+        to cancel the ceremony or receive notification that the
+        user cancelled it. Frontends MUST use the same D-Bus connection
+        throughout the ceremony.
+
+        Upon receiving this method call, backends MUST send
+        :ref:`org.freedesktop.impl.portal.experimental.Credential::DiscoveryRequested`
+        when the user is ready to perform the authentication ceremony.
+        Backends MUST send all signals as unicast signals to the original sender
+        calling this method.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate the credential selection dialog.
+
+        * ``top_origin`` (``s``)
+
+          Top-level origin of the request if different from the origin.
+
+        * ``rp_id`` (``s``)
+
+          WebAuthn relying party ID.
+
+          Required if @type is ``PublicKeyCreate`` or ``PublicKeyGet``.
+    -->
+    <method name="CreateSession">
+      <arg name="session_handle" type="o" direction="in"/>
+      <arg name="parent_window" type="s" direction="in"/>
+      <arg name="origin" type="s" direction="in"/>
+      <arg name="type" type="u" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In4" value="QList&lt;QVariantMap&gt;"/>
+      <arg name="sources" type="a(ss)" direction="in"/>
+      <arg name="app_id" type="s" direction="in"/>
+      <arg name="app_pid" type="u" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In9" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyNeedsPin:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @attempts_left: The number of PIN attempts remaining before the device is locked out and must be reset/wiped. ``0xffffffff`` means the number of attempts left is unknown.
+        @options: Vardict with optional further information.
+
+        The device needs PIN user verification: prompt the user to enter the
+        PIN. The backend must emit the collected value as a
+        :ref:`org.freedesktop.impl.portal.experimental.Credential::ClientPinEntered`
+        signal. See the documentation on that signal for PIN requirements.
+
+        The backend should consider rate-limiting requests, or requiring the
+        user to power-cycle (e.g., unplug and plug back in) the device after
+        repeated incorrect attempts to prevent the device from being locked out
+        due to user error or abuse.
+
+        The backend should warn the user that the credentials may be permanently
+        lost if they continue to enter incorrect PINs.
+
+        There are currently no supported keys in the @options vardict.
+
+
+        .. seealso::
+           * `CTAP 2.3 documentation on PIN and user verification retries`_
+    -->
+    <method name="NotifyNeedsPin">
+      <arg name="session_handle" type="o" direction="in"/>
+      <arg name="attempts_left" type="u" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyNeedsUserVerification:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @attempts_left: The number of user verification attempts remaining before the built-in user verification methods are disabled until the next successful PIN verification. ``0xffffffff`` means the number of attempts left is unknown.
+        @options: Vardict with optional further information.
+
+        The authenticator needs on-device user verification (likely biometrics, or
+        can be on-device PIN entry). Prompt the user to interact with the
+        device.
+
+        The backend should display the number of built-in user verification
+        attempts remaining before falling back to client PIN verification.
+
+        .. note::
+
+           This is distinct from
+           :ref:`org.freedesktop.impl.portal.experimental.Credential.NotifyNeedsPin`,
+           which uses a PIN captured on the client device rather than directly
+           on the authenticator.
+
+        There are currently no supported keys in the @options vardict.
+
+        .. seealso::
+           * `CTAP 2.3 documentation on PIN and user verification retries`_
+
+        .. _CTAP 2.3 documentation on PIN and user verification retries: https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authnrClientPin-globalState-retries
+    -->
+    <method name="NotifyNeedsUserVerification">
+      <arg name="session_handle" type="o" direction="in"/>
+      <arg name="attempts_left" type="u" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyNeedsUserPresence:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @options: Vardict with optional further information.
+
+        Device requires user interaction (e.g. pressing a button) to release credentials; prompt the user
+        to do so. The device may require additional user verification, but that
+        might not be known until after the user taps the device.
+
+        There are currently no supported keys in the @options vardict.
+    -->
+    <method name="NotifyNeedsUserPresence">
+      <arg name="session_handle" type="o" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifySelectingCredential:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @credentials: A list of metadata for credentials that are able to fulfill the request.
+        @options: Vardict with optional further information.
+
+        The device is ready to release credentials, but multiple credentials
+        match the request. The backend must prompt the user to select one of the
+        credentials.
+
+        Each metadata object in @credentials contains the following fields:
+
+        * ``id``: An opaque value to send back to the authenticator. It is NOT the WebAuthn ``credentialId``.
+        * ``name``: The account name for the credential.
+        * ``display_name``: The human-readable username for the credential.
+
+        There are currently no supported keys in the @options vardict.
+    -->
+    <method name="NotifySelectingCredential">
+      <arg name="session_handle" type="o" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QList&lt;QVariantMap&gt;"/>
+      <arg name="credentials" type="aa{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyHybridStarted:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @invocation_data: A memory-mapped filed containing a string of data that is used to invoke the hybrid flow on the peer device.
+        @options: Vardict with optional further information.
+
+        Hybrid discovery is activated and is awaiting an invocation on the peer
+        device. The backend MUST display the @invocation_data as a QR code. For
+        public key credentials (where @type of
+        :ref:`org.freedesktop.impl.portal.experimental.Credential.CreateSession`
+        is set to ``PublicKeyCreate`` or ``PublicKeyGet``), the backend SHOULD
+        overlay the FIDO passkey logo on the QR code.
+
+        The backend MAY use other invocation methods besides QR code as the CTAP2 spec evolves.
+
+        @invocation_data is a file descriptor whose data consists of the UTF-8-encoded PIN. The file
+        must be memory-mapped to be read. Call ``fstat()`` to determine the length of the data.
+
+        There are currently no supported keys in the @options vardict.
+
+        .. seealso::
+           * `CTAP 2.3 Hybrid Transport documentation`_
+           * `FIDO Alliance Logos`_
+
+        .. _CTAP 2.3 Hybrid Transport documentation: https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-hybrid
+        .. _FIDO Alliance Logos: https://fidoalliance.org/overview/legal/
+    -->
+    <method name="NotifyHybridStarted">
+      <arg name="session_handle" type="o" direction="in"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg name="invocation_data" type="h" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyHybridConnecting:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @options: Vardict with optional further information.
+
+        The other device has been detected, and a connection is being
+        established. The backend should communicate a pending status and prompt
+        the user to keep the devices close.
+
+        There are currently no supported keys in the @options vardict.
+
+        .. seealso::
+           * `CTAP 2.3 Hybrid Transport documentation`_
+    -->
+    <method name="NotifyHybridConnecting">
+      <arg name="session_handle" type="o" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyHybridConnected:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @options: Vardict with optional further information.
+
+        A connection has been established, waiting for user to release
+        credential on their device. The backend should prompt the user to follow
+        the instructions on the peer device.
+
+        There are currently no supported keys in the @options vardict.
+
+        .. seealso::
+           * `CTAP 2.3 Hybrid Transport documentation`_
+    -->
+    <method name="NotifyHybridConnected">
+      <arg name="session_handle" type="o" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyNfcConnected:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @options: Vardict with optional further information.
+
+        An NFC device has been detected. The backend should prompt the user to
+        keep the peer device on the NFC reader so that the ceremony can
+        complete.
+
+        There are currently no supported keys in the @options vardict.
+    -->
+    <method name="NotifyNfcConnected">
+      <arg name="session_handle" type="o" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyUsbConnected:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @options: Vardict with optional further information.
+
+        USB device connected, prompt user to interact with the device (e.g.
+        press the button).
+
+        The device may require additional user verification to complete the
+        ceremony, but that might not be known until after the user taps the
+        device.
+
+        There are currently no supported keys in the @options vardict.
+    -->
+    <method name="NotifyUsbConnected">
+      <arg name="session_handle" type="o" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!--
+        NotifyCeremonyCompleted:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+
+        The frontend should call this method when the ceremony completes
+        successfully, and the dialog can be closed.
+    -->
+    <method name="NotifyCeremonyCompleted">
+      <arg name="session_handle" type="o" direction="in"/>
+    </method>
+
+    <!--
+        NotifyErrorOccurred:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @error: The error that occurred.
+
+        Notify the backend that an error occurred.
+
+        @error may contain the following values:
+
+        * ``ERROR_AUTHENTICATOR = 0x80000001``
+
+          An unknown authenticator error occurred.
+
+        * ``ERROR_NO_CREDENTIALS = 0x80000002``
+
+          The authenticator reported that it has no matching credentials stored.
+
+        * ``ERROR_PIN_ATTEMPTS_EXHAUSTED = 0x80000003``
+
+          Too many PIN attempts have been entered, and the authenticator is
+          permanently locked out and must be reset.
+
+        * ``ERROR_INTERNAL = 0x80000004``
+
+          An internal portal error occurred.
+
+        * ``ERROR_TIMED_OUT = 0x80000005``
+
+          The credential request has timed out.
+
+        * ``ERROR_CANCELLED = 0x80000006``
+
+          The user cancelled the request.
+    -->
+    <method name="NotifyErrorOccurred">
+      <arg name="session_handle" type="o" direction="in"/>
+      <arg name="error" type="u" direction="in"/>
+    </method>
+
+    <!--
+        DiscoveryRequested:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @options: Vardict with optional further information.
+
+        Request for the platform to start credential discovery. This should be
+        emitted by the backend after
+        :ref:`org.freedesktop.impl.portal.experimental.Credential.CreateSession`
+        is called, when all signals are subscribed and the user is ready to
+        perform the authentication ceremony.
+
+        There are currently no supported keys in the @options vardict.
+    -->
+    <signal name="DiscoveryRequested">
+      <arg name="session_handle" type="o"/>
+      <arg name="options" type="a{sv}"/>
+    </signal>
+    <!--
+        ClientPinEntered:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @pin_fd: The PIN entered by the user.
+        @options: Vardict with optional further information.
+
+        Sends the client PIN to the authenticator for user verification via
+        @pin_fd in response to
+        :ref:`org.freedesktop.impl.portal.experimental.Credential.NotifyNeedsPin`.
+
+        This is a file descriptor whose data consists of the UTF-8-encoded PIN.
+        The file must be memory-mapped to be read. Call ``fstat()`` to determine
+        the length of the data.
+
+        Maximum pin length is 63 bytes.
+
+        There are currently no supported keys in the @options vardict.
+    -->
+    <signal name="ClientPinEntered">
+      <arg name="session_handle" type="o"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg name="pin_fd" type="h"/>
+      <arg name="options" type="a{sv}"/>
+    </signal>
+
+    <!--
+        CredentialSelected:
+        @since: 1
+        @session_handle: The :ref:`org.freedesktop.impl.portal.Session` for this authentication ceremony.
+        @id: The opaque ID representing the selected credential metadata.
+        @options: Vardict with optional further information.
+
+        After receiving a
+        :ref:`org.freedesktop.impl.portal.experimental.Credential.NotifySelectingCredential`
+        signal, the backend must prompt the user to select a credential from
+        the list of credential metadata. The backend must send the @id of
+        selected credential metadata to the authenticator to
+        release the credential.
+
+        .. note::
+
+           @id is NOT the WebAuthn credential ID; it is an opaque
+           identifier used just for selecting the credential in this ceremony.
+
+        There are currently no supported keys in the @options vardict.
+    -->
+    <signal name="CredentialSelected">
+      <arg name="session_handle" type="o"/>
+      <arg name="id" type="s"/>
+      <arg name="options" type="a{sv}"/>
+    </signal>
+
+    <property name="version" type="u" access="read"/>
+
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.experimental.Credential.xml
+++ b/data/org.freedesktop.portal.experimental.Credential.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0"?>
+
+<!--
+ Copyright (C) 2025 Red Hat, Inc.
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Isaiah Inuwa <isaiah.inuwa@gmail.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.experimental.Credential:
+      @short_description: Portal to request web credentials.
+
+      **Interface**: ``org.freedesktop.portal.experimental.Credential``
+
+      **Version**: Experimental 🧪
+
+      The Credential portal allows applications to request web
+      credentials. The user will be prompted to select a credential,
+      which the application can use to authenticate. The design of this portal
+      is highly inspired by the `W3C Credential Management API`_ and the related
+      credential type specifications.
+
+      Currently the only supported credential type is WebAuthn
+      credentials.
+
+      Credentials are created by
+      org.freedesktop.portal.experimental.Credential.CreateCredential()
+      and retrieved by
+      org.freedesktop.portal.experimental.Credential.GetCredential().
+
+      The D-Bus interface for the Credential portal is available
+      under the bus name ``org.freedesktop.portal.Desktop`` and the
+      object path ``/org/freedesktop/portal/desktop``.
+
+      .. seealso::
+         * `W3C Credential Management API`_
+         * `WebAuthn Specification`_
+
+      .. _WebAuthn Specification: https://www.w3.org/TR/webauthn-3
+      .. _W3C Credential Management API: https://developer.mozilla.org/en-US/docs/Web/API/Credential_Management_API
+  -->
+  <interface name="org.freedesktop.portal.experimental.Credential">
+
+    <!--
+        CreateCredential:
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`.
+        @origin: The origin of the request. Must be a valid HTTPS origin.
+        @type: Type of the created credential. Currently, ``publicKey`` is the only supported type.
+        @options: The credential request context and parameters.
+        @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
+
+        Requests a new credential to be stored.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate the credential selection dialog.
+
+        * ``handle_token`` (``s``)
+
+          A string that will be used as the last element of the @handle. Must be a valid
+          object path element. See the :ref:`org.freedesktop.portal.Request` documentation for
+          more information about the @handle.
+
+        * ``public_key`` (``s``):
+
+          A string of JSON that corresponds to the WebAuthn
+          `PublicKeyCredentialCreationOptions <https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialcreationoptions>`__
+          type.
+          Required if @type is ``publicKey``.
+
+        * ``top_origin`` (``s``)
+
+          The top-level origin of the client window for cross-origin requests.
+          Optional. Omit to denote a same-origin request.
+
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
+
+        * ``type`` (``s``)
+
+          Type of the created credential.
+          Currently, ``publicKey`` is the only supported type.
+
+        * ``registration_response_json`` (``s``)
+
+          If ``type`` is ``publicKey``, a string of JSON that corresonds to the WebAuthn
+          `PublicKeyCredential <https://www.w3.org/TR/webauthn-3/#publickeycredential>`__
+          type with the ``response`` field set as an
+          `AuthenticatorAttestationResponse <https://www.w3.org/TR/webauthn-3/#authenticatorattestationresponse>`__.
+    -->
+    <method name="CreateCredential">
+      <arg name="parent_window" type="s" direction="in"/>
+      <arg name="origin" type="s" direction="in"/>
+      <arg name="type" type="s" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+        GetCredential:
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
+        @origin: The origin of the request. Must be a valid HTTPS origin.
+        @options: The credential request context and parameters.
+        @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
+
+        Returns a credential.
+
+        .. note::
+
+           Parameters for at least one credential request type must be included
+           in @options. In future versions, multiple credential types may be
+           requested in one call to GetCredential(), though there is currently
+           only one supported type: ``public_key``. The @type key of the
+           response denotes which type of credential was selected by the user
+           and returned.
+
+        Supported keys in the @options vardict include:
+
+        * ``activation_token`` (``s``)
+
+          A token that can be used to activate the credential selection dialog.
+
+        * ``handle_token`` (``s``)
+
+          A string that will be used as the last element of the @handle. Must be a valid
+          object path element. See the :ref:`org.freedesktop.portal.Request` documentation for
+          more information about the @handle.
+
+        * ``public_key`` (``a{sv}``)
+
+          A dictionary that contains a field ``request_json``, which
+          is a string of JSON that corresponds to the WebAuthn
+          `PublicKeyCredentialRequestOptions <https://www.w3.org/TR/webauthn-3/#dictionary-assertion-options>`__
+          type.
+
+        * ``top_origin`` (``s``)
+
+          The top-level origin of the client window for cross-origin requests.
+          Pass an empty string to denote a same-origin request.
+
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
+
+        * ``type`` (``s``)
+
+          Type of the returned credential.
+          Currently, ``publicKey`` is the only supported type.
+
+        * ``authentication_response_json`` (``s``)
+
+          If ``type`` is ``publicKey``, a string of JSON that corresonds to the
+          WebAuthn `PublicKeyCredential <https://www.w3.org/TR/webauthn-3/#publickeycredential>`__
+          type with the ``response`` field set as
+          an `AuthenticatorAssertionResponse <https://www.w3.org/TR/webauthn-3/#authenticatorassertionresponse>`__.
+    -->
+    <method name="GetCredential">
+      <arg name="parent_window" type="s" direction="in"/>
+      <arg name="origin" type="s" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+      ConditionalCreate:
+
+      Whether conditional mediation is supported for credential registration.
+
+      .. seealso::
+         `WebAuthn conditionalCreate capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-conditionalcreate>`__
+    -->
+    <property name="ConditionalCreate" type="b" access="read" />
+
+    <!--
+      ConditionalGet:
+
+      Whether conditional mediation is supported for authentication.
+
+      .. seealso::
+        `WebAuthn conditionalGet capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-conditionalget>`__
+    -->
+    <property name="ConditionalGet" type="b" access="read" />
+
+    <!--
+      HybridTransport:
+
+      Whether hybrid authenticators are supported.
+
+      .. seealso::
+         `WebAuthn hybridTransport capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-hybridtransport>`__
+    -->
+    <property name="HybridTransport" type="b" access="read" />
+
+    <!--
+      PasskeyPlatformAuthenticator:
+
+      Whether a passkey platform authenticator (local or via hybrid transport) is accessible via this API.
+
+      .. seealso::
+         `WebAuthn passkeyPlatformAuthenticator capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-passkeyplatformauthenticator>`__
+    -->
+    <property name="PasskeyPlatformAuthenticator" type="b" access="read" />
+
+    <!--
+      UserVerifyingPlatformAuthenticator:
+
+      Whether a user-verifying platform authenticator is available via this API.
+
+      .. seealso::
+         `WebAuthn userVerifyingPlatformAuthenticator capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-userverifyingplatformauthenticator>`__
+    -->
+    <property name="UserVerifyingPlatformAuthenticator" type="b" access="read" />
+
+    <!--
+      RelatedOrigins:
+
+      Whether matching origins using WebAuthn Related Origin Requests is supported.
+
+      .. seealso::
+         `WebAuthn relatedOrigins capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-relatedorigins>`__
+    -->
+    <property name="RelatedOrigins" type="b" access="read" />
+
+    <!--
+      SignalAllAcceptedCredentials:
+
+      Whether WebAuthn signalAllAcceptedCredentials() is supported.
+
+      .. seealso::
+         `WebAuthn signalAllAcceptedCredentials capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-signalallacceptedcredentials>`__
+    -->
+    <property name="SignalAllAcceptedCredentials" type="b" access="read" />
+
+    <!--
+      SignalCurrentUserDetails:
+
+      Whether WebAuthn signalCurrentUserDetails() is supported.
+
+      .. seealso::
+         `WebAuthn signalCurrentUserDetails capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-signalcurrentuserdetails>`__
+    -->
+    <property name="SignalCurrentUserDetails" type="b" access="read" />
+
+    <!--
+      SignalUnknownCredential:
+
+      The WebAuthn Client supports signalUnknownCredential().
+
+      .. seealso::
+         `WebAuthn signalUnknownCredential capability documentation <https://www.w3.org/TR/webauthn-3/#dom-clientcapability-signalunknowncredential>`__
+    -->
+    <property name="SignalUnknownCredential" type="b" access="read" />
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/desktop-portal/credential.c
+++ b/desktop-portal/credential.c
@@ -1,0 +1,383 @@
+/*
+ * Copyright © 2025 Isaiah Inuwa <isaiah.inuwa@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Isaiah Inuwa <isaiah.inuwa@gmail.com>
+ */
+
+#include "credential.h"
+
+#include <stdint.h>
+
+#include <gio/gunixfdlist.h>
+
+#include "dex-aio.h"
+#include "gio/gio.h"
+#include "glib.h"
+#include "glibconfig.h"
+#include "xdp-app-info.h"
+#include "xdp-context.h"
+#include "xdp-experimental-dbus.h"
+#include "xdp-experimental-handler-dbus.h"
+#include "xdp-portal-config.h"
+#include "xdp-request-dex.h"
+#include "xdp-utils.h"
+
+static gboolean handle_create_credential (XdpDbusExperimentalCredential *object,
+                                          GDBusMethodInvocation *invocation,
+                                          const gchar *arg_parent_window,
+                                          const gchar *arg_origin,
+                                          const gchar *arg_type,
+                                          GVariant *arg_options);
+
+static gboolean handle_get_credential (XdpDbusExperimentalCredential *object,
+                                       GDBusMethodInvocation *invocation,
+                                       const gchar *arg_parent_window,
+                                       const gchar *arg_origin,
+                                       GVariant *arg_options);
+struct _XdpCredential
+{
+  XdpDbusExperimentalCredentialSkeleton parent_instance;
+
+  XdpContext *context;
+  XdpDbusExperimentalHandlerCredential *handler;
+};
+
+#define XDP_TYPE_CREDENTIAL (xdp_dbus_experimental_credential_get_type ())
+G_DECLARE_FINAL_TYPE (XdpCredential, xdp_credential, XDP, CREDENTIAL, XdpDbusExperimentalCredentialSkeleton)
+
+static void
+xdp_credential_iface_init (XdpDbusExperimentalCredentialIface *iface);
+
+G_DEFINE_FINAL_TYPE_WITH_CODE (
+    XdpCredential,
+    xdp_credential,
+    XDP_DBUS_EXPERIMENTAL_TYPE_CREDENTIAL_SKELETON,
+    G_IMPLEMENT_INTERFACE (XDP_DBUS_EXPERIMENTAL_TYPE_CREDENTIAL, xdp_credential_iface_init)
+  );
+
+static void xdp_credential_iface_init (XdpDbusExperimentalCredentialIface *iface)
+{
+  iface->handle_create_credential = handle_create_credential;
+  iface->handle_get_credential = handle_get_credential;
+}
+
+static void xdp_credential_dispose (GObject *object)
+{
+  XdpCredential *credential = XDP_CREDENTIAL (object);
+
+  g_clear_object (&credential->handler);
+
+  G_OBJECT_CLASS (xdp_credential_parent_class)->dispose (object);
+}
+
+static void xdp_credential_init (XdpCredential *credential) {}
+
+static void xdp_credential_class_init (XdpCredentialClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->dispose = xdp_credential_dispose;
+}
+
+static XdpCredential *
+xdp_credential_new(XdpContext *context, XdpDbusExperimentalHandlerCredential *handler)
+{
+  XdpCredential *credential;
+
+  credential = g_object_new(xdp_credential_get_type(), NULL);
+  credential->context = context;
+  credential->handler = g_object_ref(handler);
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (credential->handler), G_MAXINT);
+
+  xdp_dbus_experimental_credential_set_conditional_create (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), FALSE);
+  xdp_dbus_experimental_credential_set_conditional_get (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), FALSE);
+  xdp_dbus_experimental_credential_set_hybrid_transport (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), TRUE);
+  xdp_dbus_experimental_credential_set_passkey_platform_authenticator (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), TRUE);
+  xdp_dbus_experimental_credential_set_user_verifying_platform_authenticator (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), FALSE);
+  xdp_dbus_experimental_credential_set_related_origins (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), TRUE);
+  xdp_dbus_experimental_credential_set_signal_all_accepted_credentials (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), FALSE);
+  xdp_dbus_experimental_credential_set_signal_current_user_details (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), FALSE);
+  xdp_dbus_experimental_credential_set_signal_unknown_credential (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), FALSE);
+
+  xdp_dbus_experimental_credential_set_version (
+      XDP_DBUS_EXPERIMENTAL_CREDENTIAL (credential), 1);
+
+  return credential;
+}
+
+const gchar *CREDENTIALSD_HANDLER_DBUS_NAME =
+    "xyz.iinuwa.credentialsd.Credentials";
+
+static XdpOptionKey create_credential_options[] = {
+    {"handle_token", G_VARIANT_TYPE_STRING, NULL},
+    {"origin", G_VARIANT_TYPE_STRING, NULL},
+    {"top_origin", G_VARIANT_TYPE_STRING, NULL},
+    {"type", G_VARIANT_TYPE_STRING, NULL},
+    {"public_key", G_VARIANT_TYPE_STRING, NULL},
+};
+
+/**
+ * create_credential_validate_options:
+ * @arg_options: (transfer none): options passed to the frontend.
+ * @error: (transfer none): pointer to an error pointer that will be populated on error.
+ * Returns: (transfer full): Filtered list of options to pass to the handler.
+ */
+static GVariant *
+create_credential_validate_options (GVariant *arg_options,
+                                 GError  **error)
+{
+  g_auto (GVariantBuilder) options = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+  gboolean validated = xdp_filter_options (arg_options,
+                                           &options,
+                                           create_credential_options,
+                                           G_N_ELEMENTS (create_credential_options),
+                                           NULL,
+                                           error);
+  if (!validated)
+      return NULL;
+  else
+      return g_variant_ref_sink (g_variant_builder_end (&options));
+}
+
+static gboolean handle_create_credential (XdpDbusExperimentalCredential *object,
+                                          GDBusMethodInvocation         *invocation,
+                                          const gchar                   *arg_parent_window,
+                                          const gchar                   *arg_origin,
+                                          const gchar                   *arg_type,
+                                          GVariant                      *arg_options)
+{
+  XdpCredential *credential = XDP_CREDENTIAL (object);
+  g_autoptr (XdpRequestDex) request = NULL;
+  g_autoptr (GVariant) options = NULL;
+  g_autoptr (GError) error = NULL;
+
+  XdpAppInfo *app_info = xdp_invocation_get_app_info (invocation);
+  const gchar *app_id = xdp_app_info_get_id (app_info);
+
+  options = create_credential_validate_options (arg_options, &error);
+  if (!options)
+    {
+      g_dbus_method_invocation_return_gerror (g_steal_pointer (&invocation), error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  request = dex_await_object (xdp_request_dex_new (
+                                  credential->context,
+                                  app_info,
+                                  G_DBUS_INTERFACE_SKELETON (object),
+                                  G_DBUS_PROXY (credential->handler),
+                                  options
+                              ),
+                              &error);
+  if (!request)
+    {
+      g_dbus_method_invocation_return_gerror (g_steal_pointer (&invocation), error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  xdp_dbus_experimental_credential_complete_create_credential (
+      object,
+      invocation,
+      xdp_request_dex_get_object_path (request));
+
+  {
+    g_autoptr (XdpDbusExperimentalHandlerCredentialCreateCredentialResult) result = NULL;
+    result = dex_await_boxed (xdp_dbus_experimental_handler_credential_call_create_credential_future (
+        credential->handler,
+        arg_parent_window,
+        arg_origin,
+        arg_type,
+        options,
+        app_id
+      ),
+      &error);
+
+    if (result) {
+      xdp_request_dex_emit_response (request,
+                                     result->response,
+                                     result->results);
+    } else {
+      g_dbus_error_strip_remote_error (error);
+      g_warning ("Handler call failed: %s (%d)", error->message, error->code);
+      xdp_request_dex_emit_response (request,
+                                     XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
+                                     NULL);
+    }
+  }
+
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+static XdpOptionKey get_credential_options[] = {
+    {"handle_token", G_VARIANT_TYPE_STRING, NULL},
+    {"origin", G_VARIANT_TYPE_STRING, NULL},
+    {"top_origin", G_VARIANT_TYPE_STRING, NULL},
+    {"public_key", G_VARIANT_TYPE_STRING, NULL},
+};
+
+/**
+ * get_credential_validate_options:
+ * @arg_options: (transfer none): options passed to the frontend.
+ * @error: (transfer none): pointer to an error pointer that will be populated on error.
+ * Returns: (transfer full): Filtered list of options to pass to the handler.
+ */
+static GVariant *
+get_credential_validate_options (GVariant *arg_options,
+                                 GError  **error)
+{
+  g_auto (GVariantBuilder) options = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+  gboolean validated = xdp_filter_options (arg_options,
+                                           &options,
+                                           get_credential_options,
+                                           G_N_ELEMENTS (get_credential_options),
+                                           NULL,
+                                           error);
+  if (!validated)
+      return NULL;
+  else
+      return g_variant_ref_sink (g_variant_builder_end (&options));
+}
+
+static gboolean handle_get_credential (XdpDbusExperimentalCredential *object,
+                                       GDBusMethodInvocation         *invocation,
+                                       const gchar                   *arg_parent_window,
+                                       const gchar                   *arg_origin,
+                                       GVariant                      *arg_options)
+{
+  XdpCredential *credential = XDP_CREDENTIAL (object);
+  g_autoptr (XdpRequestDex) request = NULL;
+  g_autoptr (GVariant) options = NULL;
+  g_autoptr (GError) error = NULL;
+
+  XdpAppInfo *app_info = xdp_invocation_get_app_info (invocation);
+  const gchar *app_id = xdp_app_info_get_id (app_info);
+
+  options = get_credential_validate_options (arg_options, &error);
+  if (!options)
+    {
+      g_dbus_method_invocation_return_gerror (g_steal_pointer (&invocation), error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  request = dex_await_object (xdp_request_dex_new (
+                                  credential->context,
+                                  app_info,
+                                  G_DBUS_INTERFACE_SKELETON (object),
+                                  G_DBUS_PROXY (credential->handler),
+                                  options
+                              ),
+                              &error);
+  if (!request)
+    {
+      g_dbus_method_invocation_return_gerror (g_steal_pointer (&invocation), error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  xdp_dbus_experimental_credential_complete_get_credential (
+      object,
+      invocation,
+      xdp_request_dex_get_object_path (request));
+
+  {
+    g_autoptr (XdpDbusExperimentalHandlerCredentialGetCredentialResult) result = NULL;
+    result = dex_await_boxed (xdp_dbus_experimental_handler_credential_call_get_credential_future (
+        credential->handler,
+        arg_parent_window,
+        arg_origin,
+        options,
+        app_id
+      ),
+      &error);
+
+    if (result) {
+      xdp_request_dex_emit_response (request,
+                                     result->response,
+                                     result->results);
+    } else {
+      g_dbus_error_strip_remote_error (error);
+      g_warning ("Handler call failed: %s (%d)", error->message, error->code);
+      xdp_request_dex_emit_response (request,
+                                    XDG_DESKTOP_PORTAL_RESPONSE_OTHER,
+                                    NULL);
+    }
+  }
+
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+DexFuture *
+init_credential (gpointer user_data)
+{
+  g_info ("Initializing Credential Portal");
+
+  XdpContext *context = XDP_CONTEXT (user_data);
+  g_autoptr (XdpCredential) credential = NULL;
+  g_autoptr (XdpDbusExperimentalHandlerCredential) handler = NULL;
+  g_autoptr (GError) error = NULL;
+
+  GDBusConnection *connection = xdp_context_get_connection (context);
+  {
+    XdpPortalConfig *config = xdp_context_get_config (context);
+    XdpImplConfig *impl_config;
+
+    impl_config =
+        xdp_portal_config_find (config, CREDENTIAL_EXPERIMENTAL_DBUS_IMPL_IFACE);
+
+    if (impl_config == NULL) {
+      g_debug ("impl_config is NULL");
+      return dex_future_new_true ();
+    }
+
+    g_debug ("found impl");
+  }
+
+  g_debug ("creating handler proxy...");
+
+  handler = dex_await_object (xdp_dbus_experimental_handler_credential_proxy_new_future (
+                                  connection,
+                                  G_DBUS_PROXY_FLAGS_NONE,
+                                  CREDENTIALSD_HANDLER_DBUS_NAME,
+                                  DESKTOP_DBUS_PATH),
+                              &error);
+
+  if (!handler)
+    {
+      g_warning ("Failed to create credential proxy: %s", error->message);
+      return dex_future_new_false ();
+    }
+  g_debug ("created handler proxy.");
+
+  credential = xdp_credential_new (context, g_steal_pointer (&handler));
+
+  xdp_context_take_and_export_portal (context,
+                                      G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&credential)),
+                                      XDP_CONTEXT_EXPORT_FLAGS_RUN_IN_FIBER);
+
+  return dex_future_new_true ();
+}

--- a/desktop-portal/credential.h
+++ b/desktop-portal/credential.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2025 Isaiah Inuwa <isaiah.inuwa@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Isaiah Inuwa <isaiah.inuwa@gmail.com>
+ */
+
+
+#pragma once
+
+#include <libdex.h>
+
+DexFuture *
+init_credential (gpointer user_data);
+

--- a/desktop-portal/meson.build
+++ b/desktop-portal/meson.build
@@ -43,6 +43,12 @@ impl_experimental_built_sources = gnome.gdbus_codegen(
   namespace: 'XdpDbusExperimentalImpl',
   docbook: 'portal',
 )
+handler_experimental_built_sources = gnome.gdbus_codegen(
+  'xdp-experimental-handler-dbus',
+  sources: portal_handler_experimental_sources,
+  interface_prefix: 'org.freedesktop.handler.portal.experimental',
+  namespace: 'XdpDbusExperimentalHandler',
+  docbook: 'portal',
 )
 background_monitor_built_sources = gnome.gdbus_codegen(
   'xdp-background-dbus',
@@ -123,6 +129,7 @@ xdg_desktop_portal_sources += [
   portal_experimental_built_sources,
   host_built_sources,
   impl_built_sources,
+  handler_experimental_built_sources,
   background_monitor_built_sources,
   geoclue_built_sources,
 ]

--- a/desktop-portal/meson.build
+++ b/desktop-portal/meson.build
@@ -19,6 +19,7 @@ portal_experimental_built_sources = gnome.gdbus_codegen(
   interface_prefix: 'org.freedesktop.portal.experimental',
   namespace: 'XdpDbusExperimental',
   docbook: 'portal',
+  extra_args: gdbus_codegen_extra_args,
 )
 host_built_sources = gnome.gdbus_codegen(
   'xdp-host-dbus',
@@ -42,6 +43,7 @@ impl_experimental_built_sources = gnome.gdbus_codegen(
   interface_prefix: 'org.freedesktop.impl.portal.experimental',
   namespace: 'XdpDbusExperimentalImpl',
   docbook: 'portal',
+  extra_args: gdbus_codegen_extra_args,
 )
 handler_experimental_built_sources = gnome.gdbus_codegen(
   'xdp-experimental-handler-dbus',
@@ -49,6 +51,7 @@ handler_experimental_built_sources = gnome.gdbus_codegen(
   interface_prefix: 'org.freedesktop.handler.portal.experimental',
   namespace: 'XdpDbusExperimentalHandler',
   docbook: 'portal',
+  extra_args: gdbus_codegen_extra_args,
 )
 background_monitor_built_sources = gnome.gdbus_codegen(
   'xdp-background-dbus',
@@ -83,6 +86,7 @@ xdg_desktop_portal_sources = files(
   'background.c',
   'camera.c',
   'clipboard.c',
+  'credential.c',
   'dynamic-launcher.c',
   'email.c',
   'file-chooser.c',

--- a/desktop-portal/meson.build
+++ b/desktop-portal/meson.build
@@ -13,6 +13,13 @@ portal_built_sources = gnome.gdbus_codegen(
   docbook: 'portal',
   extra_args: gdbus_codegen_extra_args,
 )
+portal_experimental_built_sources = gnome.gdbus_codegen(
+  'xdp-experimental-dbus',
+  sources: portal_experimental_sources,
+  interface_prefix: 'org.freedesktop.portal.experimental',
+  namespace: 'XdpDbusExperimental',
+  docbook: 'portal',
+)
 host_built_sources = gnome.gdbus_codegen(
   'xdp-host-dbus',
   sources: portal_host_sources,
@@ -28,6 +35,14 @@ impl_built_sources = gnome.gdbus_codegen(
   namespace: 'XdpDbusImpl',
   docbook: 'portal',
   extra_args: gdbus_codegen_extra_args,
+)
+impl_experimental_built_sources = gnome.gdbus_codegen(
+  'xdp-impl-experimental-dbus',
+  sources: portal_impl_experimental_sources,
+  interface_prefix: 'org.freedesktop.impl.portal.experimental',
+  namespace: 'XdpDbusExperimentalImpl',
+  docbook: 'portal',
+)
 )
 background_monitor_built_sources = gnome.gdbus_codegen(
   'xdp-background-dbus',
@@ -50,7 +65,7 @@ else
 endif
 
 xdp_method_info_built_sources = configure_file(
-  command: [find_program('generate-method-info.py'), portal_sources],
+  command: [find_program('generate-method-info.py'), portal_sources, portal_experimental_sources],
   capture: true,
   output: 'xdp-method-info-generated.c',
 )
@@ -105,6 +120,7 @@ xdg_desktop_portal_sources += [
   xdp_utils_sources,
   xdp_method_info_sources,
   portal_built_sources,
+  portal_experimental_built_sources,
   host_built_sources,
   impl_built_sources,
   background_monitor_built_sources,

--- a/desktop-portal/xdp-context.c
+++ b/desktop-portal/xdp-context.c
@@ -484,6 +484,17 @@ xdp_context_register (XdpContext       *context,
 #endif
   init_registry (context);
 
+  // Experimental feature flags
+  char *experimental_flag_env =
+      getenv ("XDG_DESKTOP_PORTAL_ENABLE_EXPERIMENTAL");
+  if (experimental_flag_env != NULL)
+    {
+      gchar **flags = g_strsplit (experimental_flag_env, ",", -1);
+      for (gint i = 0; flags[i] != NULL; i++)
+        {
+        }
+    }
+
   return TRUE;
 }
 

--- a/desktop-portal/xdp-context.c
+++ b/desktop-portal/xdp-context.c
@@ -10,6 +10,7 @@
 #include "background.h"
 #include "camera.h"
 #include "clipboard.h"
+#include "credential.h"
 #include "dynamic-launcher.h"
 #include "email.h"
 #include "file-chooser.h"
@@ -492,6 +493,12 @@ xdp_context_register (XdpContext       *context,
       gchar **flags = g_strsplit (experimental_flag_env, ",", -1);
       for (gint i = 0; flags[i] != NULL; i++)
         {
+          gchar *flag = flags[i];
+          if (g_strcmp0 (flag, "credential") == 0)
+            {
+              g_debug ("Enabling experimental portal credential");
+              init_portal_in_fiber(context, init_credential);
+            }
         }
     }
 

--- a/doc/api-reference.rst
+++ b/doc/api-reference.rst
@@ -65,3 +65,4 @@ replacement will be documented in :doc:`org.freedesktop.host.portal.Registry
    doc-org.freedesktop.portal.Trash.rst
    doc-org.freedesktop.portal.Usb.rst
    doc-org.freedesktop.portal.Wallpaper.rst
+   doc-org.freedesktop.portal.experimental.Credential.rst

--- a/doc/fix-rst-dbus.py
+++ b/doc/fix-rst-dbus.py
@@ -87,7 +87,15 @@ def split_sections(lines, output_prefix):
 def adjust_title(lines):
     title = lines[3].strip()
 
-    if title.startswith("org.freedesktop.portal."):
+    if title.startswith("org.freedesktop.portal.experimental."):
+        adjusted_title = (
+            title.replace("org.freedesktop.portal.experimental.", "") + " 🧪"
+        )
+    elif title.startswith("org.freedesktop.impl.portal.experimental."):
+        adjusted_title = (
+            title.replace("org.freedesktop.impl.portal.experimental.", "") + " 🧪"
+        )
+    elif title.startswith("org.freedesktop.portal."):
         adjusted_title = title.replace("org.freedesktop.portal.", "")
     elif title.startswith("org.freedesktop.impl.portal"):
         adjusted_title = title.replace("org.freedesktop.impl.portal.", "")

--- a/doc/impl-dbus-interfaces.rst
+++ b/doc/impl-dbus-interfaces.rst
@@ -36,3 +36,4 @@ accessible to sandboxed applications.
    doc-org.freedesktop.impl.portal.Settings.rst
    doc-org.freedesktop.impl.portal.Usb.rst
    doc-org.freedesktop.impl.portal.Wallpaper.rst
+   doc-org.freedesktop.impl.portal.experimental.Credential.rst

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -40,13 +40,13 @@ endif
 if build_documentation
   # Gather the XML files under data
   all_interfaces_xml = []
-  foreach i: portal_sources
+  foreach i: portal_sources + portal_experimental_sources
     all_interfaces_xml += i
   endforeach
   foreach i: portal_host_sources
     all_interfaces_xml += i
   endforeach
-  foreach i: portal_impl_sources
+  foreach i: portal_impl_sources + portal_impl_experimental_sources
     all_interfaces_xml += i
   endforeach
   foreach i: background_monitor_sources

--- a/shared/xdp-types.h
+++ b/shared/xdp-types.h
@@ -30,6 +30,9 @@ typedef struct _XdpDbusImplAccess XdpDbusImplAccess;
 #define DESKTOP_DBUS_IFACE "org.freedesktop.portal"
 #define DESKTOP_DBUS_IMPL_IFACE "org.freedesktop.impl.portal"
 #define DESKTOP_DBUS_PATH "/org/freedesktop/portal/desktop"
+#define DESKTOP_EXPERIMENTAL_DBUS_IFACE DESKTOP_DBUS_IFACE ".experimental"
+#define DESKTOP_EXPERIMENTAL_DBUS_IMPL_IFACE                                   \
+  DESKTOP_DBUS_IMPL_IFACE ".experimental"
 
 #define ACCESS_DBUS_IMPL_IFACE DESKTOP_DBUS_IMPL_IFACE ".Access"
 

--- a/shared/xdp-types.h
+++ b/shared/xdp-types.h
@@ -55,6 +55,11 @@ typedef struct _XdpDbusImplAccess XdpDbusImplAccess;
 #define CLIPBOARD_DBUS_IFACE DESKTOP_DBUS_IFACE ".Clipboard"
 #define CLIPBOARD_DBUS_IMPL_IFACE DESKTOP_DBUS_IMPL_IFACE ".Clipboard"
 
+#define CREDENTIAL_EXPERIMENTAL_DBUS_IFACE                                     \
+  DESKTOP_EXPERIMENTAL_DBUS_IFACE ".Credential"
+#define CREDENTIAL_EXPERIMENTAL_DBUS_IMPL_IFACE                                \
+  DESKTOP_EXPERIMENTAL_DBUS_IMPL_IFACE ".Credential"
+
 #define DYNAMIC_LAUNCHER_DBUS_IFACE DESKTOP_DBUS_IFACE ".DynamicLauncher"
 #define DYNAMIC_LAUNCHER_DBUS_IMPL_IFACE DESKTOP_DBUS_IMPL_IFACE ".DynamicLauncher"
 


### PR DESCRIPTION
:warning: Still a work in progress and is not ready for review yet.

This seems to work so far. Some work to be done:
- add a mock backend implementation and client for unit testing
- convert to using libdex
- Review whether the signatures make sense, or if they need to be flattened some more.
- add `DiscoverCredential(services as)` method to frontend and backend.