### PR TITLE
file-chooser: Drop `multiple` in `SaveFileOptions`

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -137,10 +137,6 @@
 
           Whether to make the dialog modal. Default is yes.
 
-        * ``multiple`` (``b``)
-
-          Whether to allow selection of multiple files. Default is no.
-
         * ``filters`` (``a(sa(us))``)
 
           A list of serialized file filters.


### PR DESCRIPTION
This is not present in the options passed by frontend and does not make sense for the `SaveFile` method anyway.

Partially closes: https://github.com/flatpak/xdg-desktop-portal/issues/1877