### PR TITLE
RFC: Improve interfaces versioning

### DIFF
--- a/data/org.freedesktop.background.Monitor.xml
+++ b/data/org.freedesktop.background.Monitor.xml
@@ -28,7 +28,7 @@
     This interface provides APIs related to applications
     that are running in the background.
 
-    This documentation describes version 1 of this interface.
+    This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.background.Monitor">
 
@@ -54,6 +54,19 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;QVariantMap&gt;"/>
     </property>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.host.portal.Registry.xml
+++ b/data/org.freedesktop.host.portal.Registry.xml
@@ -32,7 +32,7 @@
       This interface will not work with applications xdg-desktop-portal
       identifies as sandboxed.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.host.portal.Registry">
     <!--
@@ -61,6 +61,20 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Access.xml
+++ b/data/org.freedesktop.impl.portal.Access.xml
@@ -28,6 +28,8 @@
       This backend can be used by portal implementations that
       need to ask a direct access question, such as "May xyz
       use the microphone?"
+
+      This documentation describes revision 1 of this interface.
    -->
   <interface name="org.freedesktop.impl.portal.Access">
     <!--
@@ -87,5 +89,16 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Account.xml
+++ b/data/org.freedesktop.impl.portal.Account.xml
@@ -29,6 +29,8 @@
       information about the user, like their name and avatar photo.
       The portal backend will present the user with a dialog to confirm
       which (if any) information to share.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Account">
     <!--
@@ -75,5 +77,16 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.AppChooser.xml
+++ b/data/org.freedesktop.impl.portal.AppChooser.xml
@@ -27,7 +27,7 @@
       This backend can be used by portal implementations that
       need to choose an application from a list of applications.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.AppChooser">
     <!--
@@ -70,7 +70,7 @@
 
           A token that can be used to activate the application chooser.
 
-          The activation_token option was introduced in version 2 of the interface.
+          The activation_token option was introduced in revision 2 of the interface.
 
         The following results get returned via the @results vardict:
 
@@ -86,7 +86,7 @@
           Otherwise, this token may be the same as the one passed in
           @options.
 
-          The activation_token option was introduced in version 2 of the interface.
+          The activation_token option was introduced in revision 2 of the interface.
     -->
     <method name="ChooseApplication">
       <arg type="o" name="handle" direction="in"/>
@@ -113,5 +113,16 @@
       <arg type="o" name="handle" direction="in"/>
       <arg type="as" name="choices" direction="in"/>
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 2 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Background.xml
+++ b/data/org.freedesktop.impl.portal.Background.xml
@@ -27,6 +27,8 @@
 
     This interface provides APIs related to applications
     that are running in the background.
+
+    This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Background">
 
@@ -110,5 +112,16 @@
     -->
     <signal name="RunningApplicationsChanged">
     </signal>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Clipboard.xml
+++ b/data/org.freedesktop.impl.portal.Clipboard.xml
@@ -25,6 +25,8 @@
       @short_description: Clipboard portal backend interface
 
       The Clipboard portal allows sessions to access the clipboard.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Clipboard">
     <!-- 
@@ -177,6 +179,19 @@
       <arg type="u" name="serial" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.impl.portal.DynamicLauncher.xml
@@ -25,7 +25,7 @@
       org.freedesktop.impl.portal.DynamicLauncher:
       @short_description: Dynamic launcher portal backend interface
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.DynamicLauncher">
     <!--
@@ -126,6 +126,20 @@
         - ``2``: Webapp. A launcher that represents a web app.
     -->
     <property name="SupportedLauncherTypes" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Email.xml
+++ b/data/org.freedesktop.impl.portal.Email.xml
@@ -26,6 +26,8 @@
       @short_description: Email portal backend interface
 
       This Email portal lets sandboxed applications request sending an email.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Email">
     <!--
@@ -83,5 +85,16 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.FileChooser.xml
+++ b/data/org.freedesktop.impl.portal.FileChooser.xml
@@ -31,6 +31,8 @@
       Backends must normalize URIs of locations selected by the
       user into "file://" URIs. URIs that cannot be normalized
       should be discarded.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.FileChooser">
     <!--
@@ -261,5 +263,16 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.impl.portal.GlobalShortcuts.xml
@@ -28,7 +28,7 @@
       This portal lets applications register global shortcuts so they can
       act regardless of the system state upon an input event.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.GlobalShortcuts">
     <!--
@@ -126,7 +126,7 @@
 
           A token that can be used to activate the configuration window.
 
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="ConfigureShortcuts">
       <arg type="o" name="session_handle" direction="in"/>
@@ -199,6 +199,20 @@
       <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and does not cause a revision bump
+        of this interface.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.impl.portal.GlobalShortcuts:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Inhibit.xml
+++ b/data/org.freedesktop.impl.portal.Inhibit.xml
@@ -27,6 +27,8 @@
 
       The inhibit portal lets sandboxed applications inhibit the user
       session from ending, suspending, idling or getting switched away.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Inhibit">
     <!--
@@ -129,5 +131,15 @@
       <arg type="o" name="session_handle" direction="in"/>
     </method>
 
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.InputCapture.xml
+++ b/data/org.freedesktop.impl.portal.InputCapture.xml
@@ -28,7 +28,7 @@
       :ref:`org.freedesktop.portal.InputCapture` portal, see that portal's
       documentation for details on methods, signals and arguments.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.InputCapture">
     <!--
@@ -41,9 +41,9 @@
         @response: Numeric response
         @results: Vardict with the results of the call
 
-        This method was deprecated in version 2 of this interface and will not
+        This method was deprecated in revision 2 of this interface and will not
         be called by the frontend if the implementation indicates support for
-        version 2. See CreateSession2 instead.
+        revision 2. See CreateSession2 instead.
 
         Create an input capture session.
 
@@ -91,7 +91,7 @@
 
         There are currently no supported keys in the @results vardict.
 
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="CreateSession2">
       <arg type="o" name="session_handle" direction="in"/>
@@ -139,8 +139,6 @@
           "KDE"), the version of the implementation-specific private data,
           and the implementation-specific private data itself.
 
-          This option was added in version 2 of this interface.
-
         * ``persist_mode`` (``u``)
 
           How this session should persist. Default is 0. Accepted values are:
@@ -152,8 +150,6 @@
           If the permission for the session to persist is granted, ``restore_data``
           will be returned in the @results vardict of the
           :ref:`org.freedesktop.impl.portal.InputCapture.Start` method.
-
-          This option was added in version 2 of this interface.
 
         The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
@@ -183,9 +179,7 @@
           is restored in the future, this data is used as the ``restore_data``
           argument in the @options vardict.
 
-          This option was added in version 2 of this interface.
-
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="Start">
       <arg type="o" name="handle" direction="in"/>
@@ -517,6 +511,21 @@
         - ``4``: TOUCHSCREEN
     -->
     <property name="SupportedCapabilities" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and does not cause a revision bump
+        of this interface.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.impl.portal.InputCapture:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Lockdown.xml
+++ b/data/org.freedesktop.impl.portal.Lockdown.xml
@@ -30,6 +30,8 @@
     printing or location services.
 
     This is meant to be used by different portal frontends.
+
+    This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Lockdown">
 
@@ -40,5 +42,16 @@
     <property name="disable-camera" type="b" access="readwrite"/>
     <property name="disable-microphone" type="b" access="readwrite"/>
     <property name="disable-sound-output" type="b" access="readwrite"/>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Notification.xml
+++ b/data/org.freedesktop.impl.portal.Notification.xml
@@ -28,7 +28,7 @@
       This notification interface lets sandboxed applications
       send and withdraw notifications.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Notification">
     <!--
@@ -48,7 +48,7 @@
         The format of the @notification is the same as for
         :ref:`org.freedesktop.portal.Notification.AddNotification`.
 
-        Since version 2, the icon property never uses the ``bytes`` option.
+        Since revision 2, the icon property never uses the ``bytes`` option.
     -->
     <method name="AddNotification">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -107,6 +107,20 @@
       <arg type="av" name="parameter"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and does not cause a revision bump
+        of this interface.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.impl.portal.Notification:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.PermissionStore.xml
+++ b/data/org.freedesktop.impl.portal.PermissionStore.xml
@@ -43,10 +43,24 @@
       In addition, the permission store allows to associate extra data
       (in the form of a GVariant) with each resource.
 
-      This document describes version 2 of the permission store interface.
+      This documentation describes revision 2 of the permission store interface.
   -->
   <interface name="org.freedesktop.impl.portal.PermissionStore">
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 5 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.impl.portal.PermissionStore:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
 
     <!--
         Lookup:
@@ -141,7 +155,7 @@
         Removes the entry for an application and a resource
         in the given table.
 
-        This method was added in version 2.
+        This method was added in revision 2.
     -->
     <method name="DeletePermission">
       <arg name="table" type="s" direction="in"/>

--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -25,6 +25,8 @@
       @short_description: Print portal backend interface
 
       The Print portal allows sandboxed applications to print.
+
+      This documentation describes revision 4 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Print">
     <!--
@@ -52,6 +54,8 @@
 
           Label for the accept button. Mnemonic underlines are allowed.
 
+          This option was added in revision 2.
+
         The following results get returned via the @results vardict:
 
         * ``settings`` (``a{sv}``)
@@ -72,13 +76,19 @@
           File formats supported by the app to use for print-to-file. If not set, all formats
           are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
 
+          This option was added in revision 3.
+
         * ``has_current_page`` (``b``)
 
           Whether it makes sense to return "current" for the ``print-pages`` setting.
 
+          This option was added in revision 4.
+
         * ``has_selected_pages`` (``b``)
 
           Whether it makes sense to return "selection" for the ``print-pages`` setting.
+
+          This option was added in revision 4.
 
         The :ref:`org.freedesktop.portal.Print.PreparePrint` documentation has details about
         the supported keys in settings and page-setup.
@@ -135,6 +145,8 @@
 
           File formats supported by the app to use for print-to-file. If not set, all formats
           are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
+
+          This option was added in revision 3.
     -->
     <method name="Print">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -149,5 +161,16 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 4 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 3 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -25,7 +25,7 @@
 
       The Remote desktop portal allows to create remote desktop sessions.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.RemoteDesktop">
     <!--
@@ -90,7 +90,7 @@
           "KDE"), the version of the implementation-specific private data,
           and the implementation-specific private data itself.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         * ``persist_mode`` (``u``)
 
@@ -104,7 +104,7 @@
           will be returned in the results of the
           #org.freedesktop.impl.portal.RemoteDesktop.Start method.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         For available device types, see the AvailableDeviceTypes property.
     -->
@@ -151,7 +151,7 @@
           If the session should persist, ``restore_data`` must be returned in the @results
           vardict.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         The following results get returned in the @results vardict:
 
@@ -165,7 +165,7 @@
           A boolean for whether the clipboard was enabled ('true') or not ('false').
           See the :ref:`org.freedesktop.portal.Clipboard` documentation for more information.
 
-          Since version 2.
+          Since revision 2.
 
         * ``streams`` (``a(ua{sv})``)
 
@@ -178,7 +178,7 @@
           See the #org.freedesktop.impl.portal.RemoteDesktop.SelectDevices method for
           more details.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
     -->
     <method name="Start">
       <arg type="o" name="handle" direction="in"/>
@@ -428,7 +428,7 @@
 
         Request a connection to an EIS implementation.
 
-        This method is available in version 2 of this interface.
+        This method is available in revision 2 of this interface.
     -->
     <method name="ConnectToEIS">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -448,6 +448,21 @@
         - ``4``: TOUCHSCREEN
     -->
     <property name="AvailableDeviceTypes" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and does not cause a revision bump
+        of this interface.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.impl.portal.RemoteDesktop:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Request.xml
+++ b/data/org.freedesktop.impl.portal.Request.xml
@@ -34,6 +34,8 @@
 
       The portal can abort the interaction calling
       org.freedesktop.impl.portal.Request.Close() on the Request object.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Request">
 
@@ -45,5 +47,16 @@
     -->
     <method name="Close">
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -25,7 +25,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 5 of this interface.
+      This documentation describes revision 5 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.ScreenCast">
     <!--
@@ -84,7 +84,7 @@
           mode not advertised will cause the screen cast session to be closed. The default
           cursor mode is 'Hidden'.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         * ``restore_data`` (``(suv)``)
 
@@ -99,7 +99,7 @@
           "KDE"), the version of the implementation-specific private data,
           and the implementation-specific private data itself.
 
-          This option was added in version 4 of this interface.
+          This option was added in revision 4 of this interface.
 
         * ``persist_mode`` (``u``)
 
@@ -113,7 +113,7 @@
           "persist_mode" will be returned in the results of the
           org.freedesktop.impl.portal.ScreenCast.Start() method.
 
-          This option was added in version 4 of this interface.
+          This option was added in revision 4 of this interface.
 
         For available source types, see the AvailableSourceTypes property.
     -->
@@ -174,7 +174,7 @@
             The type of the content which is being screen casted.
             For available source types, see the AvailableSourceTypes property.
 
-            This property was added in version 3 of this interface.
+            This property was added in revision 3 of this interface.
 
           * ``mapping_id`` (``s``)
 
@@ -187,7 +187,7 @@
             regions, but a mapping_id will only match one of these regions per
             device.
 
-            This property was added in version 5 of this interface.
+            This property was added in revision 5 of this interface.
 
         * ``persist_mode`` (``u``)
 
@@ -199,7 +199,7 @@
           If no persist mode is returned by the Start request, it is assumed
           to be the same persist mode received during SelectSources.
 
-          This option was added in version 4 of this interface.
+          This option was added in revision 4 of this interface.
 
         * ``restore_data`` (``(suv)``)
 
@@ -221,7 +221,7 @@
           to another desktop environment, or is using a different portal
           implementation.
 
-          This response option was added in version 4 of this interface.
+          This response option was added in revision 4 of this interface.
     -->
     <method name="Start">
       <arg type="o" name="handle" direction="in"/>
@@ -252,8 +252,25 @@
         - ``1``: Hidden. The cursor is not part of the screen cast stream.
         - ``2``: Embedded: The cursor is embedded as part of the stream buffers.
         - ``4``: Metadata: The cursor is not part of the screen cast stream, but sent as PipeWire stream metadata.
+
+        This property was added in revision 2 of this interface.
     -->
     <property name="AvailableCursorModes" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 5 and does not cause a revision bump
+        of this interface.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.impl.portal.ScreenCast:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Screenshot.xml
+++ b/data/org.freedesktop.impl.portal.Screenshot.xml
@@ -27,7 +27,7 @@
 
       This screenshot portal lets sandboxed applications request a screenshot.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Screenshot">
     <!--
@@ -57,7 +57,7 @@
           Hint whether the screenshot portal has checked the 'screenshot' permission for
           the requesting app. Defaults to no.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         The following results get returned via the @results vardict:
 
@@ -104,6 +104,19 @@
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 2 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Secret.xml
+++ b/data/org.freedesktop.impl.portal.Secret.xml
@@ -27,6 +27,8 @@
 
       The Secret portal allows sandboxed applications to retrieve a
       per-application master secret.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Secret">
 
@@ -59,6 +61,20 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Session.xml
+++ b/data/org.freedesktop.impl.portal.Session.xml
@@ -32,6 +32,8 @@
 
       The portal can abort the interaction by calling
       org.freedesktop.impl.portal.Session.Close() on the Session object.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Session">
 
@@ -50,6 +52,20 @@
     -->
     <signal name="Closed">
     </signal>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Settings.xml
+++ b/data/org.freedesktop.impl.portal.Settings.xml
@@ -74,6 +74,8 @@
 
     Note that the Settings portal can operate without this backend,
     implementing it is optional.
+
+    This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Settings">
 
@@ -119,6 +121,19 @@
       <arg type="v" name="value" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Usb.xml
+++ b/data/org.freedesktop.impl.portal.Usb.xml
@@ -29,7 +29,7 @@
       The implementation side allows requesting permission from the user
       to access USB devices with a GUI.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Usb">
 
@@ -80,6 +80,19 @@
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Wallpaper.xml
+++ b/data/org.freedesktop.impl.portal.Wallpaper.xml
@@ -27,6 +27,8 @@
 
       This simple interface lets sandboxed applications set the user's
       desktop background picture.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Wallpaper">
     <!--
@@ -61,5 +63,16 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="u" name="response" direction="out"/>
     </method>
+
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and does not cause a revision bump
+        of this interface.
+
+        Consequently, 1 is assumed if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Account.xml
+++ b/data/org.freedesktop.portal.Account.xml
@@ -28,7 +28,7 @@
       This simple interface lets sandboxed applications query basic
       information about the user, like their name and avatar photo.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Account">
     <!--
@@ -75,6 +75,20 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Background.xml
+++ b/data/org.freedesktop.portal.Background.xml
@@ -29,7 +29,7 @@
       the application is allowed to run in the background or started
       automatically when the user logs in.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Background">
     <!--
@@ -88,7 +88,7 @@
       SetStatus:
       @options: Vardict with optional further information
 
-      This method was added in version 2 of this interface.
+      This method was added in revision 2 of this interface.
 
       Sets the status of the application running in background.
 
@@ -106,6 +106,20 @@
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.Background:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Camera.xml
+++ b/data/org.freedesktop.portal.Camera.xml
@@ -25,6 +25,8 @@
 
       The camera portal enables applications to access camera devices, such as
       web cams.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Camera">
     <!--
@@ -77,6 +79,20 @@
         A boolean stating whether there is any cameras available.
     -->
     <property name="IsCameraPresent" type="b" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Clipboard.xml
+++ b/data/org.freedesktop.portal.Clipboard.xml
@@ -26,7 +26,7 @@
 
       The Clipboard portal allows sessions to access the clipboard.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Clipboard">
     <!-- 
@@ -179,6 +179,19 @@
       <arg type="u" name="serial" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -50,10 +50,24 @@
       bus name org.freedesktop.portal.Documents and the object path
       /org/freedesktop/portal/documents.
 
-      This documentation describes version 5 of this interface.
+      This documentation describes revision 5 of this interface.
   -->
   <interface name="org.freedesktop.portal.Documents">
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 5 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.portal.Documents:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
 
     <!--
         GetMountPoint:
@@ -130,9 +144,9 @@
         multiple roundtrips. For now it only contains as "mountpoint", the
         fuse mountpoint of the document portal.
 
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
 
-        Support for exporting directories was added in version 4 of this interface.
+        Support for exporting directories was added in revision 4 of this interface.
     -->
     <method name="AddFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -170,7 +184,7 @@
         multiple roundtrips. For now it only contains as "mountpoint", the
         fuse mountpoint of the document portal.
 
-        This method was added in version 3 of this interface.
+        This method was added in revision 3 of this interface.
     -->
     <method name="AddNamedFull">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -293,7 +307,7 @@
 
         This call is available inside the sandbox, if the application has the ``read`` permission for the documents.
 
-        This method was added in version 5 of this interface.
+        This method was added in revision 5 of this interface.
     -->
     <method name="GetHostPaths">
       <arg type="as" name="doc_ids" direction="in"/>

--- a/data/org.freedesktop.portal.DynamicLauncher.xml
+++ b/data/org.freedesktop.portal.DynamicLauncher.xml
@@ -46,7 +46,7 @@
       can be accomplished by using the org.freedesktop.portal.DynamicLauncher.RequestInstallToken()
       method and passing the acquired token to org.freedesktop.portal.DynamicLauncher.Install().
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.DynamicLauncher">
     <!--
@@ -313,6 +313,20 @@
         - 2: Webapp. A launcher that represents a web app.
     -->
     <property name="SupportedLauncherTypes" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Email.xml
+++ b/data/org.freedesktop.portal.Email.xml
@@ -28,7 +28,7 @@
       This simple portal lets sandboxed applications request to send an email,
       optionally providing an address, subject, body and attachments.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes revision 4 of this interface.
   -->
   <interface name="org.freedesktop.portal.Email">
     <!--
@@ -75,19 +75,19 @@
           Email addresses to send to. This will be used in addition to address and must
           pass the same validation.
 
-          This option was introduced in version 3 of the interface.
+          This option was introduced in revision 3 of the interface.
 
         * ``cc`` (``as``)
 
           Email addresses to cc.
 
-          This option was introduced in version 3 of the interface.
+          This option was introduced in revision 3 of the interface.
 
         * ``bcc`` (``as``)
 
           Email addresses to bcc.
 
-          This option was introduced in version 3 of the interface.
+          This option was introduced in revision 3 of the interface.
 
         * ``subject`` (``s``)
 
@@ -105,7 +105,7 @@
 
           A token that can be used to activate the chosen application.
 
-          This option was introduced in version 4 of the interface.
+          This option was introduced in revision 4 of the interface.
 
 
         All the keys in the @options vardict are optional.
@@ -117,6 +117,21 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 4 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.Email:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.FileChooser.xml
+++ b/data/org.freedesktop.portal.FileChooser.xml
@@ -37,7 +37,7 @@
       portal<org.freedesktop.portal.Documents>` by this portal stay
       accessible across sessions.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes revision 4 of this interface.
   -->
   <interface name="org.freedesktop.portal.FileChooser">
     <!--
@@ -73,7 +73,7 @@
 
         Whether to select for folders instead of files. Default is to select files.
 
-        This option was added in version 3.
+        This option was added in revision 3.
 
       * ``filters`` (``a(sa(us))``)
 
@@ -330,6 +330,21 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 4 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.FileChooser:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.FileTransfer.xml
+++ b/data/org.freedesktop.portal.FileTransfer.xml
@@ -49,7 +49,7 @@
        bus name org.freedesktop.portal.Documents and the object path
        ``/org/freedesktop/portal/documents``.
 
-       This documentation describes version 1 of this interface.
+       This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.FileTransfer">
     <!--
@@ -161,6 +161,19 @@
       <arg type="s" name="key"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.GameMode.xml
+++ b/data/org.freedesktop.portal.GameMode.xml
@@ -47,7 +47,7 @@
       automatically un-register the client. This might happen with a (small)
       delay.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes revision 4 of this interface.
     -->
     <interface name="org.freedesktop.portal.GameMode">
       <!--
@@ -131,6 +131,8 @@
 
           Like org.freedesktop.portal.GameMode.QueryStatus() but @requester
           acting on behalf of @target.
+
+          This property was added in revision 2 of this interface.
       -->
       <method name="QueryStatusByPid">
         <arg type="i" name="target" direction="in"/>
@@ -148,6 +150,8 @@
 
           Like org.freedesktop.portal.GameMode.RegisterGame() but @requester
           acting on behalf of @target.
+
+          This property was added in revision 2 of this interface.
       -->
       <method name="RegisterGameByPid">
         <arg type="i" name="target" direction="in"/>
@@ -165,6 +169,8 @@
 
           Like org.freedesktop.portal.GameMode.UnregisterGame() but @requester
           acting on behalf of @target.
+
+          This property was added in revision 2 of this interface.
       -->
       <method name="UnregisterGameByPid">
         <arg type="i" name="target" direction="in"/>
@@ -183,6 +189,8 @@
 
           Like org.freedesktop.portal.GameMode.QueryStatusByPid() but @requester
           and @target are pidfds representing the processes.
+
+          This property was added in revision 3 of this interface.
       -->
       <method name="QueryStatusByPIDFd">
         <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -201,6 +209,8 @@
 
           Like org.freedesktop.portal.GameMode.RegisterGameByPid() but @requester
           and @target are pidfds representing the processes.
+
+          This property was added in revision 3 of this interface.
       -->
       <method name="RegisterGameByPIDFd">
         <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -219,6 +229,8 @@
 
           Like org.freedesktop.portal.GameMode.UnregisterGameByPid() but @requester
           and @target are pidfds representing the processes.
+
+          This property was added in revision 3 of this interface.
       -->
       <method name="UnregisterGameByPIDFd">
         <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -231,9 +243,25 @@
           Active:
 
           Whether any pid on the system has enabled Game Mode.
+
+          This property was added in revision 4 of this interface.
       -->
       <property name="Active" type="b" access="read"/>
 
-      <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 4 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.GameMode:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
     </interface>
 </node>

--- a/data/org.freedesktop.portal.GlobalShortcuts.xml
+++ b/data/org.freedesktop.portal.GlobalShortcuts.xml
@@ -41,7 +41,7 @@
       #org.freedesktop.portal.GlobalShortcuts::Deactivated signals are emitted,
       respectively, whenever a shortcut is activated and deactivated.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.GlobalShortcuts">
     <!--
@@ -200,7 +200,7 @@
 
           A token that can be used to activate the configuration window.
 
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="ConfigureShortcuts">
       <arg type="o" name="session_handle" direction="in"/>
@@ -274,6 +274,20 @@
       <arg type="a(sa{sv})" name="shortcuts" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.GlobalShortcuts:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Inhibit.xml
+++ b/data/org.freedesktop.portal.Inhibit.xml
@@ -28,7 +28,7 @@
       This simple interface lets sandboxed applications inhibit the user
       session from ending, suspending, idling or getting switched away.
 
-      This documentation describes version 3 of this interface.
+      This documentation describes revision 3 of this interface.
   -->
   <interface name="org.freedesktop.portal.Inhibit">
     <!--
@@ -110,7 +110,7 @@
             The ``session_handle`` is an object path that was erroneously implemented
             as ``s``. For backwards compatibility it will remain this type.
 
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="CreateMonitor">
       <arg type="s" name="window" direction="in"/>
@@ -141,7 +141,7 @@
 
         * ``session-state`` (``u``)
 
-          The state of the session. This member is new in version 3.
+          The state of the session. This member is new in revision 3.
 
           - ``1``: Running
           - ``2``: Query End
@@ -162,12 +162,26 @@
       signal. This method should be called within one second or receiving a StateChanged
       signal with the 'Query End' state.
 
-      Since version 3.
+      Since revision 3.
     -->
     <method name="QueryEndResponse">
       <arg type="o" name="session_handle" direction="in"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 3 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.Inhibit:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.InputCapture.xml
+++ b/data/org.freedesktop.portal.InputCapture.xml
@@ -53,7 +53,7 @@
       captured. The transport of actual input events is delegated to a
       transport layer, specifically libei. See org.freedesktop.portal.InputCapture.ConnectToEIS().
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
    -->
   <interface name="org.freedesktop.portal.InputCapture">
     <!--
@@ -62,7 +62,7 @@
         @options: Vardict with optional further information
         @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
 
-        This method was deprecated in version 2 of this interface, see
+        This method was deprecated in revision 2 of this interface, see
         CreateSession2 instead.
 
         Create an input capture session. A successfully created session can at
@@ -155,7 +155,7 @@
           :ref:`org.freedesktop.portal.Session` object representing the created
           session. Required.
 
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="CreateSession2">
       <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
@@ -204,8 +204,6 @@
           the same session again, use the new restore token sent in response
           to starting this session.
 
-          This option was added in version 2 of this interface.
-
         * ``persist_mode`` (``u``)
 
           How this session should persist. Default is 0. Accepted values are:
@@ -217,8 +215,6 @@
           If the permission for the session to persist is granted, a restore token will
           be returned via the :ref:`org.freedesktop.portal.Request::Response` signal of the
           start method used to start the session.
-
-          This option was added in version 2 of this interface.
 
         The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
 
@@ -247,9 +243,7 @@
           be used to restore a session. See
           :ref:`org.freedesktop.portal.RemoteDesktop.SelectDevices` for details.
 
-          This response option was added in version 2 of this interface.
-
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="Start">
       <arg type="o" name="session_handle" direction="in"/>
@@ -672,6 +666,21 @@
         - ``4``: TOUCHSCREEN
     -->
     <property name="SupportedCapabilities" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.InputCapture:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Location.xml
+++ b/data/org.freedesktop.portal.Location.xml
@@ -28,7 +28,7 @@
       This simple interface lets sandboxed applications query basic
       information about the location.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Location">
     <!--
@@ -144,6 +144,19 @@
       <arg type="a{sv}" name="location" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.MemoryMonitor.xml
+++ b/data/org.freedesktop.portal.MemoryMonitor.xml
@@ -31,7 +31,7 @@
       expected to use this interface indirectly, via a library API
       such as the GLib GMemoryMonitor interface.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.MemoryMonitor">
     <!--
@@ -47,6 +47,19 @@
       <arg name="level" type="y"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.NetworkMonitor.xml
+++ b/data/org.freedesktop.portal.NetworkMonitor.xml
@@ -30,7 +30,7 @@
       expected to use this interface indirectly, via a library API
       such as the GLib GNetworkMonitor interface.
 
-      This documentation describes version 3 of this interface.
+      This documentation describes revision 3 of this interface.
   -->
   <interface name="org.freedesktop.portal.NetworkMonitor">
     <!--
@@ -47,7 +47,7 @@
         That is, whether the system as a default route for
         at least one of IPv4 or IPv6.
 
-        This method was added in version 2 to replace
+        This method was added in revision 2 to replace
         the available property.
     -->
     <method name="GetAvailable">
@@ -62,7 +62,7 @@
         the default connection that is subject ot limitations
         by service providers.
 
-        This method was added in version 2 to replace
+        This method was added in revision 2 to replace
         the metered property.
     -->
     <method name="GetMetered">
@@ -80,7 +80,7 @@
         - ``3``: Captive portal. The host is behind a captive portal and cannot reach the full internet.
         - ``4``: Full network. The host connected to a network, and can reach the full internet.
 
-        This method was added in version 2 to replace
+        This method was added in revision 2 to replace
         the connectivity property.
     -->
     <method name="GetConnectivity">
@@ -106,7 +106,7 @@
 
           The level of connectivity.
 
-        This method was added in version 3 to avoid multiple round-trips.
+        This method was added in revision 3 to avoid multiple round-trips.
     -->
     <method name="GetStatus">
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
@@ -120,7 +120,7 @@
         @reachable: Whether the hostname:port was reachable
 
         Returns whether the given hostname is believed to be reachable.
-        This method was added in version 3.
+        This method was added in revision 3.
     -->
     <method name="CanReach">
       <arg type="s" name="hostname" direction="in"/>
@@ -128,6 +128,19 @@
       <arg type="b" name="reachable" direction="out"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 3 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 2 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Notification.xml
+++ b/data/org.freedesktop.portal.Notification.xml
@@ -49,7 +49,7 @@
       #org.freedesktop.portal.Notification::ActionInvoked signal
       to the application.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Notification">
     <!--
@@ -94,7 +94,7 @@
           This can be a long string but if it doesn't fit the UI it may
           be wrapped or/and truncated.
 
-          Since: version 2
+          Since: revision 2
 
         * ``icon`` (``v``)
 
@@ -121,7 +121,7 @@
             `GBytesIcon <https://docs.gtk.org/gio/class.BytesIcon.html>`_ at the
             moment, but this interoperability may change in the future.
 
-            Since version 2, this is deprecated and should not be used.
+            Since revision 2, this is deprecated and should not be used.
             Please use the `themed` or `file-descriptor` option to set an icon.
 
           * ``file-descriptor`` (``h``)
@@ -131,7 +131,7 @@
             possible for file descriptors created with ``memfd_create()`` with
             the ``MFD_ALLOW_SEALING`` flag set.
 
-            Since: version 2
+            Since: revision 2
 
           For historical reasons, it is also possible to send a simple string
           for themed icons with a single icon name.
@@ -160,7 +160,7 @@
 
           There may be further restrictions on the supported kinds of sounds.
 
-          Since: version 2
+          Since: revision 2
 
         * ``priority`` (``s``)
 
@@ -230,7 +230,7 @@
               No ``label`` should be given when this purpose is used, so that
               the server can ignore the button if it doesn't understand the purpose.
 
-            Since: version 2
+            Since: revision 2
 
         * ``display-hint`` (``as``)
 
@@ -277,7 +277,7 @@
             If this hint isn't specified the notification's content is updated
             without any flickering.
 
-          Since: version 2
+          Since: revision 2
 
         * ``category`` (``s``)
 
@@ -385,7 +385,7 @@
             Intended to be used by browsers to mark notifications send by websites via
             the `Notifications API <https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API>`_.
 
-          Since: version 2
+          Since: revision 2
       -->
     <method name="AddNotification">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -420,7 +420,7 @@
           Button purposes that the notification server understands and supports.
           This is the list of options that can be used as `purpose` for `buttons`.
 
-        Since: version 2
+        Since: revision 2
     -->
     <property name="SupportedOptions" type="a{sv}" access="read">
       <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>
@@ -443,17 +443,32 @@
            `XDG Activation
            <https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/xdg-activation/xdg-activation-v1.xml>`_
 
-           Since: version 2
+           Since: revision 2
 
         #. The user `response` for an action based on the purpose if applicable.
 
-           Since: version 2
+           Since: revision 2
     -->
     <signal name="ActionInvoked">
       <arg type="s" name="id"/>
       <arg type="s" name="action"/>
       <arg type="av" name="parameter"/>
     </signal>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.Notification:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.OpenURI.xml
+++ b/data/org.freedesktop.portal.OpenURI.xml
@@ -29,7 +29,7 @@
        URIs (e.g. a http: link to the applications homepage)
        under the control of the user.
 
-       This documentation describes version 5 of this interface.
+       This documentation describes revision 5 of this interface.
   -->
   <interface name="org.freedesktop.portal.OpenURI">
     <!--
@@ -65,13 +65,13 @@
           Whether to ask the user to choose an app. If this is not passed, or false,
           the portal may use a default or pick the last choice.
 
-          The ask option was introduced in version 3 of the interface.
+          The ask option was introduced in revision 3 of the interface.
 
         * ``activation_token`` (``s``)
 
           A token that can be used to activate the chosen application.
 
-          The activation_token option was introduced in version 4 of the interface.
+          The activation_token option was introduced in revision 4 of the interface.
     -->
     <method name="OpenURI">
       <arg type="s" name="parent_window" direction="in"/>
@@ -111,15 +111,15 @@
           Whether to ask the user to choose an app. If this is not passed, or false,
           the portal may use a default or pick the last choice.
 
-          The ask option was introduced in version 3 of the interface.
+          The ask option was introduced in revision 3 of the interface.
 
         * ``activation_token`` (``s``)
 
           A token that can be used to activate the chosen application.
 
-          The activation_token option was introduced in version 4 of the interface.
+          The activation_token option was introduced in revision 4 of the interface.
 
-        The OpenFile method was introduced in version 2 of the OpenURI portal API.
+        The OpenFile method was introduced in revision 2 of the OpenURI portal API.
     -->
     <method name="OpenFile">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -154,9 +154,9 @@
 
           A token that can be used to activate the chosen application.
 
-          The activation_token option was introduced in version 4 of the interface.
+          The activation_token option was introduced in revision 4 of the interface.
 
-        The OpenDirectory method was introduced in version 3 of the OpenURI portal API.
+        The OpenDirectory method was introduced in revision 3 of the OpenURI portal API.
     -->
     <method name="OpenDirectory">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -177,7 +177,7 @@
 
         The @options vardict currently has no supported entries.
 
-        The SchemeSupported method was introduced in version 5 of the OpenURI portal API.
+        The SchemeSupported method was introduced in revision 5 of the OpenURI portal API.
     -->
     <method name="SchemeSupported">
       <arg type="s" name="scheme" direction="in"/>
@@ -186,6 +186,20 @@
       <arg type="b" name="supported" direction="out"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 5 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.OpenURI:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.PowerProfileMonitor.xml
+++ b/data/org.freedesktop.portal.PowerProfileMonitor.xml
@@ -30,7 +30,7 @@
       user interaction. Applications are expected to use this interface
       indirectly, via a library API such as the GLib GPowerProfileMonitor interface.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.PowerProfileMonitor">
     <!--
@@ -40,6 +40,19 @@
     -->
     <property name="power-saver-enabled" type="b" access="read"/>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Print.xml
+++ b/data/org.freedesktop.portal.Print.xml
@@ -34,7 +34,7 @@
       to print the formatted document. It is expected that high-level toolkit
       APIs such as GtkPrintOperation will hide most of this complexity.
 
-      This documentation describes version 4 of this interface.
+      This documentation describes revision 4 of this interface.
   -->
   <interface name="org.freedesktop.portal.Print">
     <!--
@@ -65,26 +65,26 @@
 
           Label for the accept button. Mnemonic underlines are allowed.
 
-          This option was added in version 2.
+          This option was added in revision 2.
 
         * ``supported_output_file_formats`` (``as``)
 
           File formats supported by the app to use for print-to-file. If not set, all formats
           are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
 
-          This option was added in version 3.
+          This option was added in revision 3.
 
         * ``has_current_page`` (``b``)
 
           Whether it makes sense to return "current" for the ``print-pages`` setting.
 
-          This option was added in version 4.
+          This option was added in revision 4.
 
         * ``has_selected_pages`` (``b``)
 
           Whether it makes sense to return "selection" for the ``print-pages`` setting.
 
-          This option was added in version 4.
+          This option was added in revision 4.
 
         The @settings and @page_setup vardict contain hints for the initial state of the print dialog.
 
@@ -319,7 +319,7 @@
           File formats supported by the app to use for print-to-file. If not set, all formats
           are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
 
-          This option was added in version 3.
+          This option was added in revision 3.
     -->
     <method name="Print">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
@@ -331,6 +331,20 @@
       <arg type="o" name="handle" direction="out"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents implemented revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 4 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (e.g. returns 0), fallback to read
+        :ref:`org.freedesktop.portal.Print:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.ProxyResolver.xml
+++ b/data/org.freedesktop.portal.ProxyResolver.xml
@@ -29,7 +29,7 @@
       user interaction. Applications are expected to use this interface indirectly,
       via a library API such as the GLib GProxyResolver interface.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.ProxyResolver">
     <!--
@@ -46,6 +46,20 @@
       <arg type="s" name="uri" direction="in"/>
       <arg type="as" name="proxies" direction="out"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Realtime.xml
+++ b/data/org.freedesktop.portal.Realtime.xml
@@ -31,7 +31,7 @@
       RealtimeKit imposes on processes which are documented here:
       https://git.0pointer.net/rtkit.git/tree/README
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
     -->
     <interface name="org.freedesktop.portal.Realtime">
       <!--
@@ -62,6 +62,19 @@
       <property name="MinNiceLevel" type="i" access="read"/>
       <property name="RTTimeUSecMax" type="x" access="read"/>
 
-      <property name="version" type="u" access="read"/>
+      <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
     </interface>
 </node>

--- a/data/org.freedesktop.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.portal.RemoteDesktop.xml
@@ -25,7 +25,7 @@
 
       The Remote desktop portal allows to create remote desktop sessions.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.RemoteDesktop">
     <!--
@@ -116,7 +116,7 @@
           the same session again, use the new restore token sent in response
           to starting this session.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         * ``persist_mode`` (``u``)
 
@@ -130,7 +130,7 @@
           be returned via the :ref:`org.freedesktop.portal.Request::Response` signal of the
           start method used to start the session.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         For available device types, see the AvailableDeviceTypes property.
     -->
@@ -171,7 +171,7 @@
 
           A boolean for whether the clipboard was enabled ('true') or not ('false').
           See the :ref:`org.freedesktop.portal.Clipboard` documentation for more information.
-          Since version 2.
+          Since revision 2.
 
         * ``streams`` (``a(ua{sv})``)
 
@@ -185,7 +185,7 @@
           be used to restore a session. See
           org.freedesktop.portal.RemoteDesktop.SelectDevices() for details.
 
-          This response option was added in version 2 of this interface.
+          This response option was added in revision 2 of this interface.
 
         If a screen cast source was selected, the results of the
         :ref:`org.freedesktop.portal.ScreenCast.Start` response signal may be
@@ -451,7 +451,7 @@
         documentation for the ``mapping_id`` stream property in
         :ref:`org.freedesktop.portal.ScreenCast.Start`.
 
-        This method was added in version 2 of this interface.
+        This method was added in revision 2 of this interface.
     -->
     <method name="ConnectToEIS">
       <annotation name="org.gtk.GDBus.C.Name" value="connect_to_eis"/>
@@ -472,6 +472,21 @@
         - ``4``: TOUCHSCREEN
     -->
     <property name="AvailableDeviceTypes" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.RemoteDesktop:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Request.xml
+++ b/data/org.freedesktop.portal.Request.xml
@@ -57,6 +57,8 @@
       The token that the caller provides should be unique and not guessable. To avoid clashes
       with calls made from unrelated libraries, it is a good idea to use a per-library prefix
       combined with a random number.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Request">
 
@@ -89,5 +91,16 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results"/>
     </signal>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -25,7 +25,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 5 of this interface.
+      This documentation describes revision 5 of this interface.
   -->
   <interface name="org.freedesktop.portal.ScreenCast">
     <!--
@@ -106,7 +106,7 @@
           not advertised will cause the screen cast session to be closed. The default
           cursor mode is 'Hidden'.
 
-          This option was added in version 2 of this interface.
+          This option was added in revision 2 of this interface.
 
         * ``restore_token`` (``s``)
 
@@ -125,7 +125,7 @@
           Persistent remote desktop screen cast sessions can only be handled
           via the :ref:`org.freedesktop.portal.RemoteDesktop` interface.
 
-          This option was added in version 4 of this interface.
+          This option was added in revision 4 of this interface.
 
         * ``persist_mode`` (``u``)
 
@@ -143,7 +143,7 @@
           be returned via the :ref:`org.freedesktop.portal.Request::Response` signal of the
           :ref:`org.freedesktop.portal.ScreenCast.Start` method.
 
-          This option was added in version 4 of this interface.
+          This option was added in revision 4 of this interface.
 
         For available source types, see the AvailableSourceTypes property.
     -->
@@ -197,7 +197,7 @@
 
             Opaque identifier. Will be unique for this stream and local to this
             session. Will persist with future sessions, if they are restored
-            using a restore token. This property was added in version 4 of this
+            using a restore token. This property was added in revision 4 of this
             interface. Optional.
 
           * ``position`` (``(ii)``)
@@ -219,7 +219,7 @@
 
             The type of the content which is being screen casted.
             For available source types, see the AvailableSourceTypes property.
-            This property was added in version 3 of this interface.
+            This property was added in revision 3 of this interface.
 
           * ``mapping_id`` (``s``)
 
@@ -232,7 +232,7 @@
             regions, but a mapping_id will only match one of these regions per
             device.
 
-            This property was added in version 5 of this interface.
+            This property was added in revision 5 of this interface.
 
         * ``restore_token`` (``s``)
 
@@ -240,7 +240,7 @@
           be used to restore a session. See
           org.freedesktop.portal.ScreenCast.SelectSources() for details.
 
-          This response option was added in version 4 of this interface.
+          This response option was added in revision 4 of this interface.
     -->
     <method name="Start">
       <arg type="o" name="session_handle" direction="in"/>
@@ -290,9 +290,24 @@
         - ``2``: Embedded: The cursor is embedded as part of the stream buffers.
         - ``4``: Metadata: The cursor is not part of the screen cast stream, but sent as PipeWire stream metadata.
 
-        This property was added in version 2 of this interface.
+        This property was added in revision 2 of this interface.
     -->
     <property name="AvailableCursorModes" type="u" access="read"/>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 5 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.ScreenCast:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -31,7 +31,7 @@
       may involve adding it to the :ref:`Documents
       portal<org.freedesktop.portal.Documents>`).
 
-      This documentation describes **version 2** of this interface.
+      This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Screenshot">
     <!--
@@ -57,7 +57,7 @@
         * ``interactive`` (``b``)
 
           Hint whether the dialog should offer customization before taking a screenshot.
-          Default is no.  **Since version 2.**
+          Default is no.  **Since revision 2.**
 
         The following results get returned via the :ref:`org.freedesktop.portal.Request::Response`
         signal:
@@ -100,6 +100,20 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 2 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 2 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Secret.xml
+++ b/data/org.freedesktop.portal.Secret.xml
@@ -29,7 +29,7 @@
       per-application secret.  The secret can then be used for
       encrypting confidential data inside the sandbox.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Secret">
 
@@ -80,6 +80,20 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Session.xml
+++ b/data/org.freedesktop.portal.Session.xml
@@ -49,6 +49,8 @@
 
       A client who started a session vanishing from the D-Bus is equivalent to
       closing all active sessions made by said client.
+
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Session">
 
@@ -73,6 +75,24 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
       <arg type="a{sv}" name="details"/>
     </signal>
-    <property name="version" type="u" access="read"/>
+
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <!--
+        version:
+        xdg-desktop-portal never set a value to this property.
+    -->
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Settings.xml
+++ b/data/org.freedesktop.portal.Settings.xml
@@ -72,7 +72,7 @@
 
       Unknown values should be treated as ``0`` (no preference).
 
-    This documentation describes version 2 of this interface.
+    This documentation describes revision 2 of this interface.
   -->
   <interface name="org.freedesktop.portal.Settings">
 
@@ -119,7 +119,7 @@
 
       Reads a single value which may be any valid DBus type. Returns an error on any unknown namespace or key.
 
-      This method was added in version 2.
+      This method was added in revision 2.
     -->
     <method name="ReadOne">
       <arg type="s" name="namespace" direction="in"/>
@@ -141,6 +141,20 @@
       <arg type="v" name="value" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        If missing or unset (returns 0), fallback to read
+        :ref:`org.freedesktop.portal.Settings:version`.
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Trash.xml
+++ b/data/org.freedesktop.portal.Trash.xml
@@ -28,7 +28,7 @@
       This simple interface lets sandboxed applications send files to
       the trashcan.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Trash">
     <!--
@@ -45,6 +45,19 @@
       <arg type="u" name="result" direction="out"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Usb.xml
+++ b/data/org.freedesktop.portal.Usb.xml
@@ -31,7 +31,7 @@
       Applications should prefer specialized portals for specific
       device types, such as the Camera portal for cameras.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
     -->
   <interface name="org.freedesktop.portal.Usb">
 
@@ -247,6 +247,19 @@
       <arg type="a(ssa{sv})" name="events" direction="out"/>
     </signal>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Wallpaper.xml
+++ b/data/org.freedesktop.portal.Wallpaper.xml
@@ -28,7 +28,7 @@
       This simple interface lets sandboxed applications set the user's
       desktop background picture.
 
-      This documentation describes version 1 of this interface.
+      This documentation describes revision 1 of this interface.
   -->
   <interface name="org.freedesktop.portal.Wallpaper">
     <!--
@@ -93,6 +93,19 @@
       <arg type="o" name="handle" direction="out"/>
     </method>
 
-    <property name="version" type="u" access="read"/>
+    <!--
+        active-revision:
+        Represents active revision/feature-set of the interface.
+
+        This property was added post-introduction of revision 1 and no revision bump of this
+        interface was made for this specific addition.
+
+        Consequently, assume 1 if missing or unset (e.g. returns 0).
+    -->
+    <property name="active-revision" type="u" access="read"/>
+
+    <property name="version" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
   </interface>
 </node>

--- a/doc/common-conventions.rst
+++ b/doc/common-conventions.rst
@@ -13,6 +13,7 @@ documented in the pages below:
    sessions
    window-identifiers
    icons
+   versioning
 
 .. cssclass:: tiled-toc
 
@@ -56,3 +57,5 @@ documented in the pages below:
       :class: only-dark
 
    :doc:`Icons </icons>`
+
+*  :doc:`Versioning </versioning>`

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -98,6 +98,7 @@ if build_documentation
     'sessions.rst',
     'system-integration.rst',
     'terminology.rst',
+    'versioning.rst',
     'window-identifiers.rst',
     'writing-a-new-backend.rst',
   ]

--- a/doc/versioning.rst
+++ b/doc/versioning.rst
@@ -1,0 +1,46 @@
+Versionning
+===========
+
+D−Bus Interfaces
+----------------
+
+D-Bus interfaces are versionned to:
+
+- Enable non-backward compatible changes (e.g. remove deprecated functions,
+  interface overhaul) with major bump.
+- Enable backward compatible changes (e.g. method addition, new property for
+  the optional argument) with minor bump.
+
+Two major version of an interface can coexist to allow a deprecation period for
+the former version.
+
+The major version is determined by the main interface name (to not mix up with
+the deprecated ``version`` property in interfaces documentation).
+
+.. csv-table:: Major Version Example
+    :header: "Interface Name", "Version", "Reason"
+
+    "org.freedesktop.portal.Settings", "1", "Lack of number suffix, default to 1"
+    "org.freedesktop.portal.Camera2", "2", "Suffix number is 2"
+
+Interfaces have a minor version documented as "revision" (previously
+"version" but renamed to avoid confusion), assume 1 if not documented.
+
+Each of those interfaces must have a ``active-revision`` property which is not
+meant to match the documented "revision" but the revision matching the
+feature-set enabled, if missing or not set (returns 0) check the interface
+documentation of the property for the recommended fallback or assumption to do.
+
+The ``version`` property has been deprecated and is not guaranted to be identical
+to the new ``active-revision`` for every interface.
+
+Implementation interfaces
+-------------------------
+
+Portal implementation interfaces are also versionned (and can have revisions) but
+do not require to match their non-implementation counterpart.
+
+When an implementation provides an interfaces, it is expected that the feature-set
+behind the set ``active-revision`` is implemented, if missing or not set (returns
+0\) check the interface documentation of the property for the matching fallback
+behaviour that will be used.

--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -1509,6 +1509,8 @@ on_peer_disconnect (const char *name,
   xdp_app_info_registry_delete (app_info_registry, name);
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusDocuments, documents)
+
 static void
 on_bus_acquired (GDBusConnection *connection,
                  const gchar     *name,
@@ -1521,7 +1523,8 @@ on_bus_acquired (GDBusConnection *connection,
 
   app_info_registry = xdp_app_info_registry_new ();
 
-  xdp_dbus_documents_set_version (XDP_DBUS_DOCUMENTS (dbus_api), 5);
+  /* Active revision and version (deprecated) are identical */
+  documents_dbus_set_active_revision (XDP_DBUS_DOCUMENTS (dbus_api), 5);
 
   g_signal_connect_swapped (dbus_api, "handle-get-mount-point", G_CALLBACK (handle_get_mount_point), NULL);
   g_signal_connect_swapped (dbus_api, "handle-add", G_CALLBACK (handle_method), portal_add);

--- a/document-portal/file-transfer.c
+++ b/document-portal/file-transfer.c
@@ -553,6 +553,8 @@ handle_method (GCallback              method_callback,
   return TRUE;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusFileTransfer, file_transfer)
+
 GDBusInterfaceSkeleton *
 file_transfer_create (void)
 {
@@ -563,7 +565,8 @@ file_transfer_create (void)
   g_signal_connect_swapped (file_transfer, "handle-retrieve-files", G_CALLBACK (handle_method), retrieve_files);
   g_signal_connect_swapped (file_transfer, "handle-stop-transfer", G_CALLBACK (handle_method), stop_transfer);
 
-  xdp_dbus_file_transfer_set_version (XDP_DBUS_FILE_TRANSFER (file_transfer), 1);
+  /* Active revision and version (deprecated) are identical */
+  file_transfer_dbus_set_active_revision (XDP_DBUS_FILE_TRANSFER (file_transfer), 1);
 
   transfers = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_object_unref);
 

--- a/document-portal/xdg-permission-store.c
+++ b/document-portal/xdg-permission-store.c
@@ -519,7 +519,11 @@ xdg_permission_store_start (GDBusConnection *connection)
 
   store = xdg_permission_store_skeleton_new ();
 
+  /* Active revision and version (deprecated) are identical */
+  xdg_permission_store_set_active_revision (XDG_PERMISSION_STORE (store), 2);
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   xdg_permission_store_set_version (XDG_PERMISSION_STORE (store), 2);
+  G_GNUC_END_IGNORE_DEPRECATIONS
 
   g_signal_connect (store, "handle-list", G_CALLBACK (handle_list), NULL);
   g_signal_connect (store, "handle-lookup", G_CALLBACK (handle_lookup), NULL);

--- a/src/account.c
+++ b/src/account.c
@@ -262,15 +262,26 @@ account_class_init (AccountClass *klass)
   object_class->dispose = account_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusAccount, account)
+
 static Account *
 account_new (XdpDbusImplAccount *impl)
 {
   Account *account;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   account = g_object_new (account_get_type (), NULL);
   account->impl = g_object_ref (impl);
 
-  xdp_dbus_account_set_version (XDP_DBUS_ACCOUNT (account), 1);
+  impl_revision =
+    MAX (xdp_dbus_impl_account_get_active_revision (account->impl), 1);
+  if (impl_revision >= 1)
+    active_revision = 1;
+
+  /* Active revision and version (deprecated) are identical */
+  account_dbus_set_active_revision (XDP_DBUS_ACCOUNT (account),
+                                    active_revision);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (account->impl), G_MAXINT);
 

--- a/src/background.c
+++ b/src/background.c
@@ -1363,6 +1363,8 @@ background_class_init (BackgroundClass *klass)
   object_class->dispose = background_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusBackground, background)
+
 static Background *
 background_new (XdpDbusImplBackground *background_impl,
                 XdpDbusImplAccess     *access_impl,
@@ -1371,6 +1373,8 @@ background_new (XdpDbusImplBackground *background_impl,
   g_autoptr(Background) background = NULL;
   g_autofree char *instance_path = NULL;
   g_autoptr(GFile) instance_dir = NULL;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
   g_autoptr(GError) error = NULL;
 
   background = g_object_new (background_get_type (), NULL);
@@ -1378,7 +1382,15 @@ background_new (XdpDbusImplBackground *background_impl,
   background->access_impl = g_object_ref (access_impl);
   background->monitor = g_object_ref (background_monitor);
 
-  xdp_dbus_background_set_version (XDP_DBUS_BACKGROUND (background), 2);
+  impl_revision =
+    MAX (xdp_dbus_impl_background_get_active_revision (background->impl), 1);
+  /* Revision 2 requires at least impl revision 1 */
+  if (impl_revision >= 1)
+    active_revision = 2;
+
+  /* Active revision and version (deprecated) are identical */
+  background_dbus_set_active_revision (XDP_DBUS_BACKGROUND (background),
+                                       active_revision);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (background->impl),
                                     G_MAXINT);

--- a/src/camera.c
+++ b/src/camera.c
@@ -501,6 +501,8 @@ camera_class_init (CameraClass *klass)
   object_class->finalize = camera_finalize;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusCamera, camera)
+
 static Camera *
 camera_new (XdpDbusImplAccess   *access_impl,
             XdpDbusImplLockdown *lockdown_impl)
@@ -514,7 +516,8 @@ camera_new (XdpDbusImplAccess   *access_impl,
   camera->access_impl = g_object_ref (access_impl);
   camera->lockdown_impl = g_object_ref (lockdown_impl);
 
-  xdp_dbus_camera_set_version (XDP_DBUS_CAMERA (camera), 1);
+  /* Active revision and version (deprecated) are identical */
+  camera_dbus_set_active_revision (XDP_DBUS_CAMERA (camera), 1);
 
   pipewire_socket_path = g_strdup_printf ("%s/pipewire-0",
                                           g_get_user_runtime_dir ());

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -607,17 +607,27 @@ selection_owner_changed_cb (XdpDbusImplClipboard *impl,
     }
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusClipboard, clipboard)
+
 static Clipboard *
 clipboard_new (XdpDbusImplClipboard *impl)
 {
   Clipboard *clipboard;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   clipboard = g_object_new (clipboard_get_type (), NULL);
   clipboard->impl = g_object_ref (impl);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (clipboard->impl), G_MAXINT);
 
-  xdp_dbus_clipboard_set_version (XDP_DBUS_CLIPBOARD (clipboard), 1);
+  impl_revision =
+    MAX (xdp_dbus_impl_clipboard_get_active_revision (clipboard->impl), 1);
+  if (impl_revision >= 1)
+    active_revision = 1;
+
+  /* Active revision and version (deprecated) are identical */
+  clipboard_dbus_set_active_revision (XDP_DBUS_CLIPBOARD (clipboard), active_revision);
 
   g_signal_connect_object (clipboard->impl, "selection-transfer",
                            G_CALLBACK (selection_transfer_cb),

--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -1099,10 +1099,14 @@ dynamic_launcher_class_init (DynamicLauncherClass *klass)
   object_class->dispose = dynamic_launcher_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusDynamicLauncher, dynamic_launcher)
+
 static DynamicLauncher*
 dynamic_launcher_new (XdpDbusImplDynamicLauncher *impl)
 {
   DynamicLauncher *dynamic_launcher;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   dynamic_launcher = g_object_new (dynamic_launcher_get_type (), NULL);
   dynamic_launcher->impl = g_object_ref (impl);
@@ -1110,7 +1114,14 @@ dynamic_launcher_new (XdpDbusImplDynamicLauncher *impl)
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (dynamic_launcher->impl),
                                     G_MAXINT);
 
-  xdp_dbus_dynamic_launcher_set_version (XDP_DBUS_DYNAMIC_LAUNCHER (dynamic_launcher), 1);
+  impl_revision =
+    MAX (xdp_dbus_impl_dynamic_launcher_get_active_revision (dynamic_launcher->impl), 1);
+  if (impl_revision >= 1)
+    active_revision = 1;
+
+  /* Active revision and version (deprecated) are identical */
+  dynamic_launcher_dbus_set_active_revision (XDP_DBUS_DYNAMIC_LAUNCHER (dynamic_launcher),
+                                             active_revision);
 
   g_object_bind_property (G_OBJECT (dynamic_launcher->impl), "supported-launcher-types",
                           G_OBJECT (dynamic_launcher), "supported-launcher-types",

--- a/src/email.c
+++ b/src/email.c
@@ -336,17 +336,28 @@ email_class_init (EmailClass *klass)
   object_class->dispose = email_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusEmail, email)
+
 static Email *
 email_new (XdpDbusImplEmail *impl)
 {
   Email *email;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   email = g_object_new (email_get_type (), NULL);
   email->impl = g_object_ref (impl);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (email->impl), G_MAXINT);
 
-  xdp_dbus_email_set_version (XDP_DBUS_EMAIL (email), 4);
+  impl_revision =
+    MAX (xdp_dbus_impl_email_get_active_revision (email->impl), 1);
+  /* Revision 4 requires at least impl revision 1 */
+  if (impl_revision >= 1)
+    active_revision = 4;
+
+  /* Active revision and version (deprecated) are identical */
+  email_dbus_set_active_revision (XDP_DBUS_EMAIL (email), active_revision);
 
   return email;
 }

--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -834,11 +834,15 @@ file_chooser_class_init (FileChooserClass *klass)
   object_class->dispose = file_chooser_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusFileChooser, file_chooser)
+
 static FileChooser *
 file_chooser_new (XdpDbusImplFileChooser *impl,
                   XdpDbusImplLockdown    *lockdown_impl)
 {
   FileChooser *file_chooser;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   file_chooser = g_object_new (file_chooser_get_type (), NULL);
   file_chooser->impl = g_object_ref (impl);
@@ -846,7 +850,15 @@ file_chooser_new (XdpDbusImplFileChooser *impl,
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (file_chooser->impl), G_MAXINT);
 
-  xdp_dbus_file_chooser_set_version (XDP_DBUS_FILE_CHOOSER (file_chooser), 4);
+  impl_revision =
+    MAX (xdp_dbus_impl_file_chooser_get_active_revision (file_chooser->impl), 1);
+  /* Revision 4 requires at least impl revision 1 */
+  if (impl_revision >= 1)
+    active_revision = 4;
+
+  /* Active revision and version (deprecated) are identical */
+  file_chooser_dbus_set_active_revision (XDP_DBUS_FILE_CHOOSER (file_chooser),
+                                         active_revision);
 
   return file_chooser;
 }

--- a/src/gamemode.c
+++ b/src/gamemode.c
@@ -580,6 +580,8 @@ on_client_properties_changed (GDBusProxy  *proxy,
   update_active_state_from_cache (gamemode, proxy);
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusGameMode, game_mode)
+
 static GameMode *
 game_mode_new (GDBusProxy *client)
 {
@@ -588,7 +590,8 @@ game_mode_new (GDBusProxy *client)
   gamemode = g_object_new (game_mode_get_type (), NULL);
   gamemode->client = g_object_ref (client);
 
-  xdp_dbus_game_mode_set_version (XDP_DBUS_GAME_MODE (gamemode), 4);
+  /* Active revision and version (deprecated) are identical */
+  game_mode_dbus_set_active_revision (XDP_DBUS_GAME_MODE (gamemode), 4);
 
   g_signal_connect_object (gamemode->client, "g-properties-changed",
                            G_CALLBACK (on_client_properties_changed),

--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -47,7 +47,7 @@ struct _GlobalShortcuts
 
   XdpContext *context;
   XdpDbusImplGlobalShortcuts *impl;
-  uint32_t impl_version;
+  uint32_t impl_revision;
 };
 
 struct _GlobalShortcutsClass
@@ -640,7 +640,7 @@ handle_configure_shortcuts (XdpDbusGlobalShortcuts *object,
   g_auto(GVariantBuilder) options_builder =
     G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-  if (global_shortcuts->impl_version < 2)
+  if (global_shortcuts->impl_revision < 2)
     return G_DBUS_METHOD_INVOCATION_UNHANDLED;
 
   if (!xdp_filter_options (arg_options, &options_builder,
@@ -789,11 +789,16 @@ shortcuts_changed_cb (XdpDbusImplGlobalShortcuts *impl,
                                    NULL);
 }
 
+XDP_DEFINE_COMPAT_DBUS_IMPL_GET_ACTIVE_REVISION (XdpDbusImplGlobalShortcuts, global_shortcuts)
+
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusGlobalShortcuts, global_shortcuts)
+
 static GlobalShortcuts *
 global_shortcuts_new (XdpContext                 *context,
                       XdpDbusImplGlobalShortcuts *impl)
 {
   GlobalShortcuts *global_shortcuts;
+  uint32_t active_revision = 0;
 
   global_shortcuts = g_object_new (global_shortcuts_get_type (), NULL);
   global_shortcuts->context = context;
@@ -815,10 +820,16 @@ global_shortcuts_new (XdpContext                 *context,
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (global_shortcuts->impl),
                                     G_MAXINT);
 
-  global_shortcuts->impl_version =
-    MAX (xdp_dbus_impl_global_shortcuts_get_version (global_shortcuts->impl), 1);
-  xdp_dbus_global_shortcuts_set_version (XDP_DBUS_GLOBAL_SHORTCUTS (global_shortcuts),
-                                         MIN (global_shortcuts->impl_version, 2));
+  global_shortcuts->impl_revision =
+    MAX (global_shortcuts_dbus_impl_get_active_revision (global_shortcuts->impl), 1);
+  if (global_shortcuts->impl_revision >= 2)
+    active_revision = 2;
+  else
+    active_revision = 1;
+
+  /* Active revision and version (deprecated) are identical */
+  global_shortcuts_dbus_set_active_revision (XDP_DBUS_GLOBAL_SHORTCUTS (global_shortcuts),
+                                             active_revision);
 
   return global_shortcuts;
 }

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -546,11 +546,15 @@ on_state_changed (XdpDbusImplInhibit *impl,
                                    NULL);
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusInhibit, inhibit)
+
 static Inhibit *
 inhibit_new (XdpContext         *context,
              XdpDbusImplInhibit *impl)
 {
   Inhibit *inhibit;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   inhibit = g_object_new (inhibit_get_type (), NULL);
   inhibit->context = context;
@@ -562,7 +566,14 @@ inhibit_new (XdpContext         *context,
                            G_CALLBACK (on_state_changed),
                            inhibit, G_CONNECT_DEFAULT);
 
-  xdp_dbus_inhibit_set_version (XDP_DBUS_INHIBIT (inhibit), 3);
+  impl_revision =
+    MAX (xdp_dbus_impl_inhibit_get_active_revision (inhibit->impl), 1);
+  /* Revision 3 requires at least impl revision 1 */
+  if (impl_revision >= 1)
+    active_revision = 3;
+
+  /* Active revision and version (deprecated) are identical */
+  inhibit_dbus_set_active_revision (XDP_DBUS_INHIBIT (inhibit), active_revision);
 
   return inhibit;
 }

--- a/src/input-capture.c
+++ b/src/input-capture.c
@@ -44,7 +44,7 @@ struct _InputCapture
 
   XdpContext *context;
   XdpDbusImplInputCapture *impl;
-  int impl_version;
+  uint32_t impl_revision;
 };
 
 struct _InputCaptureClass
@@ -85,7 +85,7 @@ typedef struct _InputCaptureSession
 {
   XdpSession parent;
 
-  int impl_version;
+  uint32_t impl_revision;
 
   InputCaptureSessionState state;
   gboolean clipboard_requested;
@@ -172,7 +172,7 @@ input_capture_session_new (InputCapture     *input_capture,
     return NULL;
 
   input_capture_session = (InputCaptureSession*) session;
-  input_capture_session->impl_version = input_capture->impl_version;
+  input_capture_session->impl_revision = input_capture->impl_revision;
 
   g_debug ("input capture session owned by '%s' created",
            xdp_app_info_get_sender (app_info));
@@ -186,7 +186,7 @@ input_capture_session_can_request_clipboard (InputCaptureSession *session)
   if (session->clipboard_requested)
     return FALSE;
 
-  if (session->impl_version < 2)
+  if (session->impl_revision < 2)
     return FALSE;
 
   switch (session->state)
@@ -313,7 +313,7 @@ handle_create_session (XdpDbusInputCapture   *object,
 
   g_object_set_data (G_OBJECT (request), "-xdp-input-capture", input_capture);
 
-  if (input_capture->impl_version < 2)
+  if (input_capture->impl_revision < 2)
     {
       xdp_dbus_impl_input_capture_call_create_session (input_capture->impl,
                                                        request->id,
@@ -383,7 +383,7 @@ handle_create_session2 (XdpDbusInputCapture   *object,
   g_auto(GVariantBuilder) results_builder =
     G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-  if (input_capture->impl_version < 2)
+  if (input_capture->impl_revision < 2)
     return G_DBUS_METHOD_INVOCATION_UNHANDLED;
 
   if (!xdp_filter_options (arg_options, &options_builder,
@@ -462,7 +462,7 @@ start_done (GObject      *source_object,
 
   input_capture = g_object_get_data (G_OBJECT (request), "-xdp-input-capture");
 
-  if (input_capture->impl_version < 2)
+  if (input_capture->impl_revision < 2)
     {
       if (!xdp_dbus_impl_input_capture_call_create_session_finish (impl,
                                                                    &response,
@@ -631,7 +631,7 @@ handle_start (XdpDbusInputCapture   *object,
   g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
 
-  if (input_capture->impl_version < 2)
+  if (input_capture->impl_revision < 2)
     return G_DBUS_METHOD_INVOCATION_UNHANDLED;
 
   REQUEST_AUTOLOCK (request);
@@ -1635,11 +1635,16 @@ input_capture_class_init (InputCaptureClass *klass)
     g_quark_from_static_string ("-xdp-request-capture-input-session");
 }
 
+XDP_DEFINE_COMPAT_DBUS_IMPL_GET_ACTIVE_REVISION (XdpDbusImplInputCapture, input_capture)
+
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusInputCapture, input_capture)
+
 static InputCapture *
 input_capture_new (XdpContext              *context,
                    XdpDbusImplInputCapture *impl)
 {
   InputCapture *input_capture;
+  uint32_t active_revision = 0;
 
   input_capture = g_object_new (input_capture_get_type (), NULL);
   input_capture->context = context;
@@ -1647,10 +1652,16 @@ input_capture_new (XdpContext              *context,
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (input_capture->impl), G_MAXINT);
 
-  input_capture->impl_version =
-    MAX (xdp_dbus_impl_input_capture_get_version (impl), 1);
-  xdp_dbus_input_capture_set_version (XDP_DBUS_INPUT_CAPTURE (input_capture),
-                                      MIN (input_capture->impl_version, 2));
+  input_capture->impl_revision =
+    MAX (input_capture_dbus_impl_get_active_revision (input_capture->impl), 1);
+  if (input_capture->impl_revision >= 2)
+    active_revision = 2;
+  else
+    active_revision = 1;
+
+  /* Active revision and version (deprecated) are identical */
+  input_capture_dbus_set_active_revision (XDP_DBUS_INPUT_CAPTURE (input_capture),
+                                          active_revision);
 
   g_object_bind_property (G_OBJECT (input_capture->impl), "supported-capabilities",
                           G_OBJECT (input_capture), "supported-capabilities",

--- a/src/location.c
+++ b/src/location.c
@@ -757,6 +757,8 @@ location_class_init (LocationClass *klass)
   quark_request_session = g_quark_from_static_string ("-xdp-request-location-session");
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusLocation, location)
+
 static Location *
 location_new (XdpContext          *context,
               XdpDbusImplAccess   *access_impl,
@@ -769,7 +771,8 @@ location_new (XdpContext          *context,
   location->access_impl = g_object_ref (access_impl);
   location->lockdown_impl = g_object_ref (lockdown_impl);
 
-  xdp_dbus_location_set_version (XDP_DBUS_LOCATION (location), 1);
+  /* Active revision and version (deprecated) are identical */
+  location_dbus_set_active_revision (XDP_DBUS_LOCATION (location), 1);
 
   return location;
 }

--- a/src/memory-monitor.c
+++ b/src/memory-monitor.c
@@ -28,6 +28,7 @@
 
 #include "xdp-context.h"
 #include "xdp-dbus.h"
+#include "xdp-utils.h"
 
 #include "memory-monitor.h"
 
@@ -103,6 +104,8 @@ memory_monitor_class_init (MemoryMonitorClass *klass)
   object_class->finalize = memory_monitor_finalize;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusMemoryMonitor, memory_monitor)
+
 static MemoryMonitor *
 memory_monitor_new (void)
 {
@@ -118,7 +121,8 @@ memory_monitor_new (void)
                            G_CONNECT_DEFAULT);
 #endif /* HAS_MEMORY_MONITOR */
 
-  xdp_dbus_memory_monitor_set_version (XDP_DBUS_MEMORY_MONITOR (memory_monitor), 1);
+  /* Active revision and version (deprecated) are identical */
+  memory_monitor_dbus_set_active_revision (XDP_DBUS_MEMORY_MONITOR (memory_monitor), 1);
 
   return memory_monitor;
 }

--- a/src/network-monitor.c
+++ b/src/network-monitor.c
@@ -249,6 +249,8 @@ network_monitor_class_init (NetworkMonitorClass *klass)
   object_class->dispose = network_monitor_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusNetworkMonitor, network_monitor)
+
 static NetworkMonitor *
 network_monitor_new (void)
 {
@@ -263,7 +265,8 @@ network_monitor_new (void)
                            network_monitor,
                            G_CONNECT_DEFAULT);
 
-  xdp_dbus_network_monitor_set_version (XDP_DBUS_NETWORK_MONITOR (network_monitor), 3);
+  /* Active revision and version (deprecated) are identical */
+  network_monitor_dbus_set_active_revision (XDP_DBUS_NETWORK_MONITOR (network_monitor), 3);
 
   return network_monitor;
 }

--- a/src/notification.c
+++ b/src/notification.c
@@ -47,7 +47,7 @@ struct _Notification
   XdpDbusNotificationSkeleton parent_instance;
 
   XdpDbusImplNotification *impl;
-  guint32 impl_version;
+  guint32 impl_revision;
 
   GHashTable *active; /* Pair *notification -> char *sender */
   GMutex active_mutex;
@@ -479,7 +479,7 @@ check_button_purpose (GVariant  *value,
 
 static gboolean
 parse_button (GVariantBuilder  *builder,
-              guint32           impl_version,
+              guint32           impl_revision,
               GVariant         *button,
               GError          **error)
 {
@@ -518,7 +518,7 @@ parse_button (GVariantBuilder  *builder,
           if (!target)
             target = g_steal_pointer (&value);
         }
-      else if (strcmp (key, "purpose") == 0 && impl_version > 1)
+      else if (strcmp (key, "purpose") == 0 && impl_revision > 1)
         {
           if (!check_button_purpose (value, error))
             return FALSE;
@@ -566,7 +566,7 @@ parse_button (GVariantBuilder  *builder,
 
 static gboolean
 parse_buttons (GVariantBuilder  *builder,
-               guint32           impl_version,
+               guint32           impl_revision,
                GVariant         *value,
                GError          **error)
 {
@@ -585,7 +585,7 @@ parse_buttons (GVariantBuilder  *builder,
     {
       g_autoptr(GVariant) button = g_variant_get_child_value (value, i);
 
-      if (!parse_button (builder, impl_version, button, error))
+      if (!parse_button (builder, impl_revision, button, error))
         {
           g_prefix_error (error, "invalid button: ");
           result = FALSE;
@@ -602,7 +602,7 @@ parse_buttons (GVariantBuilder  *builder,
 
 static gboolean
 parse_serialized_icon (GVariantBuilder  *builder,
-                       guint32           impl_version,
+                       guint32           impl_revision,
                        GVariant         *icon,
                        GUnixFDList      *in_fd_list,
                        GUnixFDList      *out_fd_list,
@@ -668,8 +668,8 @@ parse_serialized_icon (GVariantBuilder  *builder,
         }
       else if (xdp_validate_icon (sealed_icon, XDP_ICON_TYPE_NOTIFICATION, NULL, NULL))
         {
-          /* Since version 2 we only use file-descriptor icon */
-          if (impl_version > 1)
+          /* Since revision 2 we only use file-descriptor icon */
+          if (impl_revision > 1)
             {
               g_autoptr(GVariant) fd_icon = NULL;
 
@@ -716,7 +716,7 @@ parse_serialized_icon (GVariantBuilder  *builder,
       if (xdp_validate_icon (sealed_icon, XDP_ICON_TYPE_NOTIFICATION, NULL, NULL))
         {
           /* Convert file descriptor icons to byte icons for backwards compatibility */
-          if (impl_version < 2)
+          if (impl_revision < 2)
             {
                 g_autoptr(GBytes) bytes = NULL;
                 GVariant *bytes_icon;
@@ -944,7 +944,7 @@ parse_category (GVariantBuilder  *builder,
 
 static gboolean
 parse_notification (GVariantBuilder  *builder,
-                    guint32           impl_version,
+                    guint32           impl_revision,
                     GVariant         *notification,
                     GUnixFDList      *in_fd_list,
                     GUnixFDList      *out_fd_list,
@@ -969,7 +969,7 @@ parse_notification (GVariantBuilder  *builder,
 
           g_variant_builder_add (builder, "{sv}", key, value);
         }
-      else if (strcmp (key, "markup-body") == 0 && impl_version > 1)
+      else if (strcmp (key, "markup-body") == 0 && impl_revision > 1)
         {
           if (!parse_markup_body (builder, value, error))
             return FALSE;
@@ -977,7 +977,7 @@ parse_notification (GVariantBuilder  *builder,
       else if (strcmp (key, "icon") == 0)
         {
           if (!parse_serialized_icon (builder,
-                                      impl_version,
+                                      impl_revision,
                                       value,
                                       in_fd_list,
                                       out_fd_list,
@@ -987,7 +987,7 @@ parse_notification (GVariantBuilder  *builder,
               return FALSE;
             }
         }
-      else if (strcmp (key, "sound") == 0 && impl_version > 1)
+      else if (strcmp (key, "sound") == 0 && impl_revision > 1)
         {
           if (!parse_serialized_sound (builder,
                                        value,
@@ -1017,15 +1017,15 @@ parse_notification (GVariantBuilder  *builder,
         }
       else if (strcmp (key, "buttons") == 0)
         {
-          if (!parse_buttons (builder, impl_version, value, error))
+          if (!parse_buttons (builder, impl_revision, value, error))
             return FALSE;
         }
-      else if (strcmp (key, "display-hint") == 0 && impl_version > 1)
+      else if (strcmp (key, "display-hint") == 0 && impl_revision > 1)
         {
           if (!parse_display_hint (builder, value, error))
             return FALSE;
         }
-      else if (strcmp (key, "category") == 0 && impl_version > 1)
+      else if (strcmp (key, "category") == 0 && impl_revision > 1)
         {
           if (!parse_category (builder, value, error))
             return FALSE;
@@ -1086,7 +1086,7 @@ handle_add_in_thread_func (GTask        *task,
     }
 
   if (!parse_notification (&builder,
-                           call_data->notification->impl_version,
+                           call_data->notification->impl_revision,
                            call_data->notification_data,
                            call_data->in_fd_list,
                            call_data->out_fd_list,
@@ -1284,21 +1284,32 @@ notification_class_init (NotificationClass *klass)
   object_class->dispose = notification_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_IMPL_GET_ACTIVE_REVISION (XdpDbusImplNotification, notification)
+
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusNotification, notification)
+
 static Notification *
 notification_new (XdpContext              *context,
                   XdpDbusImplNotification *impl)
 {
   Notification *notification = NULL;
+  uint32_t active_revision = 0;
 
   notification = g_object_new (notification_get_type (), NULL);
   notification->impl = g_object_ref (impl);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (notification->impl), G_MAXINT);
 
-  notification->impl_version =
-    MAX (xdp_dbus_impl_notification_get_version (notification->impl), 1);
-  xdp_dbus_notification_set_version (XDP_DBUS_NOTIFICATION (notification),
-                                     MIN (notification->impl_version, 2));
+  notification->impl_revision =
+    MAX (notification_dbus_impl_get_active_revision (notification->impl), 1);
+  if (notification->impl_revision >= 2)
+    active_revision = 2;
+  else
+    active_revision = 1;
+
+  /* Active revision and version (deprecated) are identical */
+  notification_dbus_set_active_revision (XDP_DBUS_NOTIFICATION (notification),
+                                         active_revision);
 
   g_object_bind_property (G_OBJECT (notification->impl), "supported-options",
                           G_OBJECT (notification), "supported-options",

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -1147,6 +1147,8 @@ open_uri_class_init (OpenURIClass *klass)
   object_class->dispose = open_uri_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusOpenURI, open_uri)
+
 static OpenURI *
 open_uri_new (XdpDbusImplAppChooser *app_chooser_impl,
               XdpDbusImplLockdown   *lockdown_impl)
@@ -1161,7 +1163,11 @@ open_uri_new (XdpDbusImplAppChooser *app_chooser_impl,
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (open_uri->impl),
                                     G_MAXINT);
 
-  xdp_dbus_open_uri_set_version (XDP_DBUS_OPEN_URI (open_uri), 5);
+  /* TODO: Next AppChooser impl revision bump, add impl revision check to bump
+   * active revision only if impl revision is greater or equal to the new one. */
+
+  /* Active revision and version (deprecated) are identical */
+  open_uri_dbus_set_active_revision (XDP_DBUS_OPEN_URI (open_uri), 5);
 
   return open_uri;
 }

--- a/src/power-profile-monitor.c
+++ b/src/power-profile-monitor.c
@@ -103,6 +103,9 @@ power_profile_monitor_class_init (PowerProfileMonitorClass *klass)
   object_class->finalize = power_profile_monitor_finalize;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusPowerProfileMonitor,
+                                            power_profile_monitor)
+
 static PowerProfileMonitor *
 power_profile_monitor_new (void)
 {
@@ -119,7 +122,8 @@ power_profile_monitor_new (void)
                            G_CONNECT_DEFAULT);
 #endif /* HAS_POWER_PROFILE_MONITOR */
 
-  xdp_dbus_power_profile_monitor_set_version (
+  /* Active revision and version (deprecated) are identical */
+  power_profile_monitor_dbus_set_active_revision (
     XDP_DBUS_POWER_PROFILE_MONITOR (power_profile_monitor),
     1);
 

--- a/src/print.c
+++ b/src/print.c
@@ -359,12 +359,26 @@ print_new (XdpDbusImplPrint    *impl,
            XdpDbusImplLockdown *lockdown_impl)
 {
   Print *print;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   print = g_object_new (print_get_type (), NULL);
   print->impl = g_object_ref (impl);
   print->lockdown_impl = g_object_ref (lockdown_impl);
 
+  /* Impl revision was added when Print was revision 3/4 */
+  impl_revision =
+    MAX (xdp_dbus_impl_print_get_active_revision (print->impl), 3);
+  if (impl_revision >= 4)
+    active_revision = 4;
+  else
+    active_revision = 3;
+
+  /* Version (deprecated) does not reflect active revision/feature-set */
+  xdp_dbus_print_set_active_revision (XDP_DBUS_PRINT (print), active_revision);
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 4);
+  G_GNUC_END_IGNORE_DEPRECATIONS
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (print->impl), G_MAXINT);
 

--- a/src/proxy-resolver.c
+++ b/src/proxy-resolver.c
@@ -117,6 +117,8 @@ proxy_resolver_class_init (ProxyResolverClass *klass)
   object_class->dispose = proxy_resolver_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusProxyResolver, proxy_resolver)
+
 static ProxyResolver *
 proxy_resolver_new (void)
 {
@@ -125,7 +127,8 @@ proxy_resolver_new (void)
   proxy_resolver = g_object_new (proxy_resolver_get_type (), NULL);
   proxy_resolver->resolver = g_proxy_resolver_get_default ();
 
-  xdp_dbus_proxy_resolver_set_version (XDP_DBUS_PROXY_RESOLVER (proxy_resolver), 1);
+  /* Active revision and version (deprecated) are identical */
+  proxy_resolver_dbus_set_active_revision (XDP_DBUS_PROXY_RESOLVER (proxy_resolver), 1);
 
   return proxy_resolver;
 }

--- a/src/realtime.c
+++ b/src/realtime.c
@@ -298,6 +298,8 @@ load_all_properties (Realtime *realtime)
     }
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusRealtime, realtime)
+
 static Realtime *
 realtime_new (void)
 {
@@ -323,7 +325,8 @@ realtime_new (void)
   realtime = g_object_new (realtime_get_type (), NULL);
   realtime->rtkit_proxy = g_steal_pointer (&rtkit_proxy);
 
-  xdp_dbus_realtime_set_version (XDP_DBUS_REALTIME (realtime), 1);
+  /* Active revision and version (deprecated) are identical */
+  realtime_dbus_set_active_revision (XDP_DBUS_REALTIME (realtime), 1);
 
   if (realtime->rtkit_proxy)
     load_all_properties (realtime);

--- a/src/registry.c
+++ b/src/registry.c
@@ -172,6 +172,8 @@ registry_class_init (RegistryClass *klass)
   object_class->dispose = registry_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusHostRegistry, host_registry)
+
 static Registry *
 registry_new (XdpAppInfoRegistry *app_info_registry)
 {
@@ -180,7 +182,8 @@ registry_new (XdpAppInfoRegistry *app_info_registry)
   registry = g_object_new (registry_get_type (), NULL);
   registry->app_info_registry = g_object_ref (app_info_registry);
 
-  xdp_dbus_host_registry_set_version (XDP_DBUS_HOST_REGISTRY (registry), 1);
+  /* Active revision and version (deprecated) are identical */
+  host_registry_dbus_set_active_revision (XDP_DBUS_HOST_REGISTRY (registry), 1);
 
   return registry;
 }

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -45,6 +45,7 @@ struct _RemoteDesktop
 
   XdpContext *context;
   XdpDbusImplRemoteDesktop *impl;
+  uint32_t impl_revision;
 };
 
 struct _RemoteDesktopClass
@@ -157,7 +158,7 @@ remote_desktop_session_can_request_clipboard (RemoteDesktopSession *session)
   if (session->clipboard_requested)
     return FALSE;
 
-  if (xdp_dbus_impl_remote_desktop_get_version (remote_desktop->impl) < 2)
+  if (remote_desktop->impl_revision < 2)
     return FALSE;
 
   switch (session->state)
@@ -1659,11 +1660,14 @@ remote_desktop_class_init (RemoteDesktopClass *klass)
   object_class->dispose = remote_desktop_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_IMPL_GET_ACTIVE_REVISION (XdpDbusImplRemoteDesktop, remote_desktop)
+
 static RemoteDesktop *
 remote_desktop_new (XdpContext               *context,
                     XdpDbusImplRemoteDesktop *impl)
 {
   RemoteDesktop *remote_desktop;
+  uint32_t active_revision = 0;
 
   remote_desktop = g_object_new (remote_desktop_get_type (), NULL);
   remote_desktop->context = context;
@@ -1671,7 +1675,19 @@ remote_desktop_new (XdpContext               *context,
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (remote_desktop->impl), G_MAXINT);
 
+  remote_desktop->impl_revision =
+    MAX (remote_desktop_dbus_impl_get_active_revision (remote_desktop->impl), 1);
+  if (remote_desktop->impl_revision >= 2)
+    active_revision = 2;
+  else
+    active_revision = 1;
+
+  /* Version (deprecated) does not reflect active revision/feature-set */
+  xdp_dbus_remote_desktop_set_active_revision (XDP_DBUS_REMOTE_DESKTOP (remote_desktop),
+                                               active_revision);
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   xdp_dbus_remote_desktop_set_version (XDP_DBUS_REMOTE_DESKTOP (remote_desktop), 2);
+  G_GNUC_END_IGNORE_DEPRECATIONS
 
   g_object_bind_property (G_OBJECT (remote_desktop->impl), "available-device-types",
                           G_OBJECT (remote_desktop), "available-device-types",

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -1114,11 +1114,15 @@ screen_cast_class_init (ScreenCastClass *klass)
     g_quark_from_static_string ("-xdp-request-screen-cast-session");
 }
 
+XDP_DEFINE_COMPAT_DBUS_IMPL_GET_ACTIVE_REVISION (XdpDbusImplScreenCast, screen_cast)
+
 static ScreenCast *
 screen_cast_new (XdpContext            *context,
                  XdpDbusImplScreenCast *impl)
 {
   ScreenCast *screen_cast;
+  uint32_t impl_revision;
+  uint32_t active_revision = 0;
 
   screen_cast = g_object_new (screen_cast_get_type (), NULL);
   screen_cast->context = context;
@@ -1126,13 +1130,25 @@ screen_cast_new (XdpContext            *context,
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (screen_cast->impl), G_MAXINT);
 
+  impl_revision =
+    MAX (screen_cast_dbus_impl_get_active_revision (screen_cast->impl), 1);
+  if (impl_revision >= 5)
+    active_revision = 5;
+  else /* Until now both interfaces were bumped simultaneously */
+    active_revision = impl_revision;
+
+  /* Version (deprecated) does not reflect active revision/feature-set */
+  xdp_dbus_screen_cast_set_active_revision (XDP_DBUS_SCREEN_CAST (screen_cast),
+                                            active_revision);
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   xdp_dbus_screen_cast_set_version (XDP_DBUS_SCREEN_CAST (screen_cast), 5);
+  G_GNUC_END_IGNORE_DEPRECATIONS
 
   g_object_bind_property (G_OBJECT (screen_cast->impl), "available-source-types",
                           G_OBJECT (screen_cast), "available-source-types",
                           G_BINDING_SYNC_CREATE);
 
-  if (xdp_dbus_impl_screen_cast_get_version (screen_cast->impl) >= 2)
+  if (impl_revision >= 2)
     {
       g_object_bind_property (G_OBJECT (screen_cast->impl), "available-cursor-modes",
                               G_OBJECT (screen_cast), "available-cursor-modes",

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -53,7 +53,7 @@ struct _Screenshot
 
   XdpDbusImplScreenshot *impl;
   XdpDbusImplAccess *access_impl;
-  guint32 impl_version;
+  guint32 impl_revision;
 };
 
 struct _ScreenshotClass
@@ -333,7 +333,7 @@ handle_screenshot_in_thread_func (GTask *task,
   if (!g_variant_lookup (options, "modal", "b", &modal))
     modal = TRUE;
 
-  if (xdp_dbus_impl_screenshot_get_version (screenshot->impl) >= 2)
+  if (screenshot->impl_revision >= 2)
     {
       if (!interactive &&
           !check_non_interactive_permission_in_thread (screenshot,
@@ -523,11 +523,16 @@ screenshot_class_init (ScreenshotClass *klass)
   object_class->dispose = screenshot_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_IMPL_GET_ACTIVE_REVISION (XdpDbusImplScreenshot, screenshot)
+
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusScreenshot, screenshot)
+
 static Screenshot *
 screenshot_new (XdpDbusImplScreenshot *impl,
                 XdpDbusImplAccess     *access_impl)
 {
   Screenshot *screenshot;
+  uint32_t active_revision = 0;
 
   screenshot = g_object_new (screenshot_get_type (), NULL);
   screenshot->access_impl = g_object_ref (access_impl);
@@ -536,13 +541,18 @@ screenshot_new (XdpDbusImplScreenshot *impl,
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (screenshot->impl), G_MAXINT);
 
 
-  /* Before there was a version property, the version was hardcoded to 2, so
-   * make sure we retain that behaviour */
-  screenshot->impl_version =
-    MAX (xdp_dbus_impl_screenshot_get_version (screenshot->impl), 2);
+  /* Before there was a version property, it was hardcoded to 2, so make sure we
+   * retain that behaviour */
+  screenshot->impl_revision =
+    MAX (screenshot_dbus_impl_get_active_revision (screenshot->impl), 2);
+  if (screenshot->impl_revision >= 2)
+    active_revision = 2;
+  else
+    active_revision = 1;
 
-  xdp_dbus_screenshot_set_version (XDP_DBUS_SCREENSHOT (screenshot),
-                                   MIN (screenshot->impl_version, 2));
+  /* Active revision and version (deprecated) are identical */
+  screenshot_dbus_set_active_revision (XDP_DBUS_SCREENSHOT (screenshot),
+                                       active_revision);
 
   return screenshot;
 }

--- a/src/secret.c
+++ b/src/secret.c
@@ -207,6 +207,8 @@ secret_class_init (SecretClass *klass)
   object_class->dispose = secret_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusSecret, secret)
+
 static Secret *
 secret_new (XdpDbusImplSecret *impl)
 {
@@ -217,7 +219,8 @@ secret_new (XdpDbusImplSecret *impl)
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (secret->impl), G_MAXINT);
 
-  xdp_dbus_secret_set_version (XDP_DBUS_SECRET (secret), 1);
+  /* Active revision and version (deprecated) are identical */
+  secret_dbus_set_active_revision (XDP_DBUS_SECRET (secret), 1);
 
   return secret;
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -285,6 +285,8 @@ settings_class_init (SettingsClass *klass)
   object_class->finalize = settings_finalize;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusSettings, settings)
+
 static Settings *
 settings_new (GPtrArray *impls)
 {
@@ -294,7 +296,8 @@ settings_new (GPtrArray *impls)
   settings->n_impls = impls->len;
   settings->impls = (XdpDbusImplSettings **) g_ptr_array_steal (impls, NULL);
 
-  xdp_dbus_settings_set_version (XDP_DBUS_SETTINGS (settings), 2);
+  /* Active revision and version (deprecated) are identical */
+  settings_dbus_set_active_revision (XDP_DBUS_SETTINGS (settings), 2);
 
   for (size_t i = 0; i < settings->n_impls; i++)
     {

--- a/src/trash.c
+++ b/src/trash.c
@@ -796,13 +796,17 @@ trash_class_init (TrashClass *klass)
 {
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusTrash, trash)
+
 void
 init_trash (XdpContext *context)
 {
   g_autoptr(Trash) trash = NULL;
 
   trash = g_object_new (trash_get_type (), NULL);
-  xdp_dbus_trash_set_version (XDP_DBUS_TRASH (trash), 1);
+
+  /* Active revision and version (deprecated) are identical */
+  trash_dbus_set_active_revision (XDP_DBUS_TRASH (trash), 1);
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&trash)),

--- a/src/usb.c
+++ b/src/usb.c
@@ -1496,6 +1496,8 @@ xdp_usb_init (XdpUsb *self)
 {
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusUsb, usb)
+
 static XdpUsb *
 usb_new (XdpContext     *context,
          XdpDbusImplUsb *impl)
@@ -1515,7 +1517,8 @@ usb_new (XdpContext     *context,
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (usb->impl), G_MAXINT);
 
-  xdp_dbus_usb_set_version (XDP_DBUS_USB (usb), 1);
+  /* Active revision and version (deprecated) are identical */
+  usb_dbus_set_active_revision (XDP_DBUS_USB (usb), 1);
 
   usb->ids_to_devices = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                g_free, g_object_unref);

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -392,6 +392,8 @@ wallpaper_class_init (WallpaperClass *klass)
   object_class->dispose = wallpaper_dispose;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusWallpaper, wallpaper)
+
 static Wallpaper *
 wallpaper_new (XdpDbusImplWallpaper *impl,
                XdpDbusImplAccess    *access_impl)
@@ -404,7 +406,8 @@ wallpaper_new (XdpDbusImplWallpaper *impl,
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (wallpaper->impl), G_MAXINT);
 
-  xdp_dbus_wallpaper_set_version (XDP_DBUS_WALLPAPER (wallpaper), 1);
+  /* Active revision and version (deprecated) are identical */
+  wallpaper_dbus_set_active_revision (XDP_DBUS_WALLPAPER (wallpaper), 1);
 
   return wallpaper;
 }

--- a/src/xdp-background-monitor.c
+++ b/src/xdp-background-monitor.c
@@ -150,10 +150,14 @@ xdp_background_monitor_class_init (XdpBackgroundMonitorClass *klass)
   object_class->finalize = xdp_background_monitor_finalize;
 }
 
+XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION (XdpDbusBackgroundMonitor, background_monitor)
+
 static void
 xdp_background_monitor_init (XdpBackgroundMonitor *self)
 {
-  xdp_dbus_background_monitor_set_version (XDP_DBUS_BACKGROUND_MONITOR (self), 1);
+  /* Active revision and (deprecated) version are identical */
+  background_monitor_dbus_set_active_revision (XDP_DBUS_BACKGROUND_MONITOR (self),
+                                               1);
 }
 
 XdpBackgroundMonitor *

--- a/src/xdp-documents.c
+++ b/src/xdp-documents.c
@@ -88,7 +88,7 @@ xdp_register_document (const char        *uri,
   const char *permissions[5];
   g_autofree char *doc_path = NULL;
   int i;
-  int version;
+  int revision;
   gboolean handled_permissions = FALSE;
   DocumentAddFullFlags full_flags;
 
@@ -132,14 +132,14 @@ xdp_register_document (const char        *uri,
     permissions[i++] = "delete";
   permissions[i++] = NULL;
 
-  version = xdp_dbus_documents_get_version (documents);
+  revision = xdp_dbus_documents_get_active_revision (documents);
   full_flags = DOCUMENT_ADD_FLAGS_REUSE_EXISTING | DOCUMENT_ADD_FLAGS_PERSISTENT | DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP;
   if (flags & XDP_DOCUMENT_FLAG_DIRECTORY)
     full_flags |= DOCUMENT_ADD_FLAGS_DIRECTORY;
 
   if (flags & XDP_DOCUMENT_FLAG_FOR_SAVE)
     {
-      if (version >= 3)
+      if (revision >= 3)
         {
           ret = xdp_dbus_documents_call_add_named_full_sync (documents,
                                                              g_variant_new_handle (fd_in),
@@ -169,7 +169,7 @@ xdp_register_document (const char        *uri,
     }
   else
     {
-      if (version >= 2)
+      if (revision >= 2)
         {
           ret = xdp_dbus_documents_call_add_full_sync (documents,
                                                        g_variant_new_fixed_array (G_VARIANT_TYPE_HANDLE, &fd_in, 1, sizeof (gint32)),

--- a/src/xdp-request.c
+++ b/src/xdp-request.c
@@ -111,6 +111,8 @@ static void
 xdp_request_init (XdpRequest *request)
 {
   g_mutex_init (&request->mutex);
+
+  xdp_dbus_request_set_active_revision (XDP_DBUS_REQUEST (request), 1);
 }
 
 static void

--- a/src/xdp-session.c
+++ b/src/xdp-session.c
@@ -367,6 +367,8 @@ xdp_session_initable_init (GInitable     *initable,
                            session,
                            G_CONNECT_DEFAULT);
 
+  xdp_dbus_session_set_active_revision (XDP_DBUS_SESSION (session), 1);
+
   return TRUE;
 }
 

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -197,3 +197,13 @@ gboolean xdp_copy_fd_to_lists (GUnixFDList  *fd_list_src,
 
 #define XDP_EXPORT_TEST XDP_EXPORT
 #define XDP_EXPORT __attribute__((visibility("default"))) extern
+
+#define XDP_DEFINE_COMPAT_DBUS_SET_ACTIVE_REVISION(XdpDbusType, portal) \
+  static void \
+  portal ## _dbus_set_active_revision (XdpDbusType *object, guint value)\
+  {\
+    xdp_dbus_ ## portal ## _set_active_revision (object, value); \
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS \
+    xdp_dbus_ ## portal ## _set_version (object, value); \
+    G_GNUC_END_IGNORE_DEPRECATIONS \
+  }

--- a/src/xdp-utils.h
+++ b/src/xdp-utils.h
@@ -207,3 +207,15 @@ gboolean xdp_copy_fd_to_lists (GUnixFDList  *fd_list_src,
     xdp_dbus_ ## portal ## _set_version (object, value); \
     G_GNUC_END_IGNORE_DEPRECATIONS \
   }
+
+#define XDP_DEFINE_COMPAT_DBUS_IMPL_GET_ACTIVE_REVISION(XdpDbusImplType, portal) \
+  static guint \
+  portal ## _dbus_impl_get_active_revision (XdpDbusImplType *object)\
+  {\
+    guint ret = xdp_dbus_impl_ ## portal ## _get_active_revision (object); \
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS \
+    if (!ret) \
+      ret = xdp_dbus_impl_ ## portal ## _get_version (object); \
+    G_GNUC_END_IGNORE_DEPRECATIONS \
+    return ret; \
+  }

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -30,7 +30,9 @@ def required_templates():
 
 
 class TestAccount:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Account", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Account", 1)
 
     def test_basic1(self, xdg_document_portal, portals, dbus_con, xdp_app_info):

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -35,7 +35,9 @@ class TestBackground:
 
         return keyfile
 
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Background", 2)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Background", 2)
 
     def test_request_background(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -27,7 +27,9 @@ class TestCamera:
             permissions,
         )
 
-    def test_version(self, portals, dbus_con):
+    def test_check_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Camera", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Camera", 1)
 
     def test_access(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -32,7 +32,9 @@ class SessionType(Enum):
     "type", (SessionType.REMOTE_DESKTOP, SessionType.INPUT_CAPTURE)
 )
 class TestClipboard:
-    def test_version(self, portals, dbus_con, type):
+    def test_active_revision(self, portals, dbus_con, type):
+        xdp.check_active_revision(dbus_con, "Clipboard", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Clipboard", 1)
 
     def start_remote_desktop_session(self, dbus_con):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -19,7 +19,7 @@ def xdp_app_info() -> xdp.AppInfo:
 
 
 class TestDocuments:
-    def test_version(self, xdg_document_portal, dbus_con):
+    def test_active_revision(self, xdg_document_portal, dbus_con):
         documents = dbus_con.get_object(
             "org.freedesktop.portal.Documents",
             "/org/freedesktop/portal/documents",
@@ -29,6 +29,14 @@ class TestDocuments:
             documents,
             "org.freedesktop.DBus.Properties",
         )
+
+        portal_revision = properties_intf.Get(
+            "org.freedesktop.portal.Documents",
+            "active-revision",
+        )
+        assert int(portal_revision) == 5
+
+        # Check deprecated version to keep it consistent with active revision
         portal_version = properties_intf.Get(
             "org.freedesktop.portal.Documents",
             "version",

--- a/tests/test_dynamiclauncher.py
+++ b/tests/test_dynamiclauncher.py
@@ -37,9 +37,11 @@ def required_templates():
 
 
 class TestDynamicLauncher:
-    def test_version(self, portals, dbus_con):
-        """tests the version of the interface"""
+    def test_active_revision(self, portals, dbus_con):
+        """tests the active revision of the interface"""
 
+        xdp.check_active_revision(dbus_con, "DynamicLauncher", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "DynamicLauncher", 1)
 
     def test_basic(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -15,9 +15,11 @@ def required_templates():
 
 
 class TestEmail:
-    def test_version(self, portals, dbus_con):
-        """tests the version of the interface"""
+    def test_active_revision(self, portals, dbus_con):
+        """tests the active revision of the interface"""
 
+        xdp.check_active_revision(dbus_con, "Email", 4)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Email", 4)
 
     def test_basic(self, portals, dbus_con):

--- a/tests/test_filechooser.py
+++ b/tests/test_filechooser.py
@@ -37,7 +37,9 @@ def required_templates():
 
 
 class TestFilechooser:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "FileChooser", 4)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "FileChooser", 4)
 
     def test_open_file_basic(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_globalshortcuts.py
+++ b/tests/test_globalshortcuts.py
@@ -15,7 +15,9 @@ def required_templates():
 
 
 class TestGlobalShortcuts:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "GlobalShortcuts", 2)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "GlobalShortcuts", 2)
 
     def test_create_close_session(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_inhibit.py
+++ b/tests/test_inhibit.py
@@ -39,7 +39,9 @@ class TestInhibit:
             permissions,
         )
 
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Inhibit", 3)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Inhibit", 3)
 
     def test_basic(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_inputcapture.py
+++ b/tests/test_inputcapture.py
@@ -287,7 +287,9 @@ class InputcaptureSession:
 
 
 class TestInputCapture:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "InputCapture", 2)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "InputCapture", 2)
 
     @pytest.mark.parametrize(

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -15,7 +15,9 @@ def required_templates():
 
 
 class TestLocation:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Location", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Location", 1)
 
     def get_geoclue_mock(self, dbus_con_sys):

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -121,7 +121,11 @@ class TestNotification:
         )
 
     @pytest.mark.parametrize("template_params", ALL_VERSIONS_PARAMS)
-    def test_version(self, portals, dbus_con, template_params):
+    def test_active_revision(self, portals, dbus_con, template_params):
+        xdp.check_active_revision(
+            dbus_con, "Notification", template_params["notification"]["version"]
+        )
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(
             dbus_con, "Notification", template_params["notification"]["version"]
         )

--- a/tests/test_openuri.py
+++ b/tests/test_openuri.py
@@ -104,7 +104,9 @@ class TestOpenURI:
             ),
         )
 
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "OpenURI", 5)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "OpenURI", 5)
 
     def test_http1(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_permission_store.py
+++ b/tests/test_permission_store.py
@@ -85,6 +85,14 @@ class TestPermissionStore:
             permission_store,
             "org.freedesktop.DBus.Properties",
         )
+
+        portal_revision = properties_intf.Get(
+            "org.freedesktop.impl.portal.PermissionStore",
+            "active-revision",
+        )
+        assert int(portal_revision) == 2
+
+        # Check deprecated version to keep it consistent with active revision
         portal_version = properties_intf.Get(
             "org.freedesktop.impl.portal.PermissionStore",
             "version",

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -28,7 +28,9 @@ def required_templates():
 
 
 class TestPrint:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Print", 3)
+        # Check deprecated version since it can differ from active revision
         xdp.check_version(dbus_con, "Print", 4)
 
     def test_prepare_print_basic(self, portals, dbus_con, xdp_app_info):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -35,7 +35,7 @@ def required_templates():
 
 
 class TestRegistry:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
         documents = dbus_con.get_object(
             "org.freedesktop.portal.Desktop",
             "/org/freedesktop/portal/desktop",
@@ -45,6 +45,14 @@ class TestRegistry:
             documents,
             "org.freedesktop.DBus.Properties",
         )
+
+        portal_active_revision = properties_intf.Get(
+            "org.freedesktop.host.portal.Registry",
+            "active-revision",
+        )
+        assert int(portal_active_revision) == 1
+
+        # Check deprecated version to keep it consistent with active revision
         portal_version = properties_intf.Get(
             "org.freedesktop.host.portal.Registry",
             "version",

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -16,7 +16,9 @@ def required_templates():
 
 
 class TestRemoteDesktop:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "RemoteDesktop", 2)
+        # Check deprecated version since it can differ from active revision
         xdp.check_version(dbus_con, "RemoteDesktop", 2)
 
     def test_create_close_session(self, portals, dbus_con):

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -45,7 +45,9 @@ class TestScreenshot:
             [permission],
         )
 
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Screenshot", 2)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Screenshot", 2)
 
     @pytest.mark.parametrize("modal", [True, False])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -223,7 +223,9 @@ def xdg_desktop_portal_dir_default_files():
 
 
 class TestSettings:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Settings", 2)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Settings", 2)
 
     @pytest.mark.parametrize(

--- a/tests/test_trash.py
+++ b/tests/test_trash.py
@@ -12,7 +12,9 @@ from gi.repository import GLib
 
 
 class TestTrash:
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Trash", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Trash", 1)
 
     def test_trash_file_fails(self, portals, dbus_con):

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -97,7 +97,9 @@ A: idVendor={vendor}
 
         return f"/sys/devices/usb{n}"
 
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Usb", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Usb", 1)
 
     def test_create_close_session(self, portals, dbus_con):

--- a/tests/test_wallpaper.py
+++ b/tests/test_wallpaper.py
@@ -26,7 +26,9 @@ class TestWallpaper:
             [permission],
         )
 
-    def test_version(self, portals, dbus_con):
+    def test_active_revision(self, portals, dbus_con):
+        xdp.check_active_revision(dbus_con, "Wallpaper", 1)
+        # Check deprecated version to keep it consistent with active revision
         xdp.check_version(dbus_con, "Wallpaper", 1)
 
     def test_wallpaper_uri(self, portals, dbus_con, xdp_app_info):

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -238,6 +238,23 @@ def check_version(bus: dbus.Bus, portal_name: str, expected_version: int):
         assert e is None, str(e)
 
 
+def check_active_revision(bus: dbus.Bus, portal_name: str, expected_revision: int):
+    """
+    Checks that the portal_name portal action revision is equal to
+    expected_revision.
+    """
+    properties_intf = dbus.Interface(
+        get_xdp_dbus_object(bus), "org.freedesktop.DBus.Properties"
+    )
+    portal_iface_name = portal_interface_name(portal_name)
+    try:
+        portal_revision = properties_intf.Get(portal_iface_name, "active-revision")
+        assert int(portal_revision) == expected_revision
+    except dbus.exceptions.DBusException as e:
+        logger.critical(e)
+        assert e is None, str(e)
+
+
 def desktop_files_path() -> Path:
     """Returns the default path for desktop files"""
     return Path(os.environ["XDG_DATA_HOME"]) / "applications"


### PR DESCRIPTION
This is tentative to improve xdg-desktop-portal D-Bus interfaces versioning (unrelated to xdp own versioning but could help).

[RST preview](https://github.com/tytan652/xdg-desktop-portal/blob/improve-versioning/doc/versioning.rst)

We have some portals that have deprecated functionality without a proper way to "API break", some portal in a weird middle-ground (e.g. Notification) and `version` property that do not have the same API expectation across interfaces.

- Major version is on the main interface name e.g. `org.freedesktop.portal.Camera2`, the lack or number suffix means 1
- The `version` in the interface documentation is turned into `revision` and behave similarly to a minor version
- The `version` interface is replaced with `active-revision` and act as a reference of the available feature-set.
  - `version` is kept deprecated on existing interfaces, and new interfaces are expected to only provide `active-revision`
  - If the property is not set by the implementation, assume 1.
  - `active-revision` only shows the active feature-set not the documented revision.
  
It allows to keep two major version of an interface in parallel to allow a deprecation period that could be align more with Desktop environments releases since they provide implementations.

This could also detach the "API breakage" from xdg-desktop-portal own versioning.

PS: This is also meant to enable grounds forward enabling staging portals (in a specific object path) with lower stability expectation.

TODO (maybe in a separated PR ?):
- [ ] Extend tests to check more impl version/revision scenario (mainly portals with impl revision greater than 1)

TODO before merge (if it happens):
- [ ] Check every `active-revision` is properly documented as being introduced after the last version/revision of the interface last release of XDP
- [x] Check GlobalShortcuts version behavior (e.g. did #1968 get merged or not)
- [ ] Check Print (impl) revision assumption