### PR TITLE
permission-db: Use g_file_load_bytes

### DIFF
--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -274,13 +274,10 @@ initable_init (GInitable    *initable,
   if (is_on_nfs (self->path))
     {
       g_autoptr(GFile) file = g_file_new_for_path (self->path);
-      char *contents;
-      gsize length;
 
       /* We avoid using mmap on NFS, because its prone to give us SIGBUS at semi-random
          times (nfs down, file removed, etc). Instead we just load the file */
-      if (g_file_load_contents (file, cancellable, &contents, &length, NULL, &my_error))
-        self->gvdb_contents = g_bytes_new_take (contents, length);
+      self->gvdb_contents = g_file_load_bytes (file, cancellable, NULL, &my_error);
     }
   else
     {


### PR DESCRIPTION
..instead of load_contents. As per the docs of the later,

If file is a resource:// based URI, the resulting bytes will reference the embedded resource instead of a copy. Otherwise, this is equivalent to calling g_file_load_contents() and g_bytes_new_take().