### PR TITLE
doc: Add a list of specialists for different portal topics

### DIFF
--- a/doc/merge-requirements.rst
+++ b/doc/merge-requirements.rst
@@ -68,3 +68,15 @@ Linyaps representative:
 - He YuMing
 - Iceyer
 - reddevillg
+
+Specialists
+-----------
+
+Portals cover a lot of different specialized topics. Committers might not be
+familiar with all of them, so it can make sense to defer to specialists in those
+topics, or in general get feedback from them. The list here should help you to
+find and contact those specialists:
+
+Printing:
+
+- Till Kamppeter (OpenPrinting, GNOME, @tillkamppeter)


### PR DESCRIPTION
The immediate reason for wanting this list is that the printing portal is constantly lacking reviewers who can judge protocol changes properly, but I'd be happy to add more people for more topics.