### PR TITLE
background: Fix signal connection

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -1387,7 +1387,7 @@ background_new (XdpDbusImplBackground *background_impl,
   g_signal_connect_object (background->impl, "running-applications-changed",
                            G_CALLBACK (on_running_apps_changed),
                            background,
-                           G_CONNECT_DEFAULT);
+                           G_CONNECT_SWAPPED);
 
   /* FIXME: it would be better if libflatpak had a monitor api for this */
   instance_path = g_build_filename (g_get_user_runtime_dir (), ".flatpak", NULL);
@@ -1406,7 +1406,7 @@ background_new (XdpDbusImplBackground *background_impl,
       g_signal_connect_object (background->instance_monitor, "changed",
                                G_CALLBACK (on_instances_changed),
                                background,
-                               G_CONNECT_DEFAULT);
+                               G_CONNECT_SWAPPED);
     }
 
   return g_steal_pointer (&background);


### PR DESCRIPTION
Two signal connections expect the user data pointer to be the first parameter but didn't specify G_CONNECT_SWAPPED.

Fixes: 86e6f3dc ("background: Get rid of global state")