### PR TITLE
Use name_to_handle_at file handles instead of dev+ino in the document portal

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -190,6 +190,7 @@ struct _XdpDomain {
   guint64 doc_dir_device;
   guint64 doc_dir_inode;
   guint32 doc_flags;
+  GBytes *doc_dir_handle;
 
   /* Below is mutable, protected by mutex */
   GMutex  tempfile_mutex;
@@ -564,6 +565,7 @@ xdp_domain_unref (XdpDomain *domain)
       g_free (domain->app_id);
       g_free (domain->doc_path);
       g_free (domain->doc_file);
+      g_clear_pointer (&domain->doc_dir_handle, g_bytes_unref);
       if (domain->inodes)
         g_assert (g_hash_table_size (domain->inodes) == 0);
       g_clear_pointer (&domain->inodes, g_hash_table_unref);
@@ -648,6 +650,7 @@ xdp_domain_new_document (XdpDomain         *parent,
   domain->doc_flags = document_entry_get_flags (doc_entry);
   domain->doc_dir_device = document_entry_get_device (doc_entry);
   domain->doc_dir_inode =  document_entry_get_inode (doc_entry);
+  domain->doc_dir_handle = document_entry_dup_handle (doc_entry);
 
   db_path = document_entry_get_path (doc_entry);
   if (xdp_document_domain_is_dir (domain))
@@ -975,9 +978,20 @@ xdp_domain_get_doc_dir (XdpDomain   *doc_domain,
   if (fstat (dirfd, buf) != 0)
     return -errno;
 
-  if (buf->st_ino != doc_domain->doc_dir_inode ||
-      buf->st_dev != doc_domain->doc_dir_device)
-    return -ENOENT;
+  if (doc_domain->doc_dir_handle != NULL)
+    {
+      /* If we have a handle, use it exclusively — st_dev is not stable across reboots */
+      g_autoptr(GBytes) handle = xdp_file_handle_for_fd (dirfd);
+
+      if (handle == NULL || !g_bytes_equal (handle, doc_domain->doc_dir_handle))
+        return -ENOENT;
+    }
+  else
+    {
+      if (buf->st_ino != doc_domain->doc_dir_inode ||
+          buf->st_dev != doc_domain->doc_dir_device)
+        return -ENOENT;
+    }
 
   if (dirfd_out)
     *dirfd_out = g_steal_fd (&dirfd);

--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -960,16 +960,27 @@ xdp_inode_kernel_unref (XdpInode *inode, unsigned long count)
 }
 
 static int
-verify_doc_dir_devino (int dirfd, XdpDomain *doc_domain)
+xdp_domain_get_doc_dir (XdpDomain   *doc_domain,
+                        int         *dirfd_out,
+                        struct stat *buf_out)
 {
-  struct stat buf;
+  g_autofd int dirfd = -1;
+  struct stat local_buf;
+  struct stat *buf = buf_out ? buf_out : &local_buf;
 
-  if (fstat (dirfd, &buf) != 0)
+  dirfd = open (doc_domain->doc_path, O_PATH | O_DIRECTORY);
+  if (dirfd < 0)
     return -errno;
 
-  if (buf.st_ino != doc_domain->doc_dir_inode ||
-      buf.st_dev != doc_domain->doc_dir_device)
+  if (fstat (dirfd, buf) != 0)
+    return -errno;
+
+  if (buf->st_ino != doc_domain->doc_dir_inode ||
+      buf->st_dev != doc_domain->doc_dir_device)
     return -ENOENT;
+
+  if (dirfd_out)
+    *dirfd_out = g_steal_fd (&dirfd);
 
   return 0;
 }
@@ -987,11 +998,7 @@ xdp_nonphysical_document_inode_opendir (XdpInode *inode)
   g_assert (domain->type == XDP_DOMAIN_DOCUMENT);
   g_assert (inode->physical == NULL);
 
-  dirfd = open (domain->doc_path, O_PATH | O_DIRECTORY);
-  if (dirfd < 0)
-    return -errno;
-
-  res = verify_doc_dir_devino (dirfd, domain);
+  res = xdp_domain_get_doc_dir (domain, &dirfd, NULL);
   if (res != 0)
     return res;
 
@@ -2382,12 +2389,8 @@ xdp_fuse_opendir (fuse_req_t             req,
 
               d = xdp_dir_new_buffered (req);
 
-              if (stat (domain->doc_path, &buf) == 0 &&
-                  buf.st_ino == domain->doc_dir_inode &&
-                  buf.st_dev == domain->doc_dir_device)
-                {
-                  xdp_dir_add (d, req, domain->doc_file, buf.st_mode);
-                }
+              if (xdp_domain_get_doc_dir (domain, NULL, &buf) == 0)
+                xdp_dir_add (d, req, domain->doc_file, buf.st_mode);
             }
         }
       else
@@ -3842,11 +3845,14 @@ xdp_fuse_lookup_id_for_inode (ino_t      ino,
     }
   else
     {
+      struct stat buf;
+
       /* directory document */
 
       /* Only return entire doc for main dir */
-      if (file_devino.dev == domain->doc_dir_device &&
-          file_devino.ino == domain->doc_dir_inode)
+      if (xdp_domain_get_doc_dir (domain, NULL, &buf) == 0 &&
+          buf.st_dev == file_devino.dev &&
+          buf.st_ino == file_devino.ino)
         return g_strdup (domain->doc_id);
 
       /* But maybe its a subfile of the document */

--- a/document-portal/document-portal-fuse.h
+++ b/document-portal/document-portal-fuse.h
@@ -8,6 +8,7 @@ G_BEGIN_DECLS
 char **        xdp_list_apps (void);
 char **        xdp_list_docs (void);
 PermissionDbEntry *xdp_lookup_doc (const char *doc_id);
+GBytes *       xdp_file_handle_for_fd (int fd);
 
 gboolean    xdp_fuse_init (GError **error);
 void        xdp_fuse_exit (void);

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1328,10 +1328,8 @@ get_app_permissions (PermissionDbEntry *entry)
 static GVariant *
 get_path (PermissionDbEntry *entry)
 {
-  g_autoptr (GVariant) data = permission_db_entry_get_data (entry);
-  const char *path;
+  const char *path = document_entry_get_path (entry);
 
-  g_variant_get (data, "(^&ayttu)", &path, NULL, NULL, NULL);
   return g_variant_new_bytestring (path);
 }
 

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -39,6 +39,7 @@
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 #include <glib-unix.h>
+#include <libglnx.h>
 
 #include "document-portal-dbus.h"
 #include "document-portal-fuse.h"
@@ -299,6 +300,26 @@ portal_delete (GDBusMethodInvocation *invocation,
 
   /* Now fuse view is up-to-date, so we can return the call */
   g_dbus_method_invocation_return_value (invocation, g_variant_new ("()"));
+}
+
+GBytes *
+xdp_file_handle_for_fd (int fd)
+{
+  g_autofree struct file_handle *handle = NULL;
+  g_autofd int fd_owned = -1;
+
+  if (!(fcntl (fd, F_GETFL) & O_PATH))
+    fd = fd_owned = glnx_fd_reopen (fd, O_PATH, NULL);
+
+  if (fd < 0 ||
+      !glnx_name_to_handle_at (fd, "",
+                               AT_EMPTY_PATH | AT_HANDLE_FID,
+                               &handle,
+                               NULL,
+                               NULL))
+    return NULL;
+
+  return g_bytes_new (handle->f_handle, handle->handle_bytes);
 }
 
 static char *

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -489,6 +489,7 @@ validate_fd (int fd,
              ValidateFdType ensure_type,
              struct stat *st_buf,
              struct stat *real_dir_st_buf,
+             GBytes **real_dir_handle_out,
              char **path_out,
              gboolean *writable_out,
              GError **error)
@@ -528,6 +529,9 @@ validate_fd (int fd,
   dir_fd = open (dirname, O_CLOEXEC | O_PATH);
   if (dir_fd < 0 || fstat (dir_fd, real_dir_st_buf) != 0)
     goto errout;
+
+  if (real_dir_handle_out)
+    *real_dir_handle_out = xdp_file_handle_for_fd (dir_fd);
 
   if (name != NULL)
     {
@@ -887,6 +891,7 @@ document_add_full (int                      *fd,
   const char *app_id = xdp_app_info_get_id (app_info);
   g_autoptr(GPtrArray) ids = g_ptr_array_new_with_free_func (g_free);
   g_autoptr(GPtrArray) paths = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GPtrArray) handles = g_ptr_array_new_with_free_func ((GDestroyNotify) g_bytes_unref);
   g_autofree struct stat *real_dir_st_bufs = NULL;
   struct stat st_buf;
   g_autofree gboolean *writable = NULL;
@@ -894,6 +899,7 @@ document_add_full (int                      *fd,
 
   g_ptr_array_set_size (paths, n_args + 1);
   g_ptr_array_set_size (ids, n_args + 1);
+  g_ptr_array_set_size (handles, n_args + 1);
   real_dir_st_bufs = g_new0 (struct stat, n_args);
   writable = g_new0 (gboolean, n_args);
 
@@ -908,7 +914,11 @@ document_add_full (int                      *fd,
       is_dir = (flags & DOCUMENT_ADD_FLAGS_DIRECTORY) != 0;
       allow_write = (target_perms & DOCUMENT_PERMISSION_FLAGS_WRITE) != 0;
 
-      if (!validate_fd (fd[i], app_info, is_dir ? VALIDATE_FD_FILE_TYPE_DIR : VALIDATE_FD_FILE_TYPE_REGULAR, &st_buf, &real_dir_st_bufs[i], &path, &writable[i], error))
+      if (!validate_fd (fd[i], app_info,
+                        is_dir ? VALIDATE_FD_FILE_TYPE_DIR : VALIDATE_FD_FILE_TYPE_REGULAR,
+                        &st_buf, &real_dir_st_bufs[i],
+                        (GBytes **)&g_ptr_array_index (handles, i),
+                        &path, &writable[i], error))
         return NULL;
 
       if (parent_dev != NULL && parent_ino != NULL)
@@ -950,6 +960,8 @@ document_add_full (int                      *fd,
           if (real_path)
             {
               g_autofree char *dirname = NULL;
+              g_autofd int dir_fd = -1;
+              g_autoptr(GBytes) old_handle = NULL;
 
               g_free (path);
               path = g_steal_pointer (&real_path);
@@ -958,13 +970,18 @@ document_add_full (int                      *fd,
                 dirname = g_strdup (path);
               else
                 dirname = g_path_get_dirname (path);
-              if (lstat (dirname, &real_dir_st_bufs[i]) != 0)
+
+              dir_fd = open (dirname, O_CLOEXEC | O_PATH);
+              if (dir_fd < 0 || fstat (dir_fd, &real_dir_st_bufs[i]) != 0)
                 {
                   g_set_error (error,
                                XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
                                "Invalid fd passed");
                   return NULL;
                 }
+
+              old_handle = g_steal_pointer (&g_ptr_array_index (handles, i));
+              g_ptr_array_index (handles, i) = xdp_file_handle_for_fd (dir_fd);
             }
           else
             g_ptr_array_index(ids,i) = g_steal_pointer (&id);
@@ -1007,7 +1024,7 @@ document_add_full (int                      *fd,
 
         if (g_ptr_array_index(ids,i) == NULL)
           {
-            char *id = do_create_doc (&real_dir_st_bufs[i], NULL, path, reuse_existing, persistent, is_dir);
+            char *id = do_create_doc (&real_dir_st_bufs[i], g_ptr_array_index (handles, i), path, reuse_existing, persistent, is_dir);
             g_ptr_array_index(ids,i) = id;
 
             if (app_id[0] != '\0' && g_strcmp0 (app_id, target_app_id) != 0)
@@ -1063,6 +1080,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
   g_autofree char *parent_path = NULL;
   const int *fds = NULL;
   struct stat parent_st_buf;
+  g_autoptr(GBytes) handle = NULL;
   gboolean reuse_existing, persistent, as_needed_by_app;
   guint32 flags = 0;
   const char *filename;
@@ -1142,6 +1160,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
       return;
     }
 
+  handle = xdp_file_handle_for_fd (parent_fd);
   path = g_build_filename (parent_path, filename, NULL);
 
   g_debug ("portal_add_named_full %s", path);
@@ -1166,7 +1185,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
       }
     else
       {
-        id = do_create_doc (&parent_st_buf, NULL, path, reuse_existing, persistent, FALSE);
+        id = do_create_doc (&parent_st_buf, handle, path, reuse_existing, persistent, FALSE);
 
         if (app_id[0] != '\0' && g_strcmp0 (app_id, target_app_id) != 0)
           {
@@ -1217,6 +1236,7 @@ portal_add_named (GDBusMethodInvocation *invocation,
   g_autofree char *parent_path = NULL;
   g_autofree char *path = NULL;
   struct stat parent_st_buf;
+  g_autoptr(GBytes) handle = NULL;
   const char *filename;
   gboolean reuse_existing, persistent;
   g_autoptr(GError) local_error = NULL;
@@ -1269,11 +1289,12 @@ portal_add_named (GDBusMethodInvocation *invocation,
       return;
     }
 
+  handle = xdp_file_handle_for_fd (parent_fd);
   path = g_build_filename (parent_path, filename, NULL);
 
   XDP_AUTOLOCK (db);
 
-  id = do_create_doc (&parent_st_buf, NULL, path, reuse_existing, persistent, FALSE);
+  id = do_create_doc (&parent_st_buf, handle, path, reuse_existing, persistent, FALSE);
 
   g_dbus_method_invocation_return_value (invocation,
                                          g_variant_new ("(s)", id));
@@ -1327,6 +1348,7 @@ portal_lookup (GDBusMethodInvocation *invocation,
   g_autofree char *path = NULL;
   g_autofd int fd = -1;
   struct stat st_buf, real_dir_st_buf;
+  g_autoptr(GBytes) handle = NULL;
   g_autofree char *id = NULL;
   g_autoptr(GError) error = NULL;
   gboolean is_dir;
@@ -1351,7 +1373,7 @@ portal_lookup (GDBusMethodInvocation *invocation,
       return TRUE;
     }
 
-  if (!validate_fd (fd, app_info, VALIDATE_FD_FILE_TYPE_ANY, &st_buf, &real_dir_st_buf, &path, NULL, &error))
+  if (!validate_fd (fd, app_info, VALIDATE_FD_FILE_TYPE_ANY, &st_buf, &real_dir_st_buf, &handle, &path, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, g_steal_pointer (&error));
       return TRUE;
@@ -1370,7 +1392,7 @@ portal_lookup (GDBusMethodInvocation *invocation,
       id = find_id (path,
                     real_dir_st_buf.st_dev,
                     real_dir_st_buf.st_ino,
-                    NULL,
+                    handle,
                     is_dir ? DOCUMENT_ENTRY_FLAG_DIRECTORY : 0,
                     TRUE /* ignore_transient */);
     }

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -421,7 +421,6 @@ do_create_doc (struct stat *parent_st_buf,
                gboolean     persistent,
                gboolean     directory)
 {
-  g_autoptr(GVariant) data = NULL;
   g_autoptr(PermissionDbEntry) entry = NULL;
   g_autofree char *id = NULL;
   guint32 flags = 0;
@@ -434,12 +433,8 @@ do_create_doc (struct stat *parent_st_buf,
     flags |= DOCUMENT_ENTRY_FLAG_TRANSIENT;
   if (directory)
     flags |= DOCUMENT_ENTRY_FLAG_DIRECTORY;
-  data =
-    g_variant_ref_sink (g_variant_new ("(^ayttu)",
-                                       path,
-                                       (guint64) parent_st_buf->st_dev,
-                                       (guint64) parent_st_buf->st_ino,
-                                       flags));
+
+  entry = document_entry_new (path, flags, parent_st_buf->st_dev, parent_st_buf->st_ino, handle);
 
   if (reuse_existing)
     {
@@ -449,30 +444,33 @@ do_create_doc (struct stat *parent_st_buf,
                     handle,
                     flags,
                     FALSE /* ignore_transient */);
-
-      /* Reuse pre-existing entry with same path */
-      if (id)
-        return g_steal_pointer (&id);
     }
 
-  while (TRUE)
+  if (id)
     {
-      g_autoptr(PermissionDbEntry) existing = NULL;
+      g_debug ("reuse_doc %s", id);
+    }
+  else
+    {
+      while (id == NULL)
+        {
+          g_autoptr(PermissionDbEntry) existing = NULL;
 
-      g_clear_pointer (&id, g_free);
-      id = xdp_name_from_id ((guint32) g_random_int ());
-      existing = permission_db_lookup (db, id);
-      if (existing == NULL)
-        break;
+          id = xdp_name_from_id ((guint32) g_random_int ());
+          existing = permission_db_lookup (db, id);
+          if (existing)
+            g_clear_pointer (&id, g_free);
+        }
+
+      g_debug ("create_doc %s", id);
     }
 
-  g_debug ("create_doc %s", id);
-
-  entry = permission_db_entry_new (data);
   permission_db_set_entry (db, id, entry);
 
   if (persistent)
     {
+      g_autoptr(GVariant) data = permission_db_entry_get_data (entry);
+
       xdg_permission_store_call_set (permission_store,
                                      TABLE_NAME,
                                      TRUE,

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -322,13 +322,108 @@ xdp_file_handle_for_fd (int fd)
   return g_bytes_new (handle->f_handle, handle->handle_bytes);
 }
 
+typedef struct _FindIdData {
+  const char *path;
+  dev_t       st_dev;
+  ino_t       st_ino;
+  GBytes     *handle;
+  uint32_t    flags;
+  gboolean    ignore_transient;
+} FindIdData;
+
+static gboolean
+find_id_matches (PermissionDbEntry *entry,
+                 gpointer           user_data)
+{
+  FindIdData *match = user_data;
+
+  if (g_strcmp0 (document_entry_get_path (entry), match->path) != 0)
+    return FALSE;
+
+  {
+    uint32_t flags = document_entry_get_flags (entry);
+
+    if (match->ignore_transient)
+      flags &= ~DOCUMENT_ENTRY_FLAG_TRANSIENT;
+
+    if (match->flags != flags)
+      return FALSE;
+  }
+
+  if (match->handle)
+    {
+      g_autoptr(GBytes) handle = NULL;
+
+      handle = document_entry_dup_handle (entry);
+      if (!handle || !g_bytes_equal (handle, match->handle))
+        return FALSE;
+    }
+  else
+    {
+      if (match->st_dev != document_entry_get_device (entry) ||
+          match->st_ino != document_entry_get_inode (entry))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
 static char *
-do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_existing, gboolean persistent, gboolean directory)
+find_id (const char *path,
+         dev_t       st_dev,
+         ino_t       st_ino,
+         GBytes     *handle,
+         uint32_t    flags,
+         gboolean    ignore_transient)
+{
+  FindIdData find_data;
+
+  find_data = (FindIdData) {
+    .path = path,
+    .st_dev = st_dev,
+    .st_ino = st_ino,
+    .handle = handle,
+    .flags = flags,
+    .ignore_transient = ignore_transient,
+  };
+
+  {
+    g_auto(GStrv) ids = NULL;
+
+    ids = permission_db_filter_ids (db, find_id_matches, &find_data);
+    if (ids[0] != NULL)
+      return g_strdup (ids[0]);
+  }
+
+  /* We didn't have a handle, so we already checked by dev+ino */
+  if (find_data.handle == NULL)
+    return NULL;
+
+  /* We didn't find a match via handle, so fall back to checking by dev+ino */
+  {
+    g_auto(GStrv) ids = NULL;
+
+    find_data.handle = NULL;
+
+    ids = permission_db_filter_ids (db, find_id_matches, &find_data);
+    if (ids[0] != NULL)
+      return g_strdup (ids[0]);
+  }
+
+  return NULL;
+}
+
+static char *
+do_create_doc (struct stat *parent_st_buf,
+               GBytes      *handle,
+               const char  *path,
+               gboolean     reuse_existing,
+               gboolean     persistent,
+               gboolean     directory)
 {
   g_autoptr(GVariant) data = NULL;
   g_autoptr(PermissionDbEntry) entry = NULL;
-  g_auto(GStrv) ids = NULL;
-  char *id = NULL;
+  g_autofree char *id = NULL;
   guint32 flags = 0;
 
   g_debug ("Creating document at path '%s', reuse_existing: %d, persistent: %d, directory: %d", path, reuse_existing, persistent, directory);
@@ -348,10 +443,16 @@ do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_exis
 
   if (reuse_existing)
     {
-      ids = permission_db_list_ids_by_value (db, data);
+      id = find_id (path,
+                    parent_st_buf->st_dev,
+                    parent_st_buf->st_ino,
+                    handle,
+                    flags,
+                    FALSE /* ignore_transient */);
 
-      if (ids[0] != NULL)
-        return g_strdup (ids[0]);  /* Reuse pre-existing entry with same path */
+      /* Reuse pre-existing entry with same path */
+      if (id)
+        return g_steal_pointer (&id);
     }
 
   while (TRUE)
@@ -381,7 +482,7 @@ do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_exis
                                      NULL, NULL, NULL);
     }
 
-  return id;
+  return g_steal_pointer (&id);
 }
 
 gboolean
@@ -908,7 +1009,7 @@ document_add_full (int                      *fd,
 
         if (g_ptr_array_index(ids,i) == NULL)
           {
-            char *id = do_create_doc (&real_dir_st_bufs[i], path, reuse_existing, persistent, is_dir);
+            char *id = do_create_doc (&real_dir_st_bufs[i], NULL, path, reuse_existing, persistent, is_dir);
             g_ptr_array_index(ids,i) = id;
 
             if (app_id[0] != '\0' && g_strcmp0 (app_id, target_app_id) != 0)
@@ -1067,7 +1168,7 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
       }
     else
       {
-        id = do_create_doc (&parent_st_buf, path, reuse_existing, persistent, FALSE);
+        id = do_create_doc (&parent_st_buf, NULL, path, reuse_existing, persistent, FALSE);
 
         if (app_id[0] != '\0' && g_strcmp0 (app_id, target_app_id) != 0)
           {
@@ -1174,7 +1275,7 @@ portal_add_named (GDBusMethodInvocation *invocation,
 
   XDP_AUTOLOCK (db);
 
-  id = do_create_doc (&parent_st_buf, path, reuse_existing, persistent, FALSE);
+  id = do_create_doc (&parent_st_buf, NULL, path, reuse_existing, persistent, FALSE);
 
   g_dbus_method_invocation_return_value (invocation,
                                          g_variant_new ("(s)", id));
@@ -1268,35 +1369,12 @@ portal_lookup (GDBusMethodInvocation *invocation,
     }
   else
     {
-      g_autoptr(GVariant) data = NULL;
-      g_autoptr(GVariant) data_transient = NULL;
-      g_auto(GStrv) ids = NULL;
-      guint32 flags = 0;
-
-      if (is_dir)
-        flags |= DOCUMENT_ENTRY_FLAG_DIRECTORY;
-
-      data = g_variant_ref_sink (g_variant_new ("(^ayttu)",
-                                                path,
-                                                (guint64)real_dir_st_buf.st_dev,
-                                                (guint64)real_dir_st_buf.st_ino,
-                                                flags));
-      ids = permission_db_list_ids_by_value (db, data);
-      if (ids[0] != NULL)
-        id = g_strdup (ids[0]);
-
-      if (id == NULL)
-        {
-          g_auto(GStrv) transient_ids = NULL;
-          data_transient = g_variant_ref_sink (g_variant_new ("(^ayttu)",
-                                                              path,
-                                                              (guint64)real_dir_st_buf.st_dev,
-                                                              (guint64)real_dir_st_buf.st_ino,
-                                                              flags|DOCUMENT_ENTRY_FLAG_TRANSIENT));
-          transient_ids = permission_db_list_ids_by_value (db, data_transient);
-          if (transient_ids[0] != NULL)
-            id = g_strdup (transient_ids[0]);
-        }
+      id = find_id (path,
+                    real_dir_st_buf.st_dev,
+                    real_dir_st_buf.st_ino,
+                    NULL,
+                    is_dir ? DOCUMENT_ENTRY_FLAG_DIRECTORY : 0,
+                    TRUE /* ignore_transient */);
     }
 
   g_dbus_method_invocation_return_value (invocation,

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1695,6 +1695,7 @@ main (int    argc,
   g_autofree char *path = NULL;
   g_autoptr(GDBusConnection) session_bus = NULL;
   g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(PermissionDb) owned_db = NULL;
   GDBusMethodInvocation *invocation;
 
   if (g_getenv ("XDG_DOCUMENT_PORTAL_WAIT_FOR_DEBUGGER") != NULL)
@@ -1743,7 +1744,7 @@ main (int    argc,
   loop = g_main_loop_new (NULL, FALSE);
 
   path = g_build_filename (g_get_user_data_dir (), "flatpak/db", TABLE_NAME, NULL);
-  db = permission_db_new (path, FALSE, &error);
+  db = owned_db = permission_db_new (path, FALSE, &error);
   if (db == NULL)
     {
       g_printerr ("Failed to load db from '%s': %s", path, error->message);

--- a/document-portal/document-portal.h
+++ b/document-portal/document-portal.h
@@ -40,6 +40,7 @@ gboolean validate_fd (int           fd,
                       ValidateFdType ensure_type,
                       struct stat  *st_buf,
                       struct stat  *real_parent_st_buf,
+                      GBytes      **real_dir_handle_out,
                       char        **path_out,
                       gboolean     *writable_out,
                       GError      **error);

--- a/document-portal/document-store.c
+++ b/document-portal/document-store.c
@@ -179,3 +179,27 @@ document_entry_dup_handle (PermissionDbEntry *entry)
 
   return g_steal_pointer (&handle);
 }
+
+PermissionDbEntry *
+document_entry_new (const char *path,
+                    guint32     flags,
+                    dev_t       st_dev,
+                    ino_t       st_ino,
+                    GBytes     *handle)
+{
+  g_autoptr(GVariant) data = NULL;
+  g_autoptr(GBytes) h = NULL;
+
+  h = handle ? g_bytes_ref (handle) : g_bytes_new (NULL, 0);
+
+  data = g_variant_ref_sink (g_variant_new ("(^ayttu@ay)",
+                                            path,
+                                            (uint64_t) st_dev,
+                                            (uint64_t) st_ino,
+                                            flags,
+                                            g_variant_new_from_bytes (G_VARIANT_TYPE ("ay"),
+                                                                      h,
+                                                                      TRUE)));
+
+  return permission_db_entry_new (data);
+}

--- a/document-portal/document-store.c
+++ b/document-portal/document-store.c
@@ -157,3 +157,25 @@ document_entry_get_flags (PermissionDbEntry *entry)
   g_autoptr(GVariant) c = g_variant_get_child_value (v, 3);
   return g_variant_get_uint32 (c);
 }
+
+GBytes *
+document_entry_dup_handle (PermissionDbEntry *entry)
+{
+  g_autoptr(GVariant) v = permission_db_entry_get_data (entry);
+  g_autoptr(GVariant) handle_variant = NULL;
+  g_autoptr(GBytes) handle = NULL;
+
+  /* Old format without handle field */
+  if (g_variant_n_children (v) < 5)
+    return NULL;
+
+  handle_variant = g_variant_get_child_value (v, 4);
+  handle = g_variant_get_data_as_bytes (handle_variant);
+
+  /* We treat 0-sized handles as no handle. The variant needs to be serializable
+   * into a dbus message, so we don't use an optional here. */
+  if (g_bytes_get_size (handle) == 0)
+    return NULL;
+
+  return g_steal_pointer (&handle);
+}

--- a/document-portal/document-store.h
+++ b/document-portal/document-store.h
@@ -33,6 +33,7 @@ char *             document_entry_dup_dirname (PermissionDbEntry *entry);
 guint64            document_entry_get_device (PermissionDbEntry *entry);
 guint64            document_entry_get_inode (PermissionDbEntry *entry);
 guint32            document_entry_get_flags (PermissionDbEntry *entry);
+GBytes *           document_entry_dup_handle (PermissionDbEntry *entry);
 
 char *  xdp_name_from_id (guint32 doc_id);
 

--- a/document-portal/document-store.h
+++ b/document-portal/document-store.h
@@ -35,6 +35,12 @@ guint64            document_entry_get_inode (PermissionDbEntry *entry);
 guint32            document_entry_get_flags (PermissionDbEntry *entry);
 GBytes *           document_entry_dup_handle (PermissionDbEntry *entry);
 
+PermissionDbEntry *document_entry_new (const char *path,
+                                       guint32     flags,
+                                       dev_t       st_dev,
+                                       ino_t       st_ino,
+                                       GBytes     *handle);
+
 char *  xdp_name_from_id (guint32 doc_id);
 
 

--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -444,7 +444,7 @@ add_files (GDBusMethodInvocation *invocation,
           return;
         }
 
-      if (!validate_fd (fd, app_info, VALIDATE_FD_FILE_TYPE_ANY, &st_buf, &parent_st_buf, &path, &fd_is_writable, NULL) ||
+      if (!validate_fd (fd, app_info, VALIDATE_FD_FILE_TYPE_ANY, &st_buf, &parent_st_buf, NULL, &path, &fd_is_writable, NULL) ||
           (transfer->writable && !fd_is_writable))
         {
           g_dbus_method_invocation_return_error (invocation,

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -506,25 +506,6 @@ permission_db_lookup (PermissionDb  *self,
   return (PermissionDbEntry *) res;
 }
 
-static gboolean
-permission_entry_equal (PermissionDbEntry *entry,
-                        gpointer           user_data)
-{
-  g_autoptr(GVariant) entry_data = NULL;
-  GVariant *data = user_data;
-
-  entry_data = permission_db_entry_get_data (entry);
-  return g_variant_equal (entry_data, data);
-}
-
-/* Transfer: full */
-char **
-permission_db_list_ids_by_value (PermissionDb *self,
-                                 GVariant     *data)
-{
-  return permission_db_filter_ids (self, permission_entry_equal, data);
-}
-
 /* Transfer: full */
 char **
 permission_db_filter_ids (PermissionDb           *self,

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -506,42 +506,54 @@ permission_db_lookup (PermissionDb  *self,
   return (PermissionDbEntry *) res;
 }
 
+static gboolean
+permission_entry_equal (PermissionDbEntry *entry,
+                        gpointer           user_data)
+{
+  g_autoptr(GVariant) entry_data = NULL;
+  GVariant *data = user_data;
+
+  entry_data = permission_db_entry_get_data (entry);
+  return g_variant_equal (entry_data, data);
+}
+
 /* Transfer: full */
 char **
 permission_db_list_ids_by_value (PermissionDb *self,
-                                 GVariant  *data)
+                                 GVariant     *data)
 {
-  g_autofree char **ids = permission_db_list_ids (self);
-  int i;
-  g_autoptr(GPtrArray) res = NULL;
+  return permission_db_filter_ids (self, permission_entry_equal, data);
+}
+
+/* Transfer: full */
+char **
+permission_db_filter_ids (PermissionDb           *self,
+                          PermissionDbLookupFunc  func,
+                          gpointer                user_data)
+{
+  g_autofree char **ids = NULL;
+  g_autoptr(GStrvBuilder) builder = NULL;
 
   g_return_val_if_fail (PERMISSION_IS_DB (self), NULL);
-  g_return_val_if_fail (data != NULL, NULL);
+  g_return_val_if_fail (func != NULL, NULL);
 
-  res = g_ptr_array_new ();
+  ids = permission_db_list_ids (self);
+  builder = g_strv_builder_new ();
 
-  for (i = 0; ids[i] != NULL; i++)
+  for (size_t i = 0; ids[i] != NULL; i++)
     {
-      char *id = ids[i];
-
+      g_autofree char *id = ids[i];
       g_autoptr(PermissionDbEntry) entry = NULL;
-      g_autoptr(GVariant) entry_data = NULL;
 
       entry = permission_db_lookup (self, id);
-      if (entry)
-        {
-          entry_data = permission_db_entry_get_data (entry);
-          if (g_variant_equal (data, entry_data))
-            {
-              g_ptr_array_add (res, id);
-              id = NULL; /* Don't free, as we return this */
-            }
-        }
-      g_free (id);
+      if (!entry)
+        continue;
+
+      if (func (entry, user_data))
+        g_strv_builder_take (builder, g_steal_pointer (&id));
     }
 
-  g_ptr_array_add (res, NULL);
-  return (char **) g_ptr_array_steal (res, NULL);
+  return g_strv_builder_end (builder);
 }
 
 static void

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -325,20 +325,18 @@ initable_iface_init (GInitableIface *initable_iface)
 char **
 permission_db_list_ids (PermissionDb *self)
 {
-  g_autoptr(GPtrArray) res = NULL;
+  g_autoptr(GStrvBuilder) builder = g_strv_builder_new ();
   GHashTableIter iter;
   gpointer key, value;
   int i;
 
   g_return_val_if_fail (PERMISSION_IS_DB (self), NULL);
 
-  res = g_ptr_array_new ();
-
   g_hash_table_iter_init (&iter, self->main_updates);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
       if (value != NULL)
-        g_ptr_array_add (res, g_strdup (key));
+        g_strv_builder_add (builder, key);
     }
 
   if (self->main_table)
@@ -348,17 +346,14 @@ permission_db_list_ids (PermissionDb *self)
 
       for (i = 0; main_ids[i] != NULL; i++)
         {
-          char *id = main_ids[i];
+          g_autofree char *id = main_ids[i];
 
-          if (g_hash_table_lookup_extended (self->main_updates, id, NULL, NULL))
-            g_free (id);
-          else
-            g_ptr_array_add (res, id);
+          if (!g_hash_table_lookup_extended (self->main_updates, id, NULL, NULL))
+            g_strv_builder_take (builder, g_steal_pointer (&id));
         }
     }
 
-  g_ptr_array_add (res, NULL);
-  return (char **) g_ptr_array_steal (res, NULL);
+  return g_strv_builder_end (builder);
 }
 
 static gboolean

--- a/document-portal/permission-db.h
+++ b/document-portal/permission-db.h
@@ -51,8 +51,6 @@ char **        permission_db_list_ids (PermissionDb *self);
 char **        permission_db_list_apps (PermissionDb *self);
 char **        permission_db_list_ids_by_app (PermissionDb  *self,
                                               const char *app);
-char **        permission_db_list_ids_by_value (PermissionDb *self,
-                                                GVariant  *data);
 char **        permission_db_filter_ids (PermissionDb           *self,
                                          PermissionDbLookupFunc  func,
                                          gpointer                user_data);

--- a/document-portal/permission-db.h
+++ b/document-portal/permission-db.h
@@ -41,6 +41,9 @@ typedef struct _PermissionDbEntry PermissionDbEntry;
  * goblint-ignore-next-line: missing_implementation */
 GType permission_db_get_type (void);
 
+typedef gboolean (*PermissionDbLookupFunc) (PermissionDbEntry *entry,
+                                            gpointer           user_data);
+
 PermissionDb *     permission_db_new (const char *path,
                                       gboolean    fail_if_not_found,
                                       GError    **error);
@@ -50,6 +53,9 @@ char **        permission_db_list_ids_by_app (PermissionDb  *self,
                                               const char *app);
 char **        permission_db_list_ids_by_value (PermissionDb *self,
                                                 GVariant  *data);
+char **        permission_db_filter_ids (PermissionDb           *self,
+                                         PermissionDbLookupFunc  func,
+                                         gpointer                user_data);
 PermissionDbEntry *permission_db_lookup (PermissionDb  *self,
                                    const char *id);
 GString *      permission_db_print_string (PermissionDb *self,

--- a/subprojects/libglnx.wrap
+++ b/subprojects/libglnx.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.gnome.org/GNOME/libglnx.git
-revision = ccea836b799256420788c463a638ded0636b1632
+revision = ff64d52116ae74f0d25e24f089db28921ea171ff
 depth = 1
 
 [provide]


### PR DESCRIPTION
The dev is specifically not stable across reboots, which can result in granted documents not being accessible anymore.

This adds another field to the document permission table to store the file handle returned by name_to_handle_at with AT_HANDLE_FID. The code transparently handles the old format, updates existing entries with the handle and prefers the handle over the dev+ino for lookup.

I did a bit of testing already, but it definitely could use more.