### PR TITLE
access: remove DE-specific messages

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -919,7 +919,6 @@ handle_request_background_in_thread_func (GTask *task,
       g_autofree char *app_id = NULL;
       g_autofree char *title = NULL;
       g_autofree char *subtitle = NULL;
-      g_autofree char *body = NULL;
       guint32 response = 2;
       g_autoptr(GVariant) results = NULL;
       g_autoptr(GError) error = NULL;
@@ -935,7 +934,6 @@ handle_request_background_in_thread_func (GTask *task,
         subtitle = g_strdup_printf (_("%s wants to be started automatically and run in the background"), info ? g_app_info_get_display_name (info) : id);
       else
         subtitle = g_strdup_printf (_("%s wants to run in the background"), info ? g_app_info_get_display_name (info) : id);
-      body = g_strdup (_("The ‘run in background’ permission can be changed at any time from the app settings"));
 
       g_debug ("Calling backend for background access for: %s", id);
 
@@ -947,7 +945,7 @@ handle_request_background_in_thread_func (GTask *task,
                                                          "",
                                                          title,
                                                          subtitle,
-                                                         body,
+                                                         "",
                                                          g_variant_builder_end (&opt_builder),
                                                          &response,
                                                          &results,

--- a/src/camera.c
+++ b/src/camera.c
@@ -89,7 +89,6 @@ query_permission_sync (Camera     *camera,
         G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree char *title = NULL;
       g_autofree char *subtitle = NULL;
-      const char *body;
       guint32 response = 2;
       g_autoptr(GVariant) results = NULL;
       g_autoptr(GError) error = NULL;
@@ -109,8 +108,6 @@ query_permission_sync (Camera     *camera,
           title = g_strdup (_("Allow Apps to Use the Camera?"));
           subtitle = g_strdup (_("An app wants to access the camera"));
         }
-
-      body = _("This permission can be changed at any time from the privacy settings");
 
       impl_request = xdp_dbus_impl_request_proxy_new_sync (
         g_dbus_proxy_get_connection (G_DBUS_PROXY (camera->access_impl)),
@@ -132,7 +129,7 @@ query_permission_sync (Camera     *camera,
                                                          "",
                                                          title,
                                                          subtitle,
-                                                         body,
+                                                         "",
                                                          g_variant_builder_end (&opt_builder),
                                                          &response,
                                                          &results,

--- a/src/location.c
+++ b/src/location.c
@@ -531,7 +531,6 @@ handle_start_in_thread_func (GTask *task,
         G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree char *title = NULL;
       g_autofree char *subtitle = NULL;
-      const char *body;
       g_autoptr(GError) error = NULL;
 
       impl_request = xdp_dbus_impl_request_proxy_new_sync (
@@ -572,15 +571,13 @@ handle_start_in_thread_func (GTask *task,
           subtitle = g_strdup (_("An app wants to use your location"));
         }
 
-      body = _("Location access can be changed at any time from the privacy settings");
-
       if (!xdp_dbus_impl_access_call_access_dialog_sync (location->access_impl,
                                                          request->id,
                                                          app_id,
                                                          parent_window,
                                                          title,
                                                          subtitle,
-                                                         body,
+                                                         "",
                                                          g_variant_builder_end (&access_opt_builder),
                                                          &access_response,
                                                          &access_results,

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -202,7 +202,6 @@ check_non_interactive_permission_in_thread (Screenshot *screenshot,
   XdpPermission permission;
   g_autofree char *subtitle = NULL;
   g_autofree char *title = NULL;
-  const char *body = "";
   uint access_response = 2;
   const char *app_id;
 
@@ -270,16 +269,13 @@ check_non_interactive_permission_in_thread (Screenshot *screenshot,
         }
     }
 
-  if (permission == XDP_PERMISSION_UNSET)
-    body = _("This permission can be changed at any time from the privacy settings");
-
   if (!xdp_dbus_impl_access_call_access_dialog_sync (screenshot->access_impl,
                                                      request->id,
                                                      app_id,
                                                      parent_window,
                                                      title,
                                                      subtitle,
-                                                     body,
+                                                     "",
                                                      g_variant_builder_end (&access_opt_builder),
                                                      &access_response,
                                                      &access_results,

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -183,7 +183,6 @@ handle_set_wallpaper_in_thread_func (GTask *task,
         G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       g_autofree gchar *title = NULL;
       g_autofree gchar *subtitle = NULL;
-      const gchar *body;
 
       g_variant_builder_add (&access_opt_builder, "{sv}",
                              "deny_label", g_variant_new_string (_("Deny")));
@@ -204,15 +203,13 @@ handle_set_wallpaper_in_thread_func (GTask *task,
           subtitle = g_strdup (_("An app wants to change the background image"));
         }
 
-      body = _("This permission can be changed at any time from the privacy settings");
-
       if (!xdp_dbus_impl_access_call_access_dialog_sync (wallpaper->access_impl,
                                                          request->id,
                                                          app_id,
                                                          parent_window,
                                                          title,
                                                          subtitle,
-                                                         body,
+                                                         "",
                                                          g_variant_builder_end (&access_opt_builder),
                                                          &access_response,
                                                          &access_results,


### PR DESCRIPTION
fixes #1593

If needed, DE-specific messages can be added in the respective access portal backends.