### PR TITLE
document-portal: Guard renameat2() flags usage behind ifdefs

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -428,14 +428,18 @@ renameat2_flags_to_string (int flags)
 #if HAVE_RENAMEAT2
   GString *s = g_string_new ("");
 
+#ifdef RENAME_EXCHANGE
   if (flags & RENAME_EXCHANGE)
     g_string_append (s, "EXCHANGE,");
+#endif
 
   if (flags & RENAME_NOREPLACE)
     g_string_append (s, "NOREPLACE,");
 
+#ifdef RENAME_WHITEOUT
   if (flags & RENAME_WHITEOUT)
     g_string_append (s, "WHITEOUT,");
+#endif
 
   /* Remove last comma */
   if (s->len > 0)


### PR DESCRIPTION
FreeBSD recently gained the `renameat2` syscall, but only supports the `RENAME_NOREPLACE` flag. This change fixes the build for us.