### PR TITLE
print: add auto-scale api

### DIFF
--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -65,6 +65,11 @@
 
           Whether it makes sense to return "selection" for the ``print-pages`` setting.
 
+        * ``has_automatic_scale`` (``b``)
+
+          Whether the app can deal with automatic scale settings, i.e. ``fit`` or ``shrink``
+          to printable area, as specified in the auto-scale parameter.
+
         The :ref:`org.freedesktop.portal.Print.PreparePrint` documentation has details about
         the supported keys in settings and page-setup.
     -->

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -18,7 +18,7 @@
       to print the formatted document. It is expected that high-level toolkit
       APIs such as GtkPrintOperation will hide most of this complexity.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes version 5 of this interface.
   -->
   <interface name="org.freedesktop.portal.Print">
     <!--
@@ -69,6 +69,13 @@
           Whether it makes sense to return "selection" for the ``print-pages`` setting.
 
           This option was added in version 4.
+
+        * ``has_automatic_scale`` (``b``)
+
+          Whether the app can deal with automatic scale settings, i.e. ``fit`` or ``shrink``
+          to printable area, as specified in the auto-scale parameter.
+
+          This option was added in version 5.
 
         The @settings and @page_setup vardict contain hints for the initial state of the print dialog.
 
@@ -134,6 +141,10 @@
         * ``scale`` (``s``)
 
           The scale in percent.
+
+        * ``auto-scale`` (``s``)
+        
+          If ``has_automatic_scale`` is true, this can be equal to ``fit`` or ``shrink``.
 
         * ``print-pages`` (``s``)
 

--- a/desktop-portal/print.c
+++ b/desktop-portal/print.c
@@ -241,6 +241,7 @@ static XdpOptionKey prepare_print_options[] = {
   { "supported_output_file_formats", G_VARIANT_TYPE_STRING_ARRAY, validate_supported_output_file_formats },
   { "has_current_page", G_VARIANT_TYPE_BOOLEAN },
   { "has_selected_pages", G_VARIANT_TYPE_BOOLEAN },
+  { "has_automatic_scale", G_VARIANT_TYPE_BOOLEAN },
 };
 
 static gboolean
@@ -346,7 +347,7 @@ print_new (XdpDbusImplPrint    *impl,
   print->impl = g_object_ref (impl);
   print->lockdown_impl = g_object_ref (lockdown_impl);
 
-  xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 4);
+  xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 5);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (print->impl), G_MAXINT);
 

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -30,7 +30,7 @@ def required_templates():
 
 class TestPrint:
     def test_version(self, portals, dbus_con):
-        xdp.check_version(dbus_con, "Print", 4)
+        xdp.check_version(dbus_con, "Print", 5)
 
     def test_prepare_print_basic(self, portals, dbus_con, xdp_app_info):
         app_id = xdp_app_info.app_id


### PR DESCRIPTION
Add an auto-scale api so as apps can scale to the printable area. This is commonly used when printing, either for images, or for documents that have different paper size (such as printing slides to A4 paper).

See [papers#564](https://gitlab.gnome.org/GNOME/papers/-/issues/564) for instance.

Related to https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/256