### PR TITLE
global-shortcuts: Fix versioning

### DIFF
--- a/src/global-shortcuts.c
+++ b/src/global-shortcuts.c
@@ -47,6 +47,7 @@ struct _GlobalShortcuts
 
   XdpContext *context;
   XdpDbusImplGlobalShortcuts *impl;
+  uint32_t impl_version;
 };
 
 struct _GlobalShortcutsClass
@@ -639,6 +640,8 @@ handle_configure_shortcuts (XdpDbusGlobalShortcuts *object,
   g_auto(GVariantBuilder) options_builder =
     G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
+  if (global_shortcuts->impl_version < 2)
+    return G_DBUS_METHOD_INVOCATION_UNHANDLED;
 
   if (!xdp_filter_options (arg_options, &options_builder,
                            global_shortcuts_configure_shortcuts_options,
@@ -812,7 +815,10 @@ global_shortcuts_new (XdpContext                 *context,
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (global_shortcuts->impl),
                                     G_MAXINT);
 
-  xdp_dbus_global_shortcuts_set_version (XDP_DBUS_GLOBAL_SHORTCUTS (global_shortcuts), 2);
+  global_shortcuts->impl_version =
+    MAX (xdp_dbus_impl_global_shortcuts_get_version (global_shortcuts->impl), 1);
+  xdp_dbus_global_shortcuts_set_version (XDP_DBUS_GLOBAL_SHORTCUTS (global_shortcuts),
+                                         MIN (global_shortcuts->impl_version, 2));
 
   return global_shortcuts;
 }

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -17,7 +17,7 @@ BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.GlobalShortcuts"
-VERSION = 1
+VERSION = 2
 
 
 logger = init_logger(__name__)


### PR DESCRIPTION
- Adapt portal version to the available implementation
- Early return ConfigureShortcuts if implementation is not at least version 2

This PR consider that it will be merged in the 1.21 cycle so before the next stable release since version 2 was added in 1.21 cycle.