### PR TITLE
Handle autostart errors

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -894,6 +894,7 @@ handle_request_background_in_thread_func (GTask *task,
   gboolean autostart_requested = FALSE;
   gboolean autostart_enabled;
   gboolean allowed;
+  XdgDesktopPortalResponseEnum portal_response;
   g_autoptr(GError) error = NULL;
   g_autofree const char **autostart_exec = { NULL };
   gboolean activatable = FALSE;
@@ -988,7 +989,6 @@ handle_request_background_in_thread_func (GTask *task,
 
   if (request->exported)
     {
-      XdgDesktopPortalResponseEnum portal_response;
       g_auto(GVariantBuilder) results =
         G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 

--- a/src/background.c
+++ b/src/background.c
@@ -821,8 +821,12 @@ enable_autostart_sync (XdpAppInfo          *app_info,
 
   if (!enable)
     {
-      unlink (path);
-
+      if (unlink (path) != 0 && errno != ENOENT)
+        {
+          g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
+                       "Could not remove Autostart file %s", path);
+          return FALSE;
+        }
       *out_enabled = FALSE;
       return TRUE;
     }

--- a/src/background.c
+++ b/src/background.c
@@ -960,31 +960,56 @@ handle_request_background_in_thread_func (GTask *task,
         {
           g_warning ("AccessDialog call failed: %s", error->message);
           g_clear_error (&error);
+          allowed = FALSE;
+          autostart_enabled = FALSE;
+          portal_response = XDG_DESKTOP_PORTAL_RESPONSE_OTHER;
         }
-
-      allowed = response == 0;
+      else
+        {
+          allowed = (response == XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS);
+          if (!allowed)
+            {
+              autostart_enabled = FALSE;
+              portal_response = XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED;
+            }
+        }
     }
   else
     {
       allowed = permission != XDP_PERMISSION_NO;
       if (permission == XDP_PERMISSION_UNSET)
         set_permission (id, XDP_PERMISSION_YES);
+      if (!allowed)
+        {
+          autostart_enabled = FALSE;
+          portal_response = XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED;
+        }
     }
 
-  g_debug ("Setting autostart for %s to %s", id,
-           allowed && autostart_requested ? "enabled" : "disabled");
-
-  autostart_enabled = FALSE;
-
-  if (!enable_autostart_sync (request->app_info,
-                              allowed && autostart_requested,
-                              autostart_exec,
-                              activatable,
-                              &autostart_enabled,
-                              &error))
+  if (allowed)
     {
-      g_warning ("EnableAutostart call failed: %s", error->message);
-      g_clear_error (&error);
+      g_debug ("Setting autostart for %s to %s", id,
+               autostart_requested ? "enabled" : "disabled");
+
+      autostart_enabled = FALSE;
+
+      if (!enable_autostart_sync (request->app_info,
+                                  autostart_requested,
+                                  autostart_exec,
+                                  activatable,
+                                  &autostart_enabled,
+                                  &error))
+        {
+          g_warning ("EnableAutostart call failed: %s", error->message);
+          g_clear_error (&error);
+          allowed = FALSE;
+          autostart_enabled = FALSE;
+          portal_response = XDG_DESKTOP_PORTAL_RESPONSE_OTHER;
+        }
+      else
+        {
+          portal_response = XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS;
+        }
     }
 
   if (request->exported)
@@ -994,11 +1019,6 @@ handle_request_background_in_thread_func (GTask *task,
 
       g_variant_builder_add (&results, "{sv}", "background", g_variant_new_boolean (allowed));
       g_variant_builder_add (&results, "{sv}", "autostart", g_variant_new_boolean (autostart_enabled));
-
-      if (allowed)
-        portal_response = XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS;
-      else
-        portal_response =  XDG_DESKTOP_PORTAL_RESPONSE_CANCELLED;
 
       xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
                                       portal_response,

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -85,13 +85,15 @@ class TestBackground:
         )
 
         assert response
-        assert response.response == 0
-        assert response.results["background"]
 
         # Unsupported on snap and linyaps
         if xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}:
+            assert response.response == 2
             assert not response.results["autostart"]
             return
+
+        assert response.response == 0
+        assert response.results["background"]
 
         gapp_info = xdp_app_info.gapp_info()
         autostart_name = gapp_info.get_name() if gapp_info else app_id
@@ -129,14 +131,15 @@ class TestBackground:
         )
 
         assert response
-        assert response.response == 0
-        assert response.results["background"]
 
         # Unsupported on snap and linyaps
         if xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}:
+            assert response.response == 2
             assert not response.results["autostart"]
             return
 
+        assert response.response == 0
+        assert response.results["background"]
         assert response.results["autostart"]
 
         assert desktop_file.exists()


### PR DESCRIPTION
I've made some changes to `background.c`, that I think make it a little nicer to use. I discovered that in error cases, `libportal`'s [`request_background_finish`](https://libportal.org/method.Portal.request_background_finish.html) doesn't always return `false` or set the `Gerror`. This is because `xdg-desktop-portal`'s `background.c` almost always emits with `portal_response` set to `XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS` (`0`). Looking at the [request documentation](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html), it looks like `portal_response` should be `2` (`XDG_DESKTOP_PORTAL_RESPONSE_OTHER`) in case of errors. The changes in these patches are meant to ensure that the correct response is sent for error cases.

I tested by building GNOME OS 50 (xdg-desktop-portal 1.20.3) with my patches applied, and using a flatpak app in GNOME Builder to test [libporal request_background](https://libportal.org/method.Portal.request_background.html) calls. Then I ran `chmod 000 ~/.config/autostart` before testing in order to force an error. The flatpak app used for testing is available on [my GitHub](https://github.com/justinrdonnelly/portal-background-test-libportal).

I'm very new to the portal code (and not really a C dev), so it's certainly possible that this is off base. But it seems to me like an improvement.

## Test Results

Below are some results from my testing to help understand what the changes do. The tables show the different values used for for the background flags to request (or not request) autostart, as well as the return value from `xdp_portal_request_background_finish`, and whether it set the `GError`.

The part to focus on is the how the patches change what happens in the error case (`chmod 000 ~/.config/autostart`). With the patches, the error case always returns `false`, and sets the `GError`.

### Baseline (xdg-desktop-portal 1.20.3)

`chmod 755 ~/.config/autostart`

| Background Flag               | Return | Error    |
| ----------------------------- | ------ | -------- |
| XDP_BACKGROUND_FLAG_AUTOSTART | TRUE   | NULL     |
| XDP_BACKGROUND_FLAG_NONE      | TRUE   | NULL     |

`chmod 000 ~/.config/autostart`

| Background Flag               | Return | Error    |
| ----------------------------- | ------ | -------- |
| XDP_BACKGROUND_FLAG_AUTOSTART | FALSE  | NULL     |
| XDP_BACKGROUND_FLAG_NONE      | TRUE   | NULL     |


### Patches

`chmod 755 ~/.config/autostart`

| Background Flag               | Return | Error    |
| ----------------------------- | ------ | -------- |
| XDP_BACKGROUND_FLAG_AUTOSTART | TRUE   | NULL     |
| XDP_BACKGROUND_FLAG_NONE      | TRUE   | NULL     |

`chmod 000 ~/.config/autostart`

| Background Flag               | Return | Error    |
| ----------------------------- | ------ | -------- |
| XDP_BACKGROUND_FLAG_AUTOSTART | FALSE  | Not NULL |
| XDP_BACKGROUND_FLAG_NONE      | FALSE  | Not NULL |
