### PR TITLE
Ensure that version is never set to an undocumented version

### DIFF
--- a/src/input-capture.c
+++ b/src/input-capture.c
@@ -1648,9 +1648,9 @@ input_capture_new (XdpContext              *context,
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (input_capture->impl), G_MAXINT);
 
   input_capture->impl_version =
-    MIN (xdp_dbus_impl_input_capture_get_version (impl), 2);
+    MAX (xdp_dbus_impl_input_capture_get_version (impl), 1);
   xdp_dbus_input_capture_set_version (XDP_DBUS_INPUT_CAPTURE (input_capture),
-                                      input_capture->impl_version);
+                                      MIN (input_capture->impl_version, 2));
 
   g_object_bind_property (G_OBJECT (input_capture->impl), "supported-capabilities",
                           G_OBJECT (input_capture), "supported-capabilities",

--- a/src/notification.c
+++ b/src/notification.c
@@ -1298,7 +1298,7 @@ notification_new (XdpContext              *context,
   notification->impl_version =
     MAX (xdp_dbus_impl_notification_get_version (notification->impl), 1);
   xdp_dbus_notification_set_version (XDP_DBUS_NOTIFICATION (notification),
-                                     notification->impl_version);
+                                     MIN (notification->impl_version, 2));
 
   g_object_bind_property (G_OBJECT (notification->impl), "supported-options",
                           G_OBJECT (notification), "supported-options",

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -528,7 +528,6 @@ screenshot_new (XdpDbusImplScreenshot *impl,
                 XdpDbusImplAccess     *access_impl)
 {
   Screenshot *screenshot;
-  g_autoptr(GVariant) version = NULL;
 
   screenshot = g_object_new (screenshot_get_type (), NULL);
   screenshot->access_impl = g_object_ref (access_impl);
@@ -539,10 +538,8 @@ screenshot_new (XdpDbusImplScreenshot *impl,
 
   /* Before there was a version property, the version was hardcoded to 2, so
    * make sure we retain that behaviour */
-  version = g_dbus_proxy_get_cached_property (G_DBUS_PROXY (screenshot->impl),
-                                              "version");
   screenshot->impl_version =
-    (version != NULL) ? g_variant_get_uint32 (version) : 2;
+    MAX (xdp_dbus_impl_screenshot_get_version (screenshot->impl), 2);
 
   xdp_dbus_screenshot_set_version (XDP_DBUS_SCREENSHOT (screenshot),
                                    screenshot->impl_version);

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -542,7 +542,7 @@ screenshot_new (XdpDbusImplScreenshot *impl,
     MAX (xdp_dbus_impl_screenshot_get_version (screenshot->impl), 2);
 
   xdp_dbus_screenshot_set_version (XDP_DBUS_SCREENSHOT (screenshot),
-                                   screenshot->impl_version);
+                                   MIN (screenshot->impl_version, 2));
 
   return screenshot;
 }


### PR DESCRIPTION
While working on #1964, I came across those two portals that could end up with version 0 if the implementation was doing something wrong.

Found that notification (and screenshot) portal allows setting a version greater than documented.

While it is the implementation that is in the wrong, portal consumer should not deal with version 0 or one that does not exist within the host xdg-desktop-portal capabilities.