### PR TITLE
Make graphical-session a weak dependency of the portal service.

### DIFF
--- a/src/xdg-desktop-portal.service.in
+++ b/src/xdg-desktop-portal.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Portal service
 PartOf=graphical-session.target
-Requisite=graphical-session.target
+Wants=graphical-session.target
 After=graphical-session.target
 
 [Service]


### PR DESCRIPTION
Not all desktops will reach graphical-session.target; That however should not keep the portal service from running.

C.f. https://launchpad.net/bugs/2144855, where the unit will fail to start with result 'dependency'.

This affects Lxqt and stand-alone window managers and is observed in Ubuntu 26.04.