### PR TITLE
printing: document that number-up and n-copies should not be applied by apps

### DIFF
--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -108,7 +108,9 @@
 
         * ``n-copies`` (``s``)
 
-          The number of copies to print.
+          The number of copies to print. This setting is sent to the printing backend,
+          therefore applications should not do copies themselves,
+          unless print-to-file is selected.
 
         * ``default-source`` (``s``)
 
@@ -173,7 +175,9 @@
 
         * ``number-up`` (``s``)
 
-          The number of pages per sheet.
+          The number of pages per sheet. This setting is sent to the printing backend,
+          therefore applications should not apply this setting themselves,
+          unless print-to-file is selected.
 
         * ``number-up-layout`` (``s``)
 
@@ -253,7 +257,8 @@
         * ``settings`` (``a{sv}``)
 
           Print settings as set up by the user in the print dialog. The same keys as in @settings
-          are supported (see above).
+          are supported (see above). Key ``output-uri`` is only present if print-to-file is
+          selected.
 
         * ``page-setup`` (``a{sv}``)
 


### PR DESCRIPTION
Following the discussion in https://github.com/flatpak/xdg-desktop-portal/pull/1849 with @tillkamppeter yesterday, this PR adds some documentation on the fact copies and number-up should not be done by apps, unless print-to-file is used.

To make this effective, this PR also specifies that output-uri is only present when print-to-file is used. That matches:
- what is already done in KDE, see https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/blob/master/src/print.cpp?ref_type=heads#L578 and https://code.qt.io/cgit/qt/qtbase.git/tree/src/printsupport/dialogs/qprintdialog_unix.cpp?h=6.10#n1307
- what is already done in GNOME: print settings are obtained from the dialog and the selected printer, and "output-uri" is only set in the file backend, there https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/print/backends/gtkprintbackendfile.c#L768

Specifying all of this is necessary to avoid any ambiguity on which side is responsible for doing copies.

cc @matthiasclasen @Sodivad 