### PR TITLE
clipboard: Ensure that the mime type string does not exceed 4kb

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -509,6 +509,15 @@ handle_selection_read (XdpDbusClipboard *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
+  if (strlen (arg_mime_type) >= 1024 * 4)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_DBUS_ERROR,
+                                             G_DBUS_ERROR_ACCESS_DENIED,
+                                             "Mime type exceeds 4kb");
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
   xdp_dbus_impl_clipboard_call_selection_read (clipboard->impl,
                                                arg_session_handle,
                                                arg_mime_type,


### PR DESCRIPTION
Some backends have troubles handling really big mime type strings. Mutter for example uses it as an XAtom. Let's just limit the size to something reasonable as early as possible.