### PR TITLE
file-chooser: Clarify `SaveFile`'s `uris` nature

### DIFF
--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -168,8 +168,8 @@
 
         * ``uris`` (``as``)
 
-          An array of strings containing the uri of the selected file. All
-          URIs must have the "file://" scheme.
+          An array of strings containing the uri of the selected file. It must
+          have exactly one element. All URIs must have the "file://" scheme.
 
         * ``choices`` (``a(ss)``)
 

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -229,8 +229,8 @@
 
       * ``uris`` (``as``)
 
-        An array of strings containing the uri of the selected file. All URIs
-        have the ``file://`` scheme.
+        An array of strings containing the uri of the selected file. It has
+        exactly one element. All URIs have the ``file://`` scheme.
 
       * ``choices`` (``a(ss)``)
 


### PR DESCRIPTION
It should have exactly one element.

Closes: https://github.com/flatpak/xdg-desktop-portal/issues/1877