### PR TITLE
Fix file chooser opening parent of requested current_folder

### DIFF
--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -514,10 +514,9 @@ handle_open_file (XdpDbusFileChooser *object,
       {
         const char *path_from_app = g_variant_get_bytestring (current_folder);
         g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app);
-        g_autofree char *real_path = g_path_get_dirname (host_path);
 
         g_variant_builder_add (&options, "{sv}", "current_folder",
-                              g_variant_new_bytestring (real_path));
+                              g_variant_new_bytestring (host_path));
       }
   }
 
@@ -658,10 +657,9 @@ handle_save_file (XdpDbusFileChooser *object,
       {
         const char *path_from_app = g_variant_get_bytestring (current_folder);
         g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app);
-        g_autofree char *real_path = g_path_get_dirname (host_path);
 
         g_variant_builder_add (&options, "{sv}", "current_folder",
-                              g_variant_new_bytestring (real_path));
+                              g_variant_new_bytestring (host_path));
       }
   }
 


### PR DESCRIPTION
The calls to `g_path_get_dirname` unconditionally strip the last component from the path, which resulted in the file chooser being opened in the wrong folder.

There is no reason to check if the path points to a file or directory - the file chooser will look at the path much later than when the portal is doing these checks, and by then a folder might have been replaced with a file, a file with a folder, or the path (or some of its parents) might not exist any longer. So the file picker implementation is already required to be able to handle "current_folder" paths that point at files.

~~For example, Nautilus resolves this by repeatedly stripping off the last component of the provided current_folder until it has a path that it is able to navigate to.~~

Fixes #1899

This is a simpler fix than https://github.com/flatpak/xdg-desktop-portal/pull/1937 while still being correct, and is not a full revert of the original bug fix PR "Try harder to find the host path for the documents" (#1571) like https://github.com/flatpak/xdg-desktop-portal/pull/1944