### PR TITLE
screen-cast: add pipewire-serial stream property

### DIFF
--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -25,7 +25,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 5 of this interface.
+      This documentation describes version 6 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.ScreenCast">
     <!--
@@ -148,6 +148,12 @@
           node ID (the first element in the tuple, and a Vardict of
           properties.
 
+          Since version 6 of this interface, the node ID in the stream
+          tuple is deprecated for stream targeting. PipeWire node IDs can
+          be reused after node destruction; consumers should prefer the
+          ``pipewire-serial`` property from the stream properties dict
+          and ``PW_KEY_TARGET_OBJECT`` for connecting to streams.
+
           The array will contain a single stream if 'multiple' (see
           SelectSources) was set to 'false', or at least one stream if
           'multiple' was set to 'true' as part of the SelectSources method.
@@ -188,6 +194,16 @@
             device.
 
             This property was added in version 5 of this interface.
+
+          * ``pipewire-serial`` (``t``)
+
+            The PipeWire ``object.serial`` for this stream's node. Unlike the
+            node ID in the stream tuple (which can be reused after node
+            destruction), the serial is a monotonically increasing 64-bit
+            identifier that is never reused. Consumers should prefer the serial
+            for stream targeting via ``PW_KEY_TARGET_OBJECT`` when available.
+
+            This property was added in version 6 of this interface.
 
         * ``persist_mode`` (``u``)
 

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -25,7 +25,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 5 of this interface.
+      This documentation describes version 6 of this interface.
   -->
   <interface name="org.freedesktop.portal.ScreenCast">
     <!--
@@ -185,6 +185,16 @@
           node ID (the first element in the tuple, and a Vardict of
           properties.
 
+          Since version 6 of this interface, the node ID in the stream
+          tuple is deprecated for stream targeting. PipeWire node IDs can
+          be reused after node destruction, so active sessions may
+          misidentify streams across monitor hotplug, resolution or
+          refresh-rate changes, or suspend/resume cycles. Consumers should
+          prefer the ``pipewire-serial`` property from the stream
+          properties dict and ``PW_KEY_TARGET_OBJECT`` for connecting to
+          streams. Backends must continue to populate the node ID for
+          compatibility with clients that do not support version 6.
+
           The array will contain a single stream if 'multiple' (see
           org.freedesktop.portal.ScreenCast.SelectSources())
           was set to 'false', or at least one stream if
@@ -233,6 +243,16 @@
             device.
 
             This property was added in version 5 of this interface.
+
+          * ``pipewire-serial`` (``t``)
+
+            The PipeWire ``object.serial`` for this stream's node. Unlike the
+            node ID in the stream tuple (which can be reused after node
+            destruction), the serial is a monotonically increasing 64-bit
+            identifier that is never reused. Consumers should prefer the serial
+            for stream targeting via ``PW_KEY_TARGET_OBJECT`` when available.
+
+            This property was added in version 6 of this interface.
 
         * ``restore_token`` (``s``)
 

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -70,6 +70,8 @@ struct _ScreenCastStream
   uint32_t id;
   int32_t width;
   int32_t height;
+  uint64_t pipewire_serial;
+  gboolean has_pipewire_serial;
 };
 
 G_DEFINE_TYPE_WITH_CODE (ScreenCast, screen_cast,
@@ -775,6 +777,9 @@ collect_screen_cast_stream_data (GVariantIter *streams_iter)
       stream->id = stream_id;
       g_variant_lookup (stream_options, "size", "(ii)",
                         &stream->width, &stream->height);
+      stream->has_pipewire_serial =
+        g_variant_lookup (stream_options, "pipewire-serial", "t",
+                          &stream->pipewire_serial);
 
       streams = g_list_prepend (streams, stream);
     }
@@ -1126,7 +1131,8 @@ screen_cast_new (XdpContext            *context,
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (screen_cast->impl), G_MAXINT);
 
-  xdp_dbus_screen_cast_set_version (XDP_DBUS_SCREEN_CAST (screen_cast), 5);
+  xdp_dbus_screen_cast_set_version (XDP_DBUS_SCREEN_CAST (screen_cast),
+                                    MIN (xdp_dbus_impl_screen_cast_get_version (screen_cast->impl), 6));
 
   g_object_bind_property (G_OBJECT (screen_cast->impl), "available-source-types",
                           G_OBJECT (screen_cast), "available-source-types",


### PR DESCRIPTION
Add optional `pipewire-serial` (uint64) to the stream properties dict
returned by `ScreenCast.Start()` and `RemoteDesktop.Start()`. This
exposes the PipeWire `object.serial`, which unlike node_id is never
reused after node destruction.

## Motivation

PipeWire node_ids are reusable. When a ScreenCast stream is destroyed
and recreated (monitor hotplug, resolution change, dock/undock),
consumers holding the old node_id can silently connect to the wrong
PipeWire node if the ID has been reassigned. PipeWire deprecated
`node.target` (node_id based) in 0.3.64 in favor of `target.object`
(serial based) for this reason.

The portal currently returns only node_id, encouraging all consumers to
use the deprecated `pw_stream_connect(target_id=node_id)` pattern.

## Changes

- **Spec** (`ScreenCast.xml`): document `pipewire-serial` as an optional
  `t` (uint64) in the stream properties dict, version 6
- **Frontend** (`screen-cast.c`): parse `pipewire-serial` from backend
  responses, store in `ScreenCastStream`, add getter function
- **Header** (`screen-cast.h`): declare
  `screen_cast_stream_get_pipewire_serial()`

The existing node_id `u` in the tuple is preserved. Old consumers ignore
the new dict key. New consumers prefer serial when present.

## Backend availability

The wlr backend can provide serial immediately (direct PipeWire access).
GNOME and KDE backends need compositor changes to pass serial through
their intermediate protocols and can add support independently.

Ref: #979