### PR TITLE
tests: Don't include interpreter in non-executable library files

### DIFF
--- a/tests/xdp_doc_utils.py
+++ b/tests/xdp_doc_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
 # This file is formatted with Python Black

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
 # This file is formatted with Python Black


### PR DESCRIPTION
Debian's Lintian tool warns about files with `#!` that are installed without executable permission.
These files are to be imported as libraries, and don't do anything useful if run as scripts, so they don't need a `#!` line.