### PR TITLE
validate-{icon,sound}: Print debug logs to stderr only

### DIFF
--- a/src/validate-icon.c
+++ b/src/validate-icon.c
@@ -342,6 +342,8 @@ main (int argc, char *argv[])
   g_autoptr(GError) error = NULL;
   g_autofd int fd_path = -1;
 
+  g_log_writer_default_set_use_stderr (TRUE);
+
   context = g_option_context_new (NULL);
   g_option_context_add_main_entries (context, entries, NULL);
   if (!g_option_context_parse (context, &argc, &argv, &error))

--- a/src/validate-sound.c
+++ b/src/validate-sound.c
@@ -328,6 +328,8 @@ main (int argc, char *argv[])
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GError) error = NULL;
 
+  g_log_writer_default_set_use_stderr (TRUE);
+
   context = g_option_context_new (NULL);
   g_option_context_add_main_entries (context, entries, NULL);
   if (!g_option_context_parse (context, &argc, &argv, &error))


### PR DESCRIPTION
stdout is used for communicating results to the parent process, so it cannot be used to also print debug logs. If G_MESSAGES_DEBUG=all were to be inherited from the parent environment, we could be writing random strings to stdout and breaking the parsing on the parent side.