### PR TITLE
input-capture: Add CreateSession missing deprecation annotation

### DIFF
--- a/data/org.freedesktop.portal.InputCapture.xml
+++ b/data/org.freedesktop.portal.InputCapture.xml
@@ -111,6 +111,7 @@
           this application may not capture events of that capability.
     -->
     <method name="CreateSession">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
       <arg type="s" name="parent_window" direction="in"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
       <arg type="a{sv}" name="options" direction="in"/>

--- a/src/input-capture.c
+++ b/src/input-capture.c
@@ -355,7 +355,9 @@ handle_create_session (XdpDbusInputCapture   *object,
                                               g_object_ref (request));
     }
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   xdp_dbus_input_capture_complete_create_session (object, invocation, request->id);
+  G_GNUC_END_IGNORE_DEPRECATIONS
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }


### PR DESCRIPTION
CreateSession was deprecated but the portal interface did not get the annotation.

I don't think there is a point to add one in the impl.