### PR TITLE
camera: Do not unref the XdpAppInfo on Open request

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -266,7 +266,7 @@ handle_open_pipewire_remote (XdpDbusCamera *object,
                              GVariant *arg_options)
 {
   Camera *camera = (Camera *) object;
-  g_autoptr(XdpAppInfo) app_info = NULL;
+  XdpAppInfo *app_info;
   XdpPermission permission;
   g_autoptr(GUnixFDList) out_fd_list = NULL;
   int fd;


### PR DESCRIPTION
This leads to a crash whenever another request for the same app is done (just use ASHPD to open camera and then do another portal request), since the XdpAppInfo is owned by the invocation and it's not up to the function to clean it up

```
 Memcheck, a memory error detector
 Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
 Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
 Command: ../_BUILD/xdg-desktop-portal/src/xdg-desktop-portal

 Thread 5 pool-0:
 Invalid read of size 8
    at 0x4D66C59: g_type_check_instance_is_fundamentally_a (gtype.c:3915)
    by 0x4D46754: g_object_ref (gobject.c:4656)
    by 0x40DECAF: xdp_app_info_registry_lookup_sender (xdp-app-info-registry.c:90)
    by 0x40DECAF: xdp_app_info_registry_ensure_for_invocation_sync (xdp-app-info-registry.c:150)
    by 0x40D4EA6: authorize_callback (xdp-context.c:204)
    by 0x4BB9497: _g_cclosure_marshal_BOOLEAN__OBJECT (gmarshal-internal.c:102)
    by 0x4D40392: g_closure_invoke (gclosure.c:916)
    by 0x4D55CC9: signal_emit_unlocked_R.isra.0 (gsignal.c:3929)
    by 0x4D56F9E: signal_emit_valist_unlocked (gsignal.c:3574)
    by 0x4D5D3B7: g_signal_emit_valist (gsignal.c:3304)
    by 0x4D5D472: g_signal_emit (gsignal.c:3624)
    by 0x4C6619F: dispatch_in_thread_func (gdbusinterfaceskeleton.c:534)
    by 0x4BEBDFB: g_task_thread_pool_thread (gtask.c:1585)
  Address 0xbd00870 is 96 bytes inside a block of size 136 free'd
    at 0x49B78BF: free (vg_replace_malloc.c:989)
    by 0x4D630EE: g_type_free_instance (gtype.c:1972)
    by 0x4D46F07: g_object_unref (gobject.c:4920)
    by 0x40B43D0: glib_autoptr_clear_GObject (gobject-autocleanups.h:31)
    by 0x40B43D0: glib_autoptr_clear_XdpAppInfo (xdp-app-info.h:42)
    by 0x40B43D0: glib_autoptr_cleanup_XdpAppInfo (xdp-app-info.h:42)
    by 0x40B43D0: handle_open_pipewire_remote (camera.c:270)
    by 0x4050B7A: _g_dbus_codegen_marshal_BOOLEAN__OBJECT_STRING_STRING.part.0 (xdp-dbus.c:238)
    by 0x4D40392: g_closure_invoke (gclosure.c:916)
    by 0x4D561C6: signal_emit_unlocked_R.isra.0 (gsignal.c:3969)
    by 0x4D5D000: signal_emitv_unlocked (gsignal.c:3253)
    by 0x4D5D000: g_signal_emitv (gsignal.c:3153)
    by 0x405B771: _xdp_dbus_camera_skeleton_handle_method_call (xdp-dbus.c:6440)
    by 0x4C66238: dispatch_in_thread_func (gdbusinterfaceskeleton.c:548)
    by 0x4BEBDFB: g_task_thread_pool_thread (gtask.c:1585)
    by 0x4A609E9: g_thread_pool_thread_proxy (gthreadpool.c:336)
  Block was alloc'd at
    at 0x49BBBE3: calloc (vg_replace_malloc.c:1675)
    by 0x4A34BC9: g_malloc0 (gmem.c:133)
    by 0x4D64663: g_type_create_instance (gtype.c:1872)
    by 0x4D4837E: g_object_new_internal.part.0 (gobject.c:2665)
    by 0x4D4A57A: g_object_new_internal (gobject.c:2981)
    by 0x4D4A57A: g_object_new_valist (gobject.c:3003)
    by 0x4BB2F01: g_initable_new_valist (ginitable.c:245)
    by 0x4BB2FFC: g_initable_new (ginitable.c:163)
    by 0x40DF6F9: xdp_app_info_snap_new (xdp-app-info-snap.c:386)
    by 0x40DB6A8: xdp_app_info_new (xdp-app-info.c:341)
    by 0x40DB6A8: xdp_app_info_new_for_invocation_sync (xdp-app-info.c:387)
    by 0x40DED2F: xdp_app_info_registry_ensure_for_invocation_sync (xdp-app-info-registry.c:161)
    by 0x40D4EA6: authorize_callback (xdp-context.c:204)
    by 0x4BB9497: _g_cclosure_marshal_BOOLEAN__OBJECT (gmarshal-internal.c:102)

 Invalid read of size 8
    at 0x4D66C61: g_type_check_instance_is_fundamentally_a (gtype.c:3917)
    by 0x4D46754: g_object_ref (gobject.c:4656)
    by 0x40DECAF: xdp_app_info_registry_lookup_sender (xdp-app-info-registry.c:90)
    by 0x40DECAF: xdp_app_info_registry_ensure_for_invocation_sync (xdp-app-info-registry.c:150)
    by 0x40D4EA6: authorize_callback (xdp-context.c:204)
    by 0x4BB9497: _g_cclosure_marshal_BOOLEAN__OBJECT (gmarshal-internal.c:102)
    by 0x4D40392: g_closure_invoke (gclosure.c:916)
    by 0x4D55CC9: signal_emit_unlocked_R.isra.0 (gsignal.c:3929)
    by 0x4D56F9E: signal_emit_valist_unlocked (gsignal.c:3574)
    by 0x4D5D3B7: g_signal_emit_valist (gsignal.c:3304)
    by 0x4D5D472: g_signal_emit (gsignal.c:3624)
    by 0x4C6619F: dispatch_in_thread_func (gdbusinterfaceskeleton.c:534)
    by 0x4BEBDFB: g_task_thread_pool_thread (gtask.c:1585)
  Address 0xaaaaaaaaaaaaaaaa is not stack'd, malloc'd or (recently) free'd

 Process terminating with default action of signal 11 (SIGSEGV): dumping core
  General Protection Fault
    at 0x4D66C61: g_type_check_instance_is_fundamentally_a (gtype.c:3917)
    by 0x4D46754: g_object_ref (gobject.c:4656)
    by 0x40DECAF: xdp_app_info_registry_lookup_sender (xdp-app-info-registry.c:90)
    by 0x40DECAF: xdp_app_info_registry_ensure_for_invocation_sync (xdp-app-info-registry.c:150)
    by 0x40D4EA6: authorize_callback (xdp-context.c:204)
    by 0x4BB9497: _g_cclosure_marshal_BOOLEAN__OBJECT (gmarshal-internal.c:102)
    by 0x4D40392: g_closure_invoke (gclosure.c:916)
    by 0x4D55CC9: signal_emit_unlocked_R.isra.0 (gsignal.c:3929)
    by 0x4D56F9E: signal_emit_valist_unlocked (gsignal.c:3574)
    by 0x4D5D3B7: g_signal_emit_valist (gsignal.c:3304)
    by 0x4D5D472: g_signal_emit (gsignal.c:3624)
    by 0x4C6619F: dispatch_in_thread_func (gdbusinterfaceskeleton.c:534)
    by 0x4BEBDFB: g_task_thread_pool_thread (gtask.c:1585)

 HEAP SUMMARY:
     in use at exit: 1,591,405 bytes in 21,678 blocks
   total heap usage: 94,984 allocs, 73,306 frees, 9,243,932 bytes allocated

 LEAK SUMMARY:
    definitely lost: 0 bytes in 0 blocks
    indirectly lost: 0 bytes in 0 blocks
      possibly lost: 10,768 bytes in 42 blocks
    still reachable: 1,474,949 bytes in 20,559 blocks
         suppressed: 0 bytes in 0 blocks
 Rerun with --leak-check=full to see details of leaked memory

 For lists of detected and suppressed errors, rerun with: -s
 ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```