### PR TITLE
Print portal version 4 fixups

### DIFF
--- a/data/org.freedesktop.impl.portal.Print.xml
+++ b/data/org.freedesktop.impl.portal.Print.xml
@@ -130,6 +130,11 @@
         * ``token`` (``u``)
 
           Token that was returned by a previous org.freedesktop.impl.portal.Print.PreparePrint() call.
+
+        * ``supported_output_file_formats`` (``as``)
+
+          File formats supported by the app to use for print-to-file. If not set, all formats
+          are assumed to be supported. The following values are allowed: "pdf", "ps", and "svg".
     -->
     <method name="Print">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>

--- a/src/print.c
+++ b/src/print.c
@@ -364,7 +364,7 @@ print_new (XdpDbusImplPrint    *impl,
   print->impl = g_object_ref (impl);
   print->lockdown_impl = g_object_ref (lockdown_impl);
 
-  xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 3);
+  xdp_dbus_print_set_version (XDP_DBUS_PRINT (print), 4);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (print->impl), G_MAXINT);
 

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -29,7 +29,7 @@ def required_templates():
 
 class TestPrint:
     def test_version(self, portals, dbus_con):
-        xdp.check_version(dbus_con, "Print", 3)
+        xdp.check_version(dbus_con, "Print", 4)
 
     def test_prepare_print_basic(self, portals, dbus_con, xdp_app_info):
         app_id = xdp_app_info.app_id


### PR DESCRIPTION
In the 1.21 cycle, the Print portal was bumped to version 4 but the code was not updated to match it and an option was undocumented in the impl which exist since version 3.