### PR TITLE
tests: Make XdpAppInfo types dataclass subclasses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@
 
 import tests.xdp_utils as xdp
 
-from typing import Any, Dict, Iterator, Optional, assert_never
+from typing import Any, Dict, Iterator, Optional
 from types import ModuleType
 
 import pytest
@@ -37,6 +37,12 @@ def pytest_sessionfinish(session, exitstatus):
     # tests were skipped
     if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
         session.exitstatus = 77
+
+
+def pytest_make_parametrize_id(config, val):
+    if isinstance(val, xdp.AppInfo):
+        return val.__class__.__name__
+    return None
 
 
 def ensure_environment_set() -> None:
@@ -117,11 +123,11 @@ def create_test_dirs(umockdev: Optional[UMockdev.Testbed]) -> Iterator[None]:
 
 
 @pytest.fixture
-def xdp_mocked_executables(xdp_app_info: xdp.AppInfo) -> list[xdp.ExecutableMock]:
+def xdp_mocked_executables(xdp_app_info_init: xdp.AppInfo) -> list[xdp.ExecutableMock]:
     exe = None
-    if xdp_app_info.kind == xdp.AppInfoKind.FLATPAK:
+    if isinstance(xdp_app_info_init, xdp.AppInfoFlatpak):
         exe = "flatpak"
-    elif xdp_app_info.kind == xdp.AppInfoKind.SNAP:
+    elif isinstance(xdp_app_info_init, xdp.AppInfoSnap):
         exe = "snap"
     else:
         return []
@@ -444,19 +450,21 @@ def xdp_overwrite_env() -> dict[str, str]:
 
 @pytest.fixture(
     params=[
-        xdp.AppInfoKind.HOST,
-        xdp.AppInfoKind.FLATPAK,
+        xdp.AppInfoHost(),
+        xdp.AppInfoFlatpak(),
     ]
     + (
         [
-            xdp.AppInfoKind.SNAP,
-            xdp.AppInfoKind.LINYAPS,
+            xdp.AppInfoSnap(),
+            xdp.AppInfoLinyaps(),
         ]
         if xdp.run_long_tests()
         else []
     )
 )
-def xdp_app_info(request) -> xdp.AppInfo:
+def xdp_app_info(
+    request,
+) -> xdp.AppInfo:
     """
     Default fixture which can be used to override the XdpAppInfo the portal
     frontend will discover.
@@ -464,43 +472,19 @@ def xdp_app_info(request) -> xdp.AppInfo:
     app info kinds.
     """
 
-    app_info_kind = request.param
-    app_id = "org.example.Test"
-
-    if app_info_kind == xdp.AppInfoKind.HOST:
-        return xdp.AppInfo.new_host(
-            app_id=app_id,
-        )
-
-    if app_info_kind == xdp.AppInfoKind.FLATPAK:
-        return xdp.AppInfo.new_flatpak(
-            app_id=app_id,
-        )
-
-    if app_info_kind == xdp.AppInfoKind.SNAP:
-        return xdp.AppInfo.new_snap(
-            common_id=app_id,
-            snap_name="test",
-            app_name="test",
-        )
-
-    if app_info_kind == xdp.AppInfoKind.LINYAPS:
-        return xdp.AppInfo.new_linyaps(
-            app_id=app_id,
-        )
-
-    assert_never(app_info_kind)
+    return request.param
 
 
 @pytest.fixture(autouse=True)
-def ensure_xdp_app_info_files(create_test_dirs, xdp_app_info) -> None:
-    xdp_app_info.ensure_files()
+def xdp_app_info_init(create_test_dirs, xdp_app_info) -> None:
+    xdp_app_info._initialize()
+    return xdp_app_info
 
 
 @pytest.fixture
 def xdp_env(
     xdp_overwrite_env: dict[str, str],
-    xdp_app_info: xdp.AppInfo,
+    xdp_app_info_init: xdp.AppInfo,
     xdp_bin_path: Path,
     umockdev: Optional[UMockdev.Testbed],
 ) -> dict[str, str]:
@@ -509,8 +493,8 @@ def xdp_env(
     env["XDG_CURRENT_DESKTOP"] = "test"
     env["PATH"] = xdp_bin_path.as_posix()
 
-    if xdp_app_info:
-        xdp_app_info.extend_env(env)
+    for key, val in xdp_app_info_init.get_xdp_executable_env().items():
+        env[key] = val
 
     if umockdev:
         env["UMOCKDEV_DIR"] = umockdev.get_root_dir()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@
 
 import tests.xdp_utils as xdp
 
-from typing import Any, Dict, Iterator, Optional, assert_never
+from typing import Any, Dict, Iterator, Optional
 from types import ModuleType
 
 import pytest
@@ -37,6 +37,12 @@ def pytest_sessionfinish(session, exitstatus):
     # tests were skipped
     if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
         session.exitstatus = 77
+
+
+def pytest_make_parametrize_id(config, val):
+    if isinstance(val, xdp.AppInfo):
+        return val.__class__.__name__
+    return None
 
 
 def ensure_environment_set() -> None:
@@ -117,11 +123,11 @@ def create_test_dirs(umockdev: Optional[UMockdev.Testbed]) -> Iterator[None]:
 
 
 @pytest.fixture
-def xdp_mocked_executables(xdp_app_info: xdp.AppInfo) -> list[xdp.ExecutableMock]:
+def xdp_mocked_executables(xdp_app_info_init: xdp.AppInfo) -> list[xdp.ExecutableMock]:
     exe = None
-    if xdp_app_info.kind == xdp.AppInfoKind.FLATPAK:
+    if type(xdp_app_info_init) is xdp.AppInfoFlatpak:
         exe = "flatpak"
-    elif xdp_app_info.kind == xdp.AppInfoKind.SNAP:
+    elif type(xdp_app_info_init) is xdp.AppInfoSnap:
         exe = "snap"
     else:
         return []
@@ -444,13 +450,15 @@ def xdp_overwrite_env() -> dict[str, str]:
 
 @pytest.fixture(
     params=[
-        xdp.AppInfoKind.HOST,
-        xdp.AppInfoKind.FLATPAK,
-        xdp.AppInfoKind.SNAP,
-        xdp.AppInfoKind.LINYAPS,
+        xdp.AppInfoHost(),
+        xdp.AppInfoFlatpak(),
+        xdp.AppInfoSnap(),
+        xdp.AppInfoLinyaps(),
     ]
 )
-def xdp_app_info(request) -> xdp.AppInfo:
+def xdp_app_info(
+    request,
+) -> xdp.AppInfo:
     """
     Default fixture which can be used to override the XdpAppInfo the portal
     frontend will discover.
@@ -458,43 +466,19 @@ def xdp_app_info(request) -> xdp.AppInfo:
     app info kinds.
     """
 
-    app_info_kind = request.param
-    app_id = "org.example.Test"
-
-    if app_info_kind == xdp.AppInfoKind.HOST:
-        return xdp.AppInfo.new_host(
-            app_id=app_id,
-        )
-
-    if app_info_kind == xdp.AppInfoKind.FLATPAK:
-        return xdp.AppInfo.new_flatpak(
-            app_id=app_id,
-        )
-
-    if app_info_kind == xdp.AppInfoKind.SNAP:
-        return xdp.AppInfo.new_snap(
-            common_id=app_id,
-            snap_name="test",
-            app_name="test",
-        )
-
-    if app_info_kind == xdp.AppInfoKind.LINYAPS:
-        return xdp.AppInfo.new_linyaps(
-            app_id=app_id,
-        )
-
-    assert_never(app_info_kind)
+    return request.param
 
 
 @pytest.fixture(autouse=True)
-def ensure_xdp_app_info_files(create_test_dirs, xdp_app_info) -> None:
-    xdp_app_info.ensure_files()
+def xdp_app_info_init(create_test_dirs, xdp_app_info) -> None:
+    xdp_app_info._initialize()
+    return xdp_app_info
 
 
 @pytest.fixture
 def xdp_env(
     xdp_overwrite_env: dict[str, str],
-    xdp_app_info: xdp.AppInfo,
+    xdp_app_info_init: xdp.AppInfo,
     xdp_bin_path: Path,
     umockdev: Optional[UMockdev.Testbed],
 ) -> dict[str, str]:
@@ -503,8 +487,8 @@ def xdp_env(
     env["XDG_CURRENT_DESKTOP"] = "test"
     env["PATH"] = xdp_bin_path.as_posix()
 
-    if xdp_app_info:
-        xdp_app_info.extend_env(env)
+    for key, val in xdp_app_info_init._env.items():
+        env[key] = val
 
     if umockdev:
         env["UMOCKDEV_DIR"] = umockdev.get_root_dir()

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -87,7 +87,7 @@ class TestBackground:
         assert response
 
         # Unsupported on snap and linyaps
-        if xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}:
+        if isinstance(xdp_app_info, (xdp.AppInfoSnap, xdp.AppInfoLinyaps)):
             assert response.response == 2
             assert not response.results["autostart"]
             return
@@ -106,7 +106,7 @@ class TestBackground:
         assert keyfile.get_boolean("Desktop Entry", "DBusActivatable")
 
         exec = keyfile.get_string("Desktop Entry", "Exec")
-        if xdp_app_info.kind == xdp.AppInfoKind.FLATPAK:
+        if isinstance(xdp_app_info, xdp.AppInfoFlatpak):
             assert exec == f"flatpak run --command=/bin/true {app_id} test"
         else:
             assert exec == "/bin/true test"
@@ -133,7 +133,7 @@ class TestBackground:
         assert response
 
         # Unsupported on snap and linyaps
-        if xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}:
+        if isinstance(xdp_app_info, (xdp.AppInfoSnap, xdp.AppInfoLinyaps)):
             assert response.response == 2
             assert not response.results["autostart"]
             return

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -89,7 +89,7 @@ class TestBackground:
         assert response.results["background"]
 
         # Unsupported on snap and linyaps
-        if xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}:
+        if type(xdp_app_info) in {xdp.AppInfoSnap, xdp.AppInfoLinyaps}:
             assert not response.results["autostart"]
             return
 
@@ -104,7 +104,7 @@ class TestBackground:
         assert keyfile.get_boolean("Desktop Entry", "DBusActivatable")
 
         exec = keyfile.get_string("Desktop Entry", "Exec")
-        if xdp_app_info.kind == xdp.AppInfoKind.FLATPAK:
+        if type(xdp_app_info) is xdp.AppInfoFlatpak:
             assert exec == f"flatpak run --command=/bin/true {app_id} test"
         else:
             assert exec == "/bin/true test"
@@ -133,7 +133,7 @@ class TestBackground:
         assert response.results["background"]
 
         # Unsupported on snap and linyaps
-        if xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}:
+        if type(xdp_app_info) in {xdp.AppInfoSnap, xdp.AppInfoLinyaps}:
             assert not response.results["autostart"]
             return
 

--- a/tests/test_document_fuse.py
+++ b/tests/test_document_fuse.py
@@ -18,9 +18,7 @@ from gi.repository import Gio, GLib
 
 @pytest.fixture
 def xdp_app_info() -> xdp.AppInfo:
-    return xdp.AppInfo.new_host(
-        app_id="",
-    )
+    return xdp.AppInfoHost(app_id="")
 
 
 def filename_to_ay(filename):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -13,9 +13,7 @@ import os
 
 @pytest.fixture
 def xdp_app_info() -> xdp.AppInfo:
-    return xdp.AppInfo.new_host(
-        app_id="",
-    )
+    return xdp.AppInfoHost(app_id="")
 
 
 class TestDocuments:

--- a/tests/test_dynamiclauncher.py
+++ b/tests/test_dynamiclauncher.py
@@ -94,9 +94,9 @@ class TestDynamicLauncher:
         except dbus.exceptions.DBusException as e:
             # Unsupported on snap and linyaps
             assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
-            assert xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}
+            assert isinstance(xdp_app_info, (xdp.AppInfoSnap, xdp.AppInfoLinyaps))
             return
-        assert xdp_app_info.kind not in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}
+        assert not isinstance(xdp_app_info, (xdp.AppInfoSnap, xdp.AppInfoLinyaps))
 
         file = Path(os.environ["XDG_DATA_HOME"]) / "applications" / desktop_file_name
         assert file.exists()

--- a/tests/test_dynamiclauncher.py
+++ b/tests/test_dynamiclauncher.py
@@ -94,9 +94,9 @@ class TestDynamicLauncher:
         except dbus.exceptions.DBusException as e:
             # Unsupported on snap and linyaps
             assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
-            assert xdp_app_info.kind in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}
+            assert type(xdp_app_info) in {xdp.AppInfoSnap, xdp.AppInfoLinyaps}
             return
-        assert xdp_app_info.kind not in {xdp.AppInfoKind.SNAP, xdp.AppInfoKind.LINYAPS}
+        assert type(xdp_app_info) not in {xdp.AppInfoSnap, xdp.AppInfoLinyaps}
 
         file = Path(os.environ["XDG_DATA_HOME"]) / "applications" / desktop_file_name
         assert file.exists()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -24,9 +24,7 @@ def xdg_data_home_files():
 
 @pytest.fixture
 def xdp_app_info() -> xdp.AppInfo:
-    return xdp.AppInfo.new_host(
-        app_id="org.example.WrongAppId",
-    )
+    return xdp.AppInfoHost(app_id="org.example.WrongAppId")
 
 
 @pytest.fixture

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -27,21 +27,15 @@ def usb_queries() -> str | None:
 
 # Supported on host and flatpak
 # Host apps get access to all usb devices. The query has no effect.
-@pytest.fixture(params=[xdp.AppInfoKind.HOST, xdp.AppInfoKind.FLATPAK])
+@pytest.fixture(params=["AppInfoHost", "AppInfoFlatpak"])
 def xdp_app_info(request, usb_queries) -> xdp.AppInfo:
     app_info_kind = request.param
-    app_id = "org.example.Test"
 
-    if app_info_kind == xdp.AppInfoKind.HOST:
-        return xdp.AppInfo.new_host(
-            app_id=app_id,
-        )
+    if app_info_kind == "AppInfoHost":
+        return xdp.AppInfoHost()
 
-    if app_info_kind == xdp.AppInfoKind.FLATPAK:
-        return xdp.AppInfo.new_flatpak(
-            app_id=app_id,
-            usb_queries=usb_queries,
-        )
+    if app_info_kind == "AppInfoFlatpak":
+        return xdp.AppInfoFlatpak(usb_queries=usb_queries)
 
     assert_never(app_info_kind)
 
@@ -169,7 +163,7 @@ A: idVendor={vendor}
 
         # If the app is not running on the host, make sure an empty usb_query
         # results in no devices being available
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and not isinstance(xdp_app_info, xdp.AppInfoHost):
             xdp.wait(300)
             assert not device_events_signal_received
             assert devices_received == 0
@@ -216,7 +210,7 @@ A: idVendor={vendor}
             "C767F1C714174C309255F70E4A7B2EE2",
         )
 
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and not isinstance(xdp_app_info, xdp.AppInfoHost):
             xdp.wait(300)
             assert not device_events_signal_received
             assert devices_received == 0
@@ -281,7 +275,7 @@ A: idVendor={vendor}
 
         usb_intf.connect_to_signal("DeviceEvents", cb_device_events)
 
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and not isinstance(xdp_app_info, xdp.AppInfoHost):
             xdp.wait(300)
             assert device_events_signal_count == 0
             assert devices_received == 0
@@ -293,7 +287,7 @@ A: idVendor={vendor}
 
         umockdev.remove_device(dev_path)
 
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and not isinstance(xdp_app_info, xdp.AppInfoHost):
             xdp.wait(300)
             assert device_events_signal_count == 0
             assert devices_received == 0

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -27,21 +27,15 @@ def usb_queries() -> str | None:
 
 # Supported on host and flatpak
 # Host apps get access to all usb devices. The query has no effect.
-@pytest.fixture(params=[xdp.AppInfoKind.HOST, xdp.AppInfoKind.FLATPAK])
+@pytest.fixture(params=["AppInfoHost", "AppInfoFlatpak"])
 def xdp_app_info(request, usb_queries) -> xdp.AppInfo:
     app_info_kind = request.param
-    app_id = "org.example.Test"
 
-    if app_info_kind == xdp.AppInfoKind.HOST:
-        return xdp.AppInfo.new_host(
-            app_id=app_id,
-        )
+    if app_info_kind == "AppInfoHost":
+        return xdp.AppInfoHost()
 
-    if app_info_kind == xdp.AppInfoKind.FLATPAK:
-        return xdp.AppInfo.new_flatpak(
-            app_id=app_id,
-            usb_queries=usb_queries,
-        )
+    if app_info_kind == "AppInfoFlatpak":
+        return xdp.AppInfoFlatpak(usb_queries=usb_queries)
 
     assert_never(app_info_kind)
 
@@ -169,7 +163,7 @@ A: idVendor={vendor}
 
         # If the app is not running on the host, make sure an empty usb_query
         # results in no devices being available
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and type(xdp_app_info) is not xdp.AppInfoHost:
             xdp.wait(300)
             assert not device_events_signal_received
             assert devices_received == 0
@@ -216,7 +210,7 @@ A: idVendor={vendor}
             "C767F1C714174C309255F70E4A7B2EE2",
         )
 
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and type(xdp_app_info) is not xdp.AppInfoHost:
             xdp.wait(300)
             assert not device_events_signal_received
             assert devices_received == 0
@@ -281,7 +275,7 @@ A: idVendor={vendor}
 
         usb_intf.connect_to_signal("DeviceEvents", cb_device_events)
 
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and type(xdp_app_info) is not xdp.AppInfoHost:
             xdp.wait(300)
             assert device_events_signal_count == 0
             assert devices_received == 0
@@ -293,7 +287,7 @@ A: idVendor={vendor}
 
         umockdev.remove_device(dev_path)
 
-        if usb_queries is None and xdp_app_info.kind != xdp.AppInfoKind.HOST:
+        if usb_queries is None and type(xdp_app_info) is not xdp.AppInfoHost:
             xdp.wait(300)
             assert device_events_signal_count == 0
             assert devices_received == 0

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -8,7 +8,7 @@ from itertools import count
 from typing import Any, Dict, Optional, NamedTuple, Callable, List
 from pathlib import Path
 from enum import Enum, IntEnum
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from urllib.parse import unquote, urlparse
 
 import os
@@ -243,91 +243,81 @@ def desktop_files_path() -> Path:
     return Path(os.environ["XDG_DATA_HOME"]) / "applications"
 
 
-class AppInfoKind(Enum):
-    HOST = 1
-    FLATPAK = 2
-    SNAP = 3
-    LINYAPS = 4
-
-
 @dataclass
 class AppInfo:
     """
-    Interacts with conftest.py via ensure_files and extend_env to make the
-    portal frontend discover the requested XdpAppInfo for incoming connections.
-
     Testing code can use this class to construct a specific XdpAppInfo for the
     xdp_app_info fixture.
+
+    To make it possible to collect AppInfo instances in pytest, construction
+    only fills out the data. The conftest.py file calls _initialize() to
+    properly initialize everything that's needed at run time, and uses some
+    properties to modify how it creates the harness.
     """
 
-    kind: AppInfoKind
     app_id: str
-    desktop_file: str
-    env: dict[str, str] = field(default_factory=dict)
-    files: dict[Path, bytes] = field(default_factory=dict)
+    desktop_file: str | None
 
-    def ensure_files(self) -> None:
-        for path, content in self.files.items():
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(content)
+    def __init__(self):
+        self._env = {}
 
-    def extend_env(self, env: dict[str, str]) -> None:
-        for key, val in self.env.items():
-            env[key] = val
+    def get_xdp_executable_env(self):
+        return self._env
 
     def gapp_info(self) -> GioUnix.DesktopAppInfo:
+        assert self.desktop_file
         desktop_file_path = desktop_files_path() / self.desktop_file
         if not os.path.exists(desktop_file_path):
             return None
 
         return GioUnix.DesktopAppInfo.new_from_filename(str(desktop_file_path))
 
-    @classmethod
-    def new_host(
-        cls,
-        app_id: str,
-        desktop_entry: bytes | None = None,
-    ):
-        kind = AppInfoKind.HOST
-        desktop_file = f"{app_id}.desktop"
-        env = {
+
+@dataclass
+class AppInfoHost(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+
+    def __post_init__(self):
+        if not self.desktop_file:
+            self.desktop_file = f"{self.app_id}.desktop"
+
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "host",
-            "XDG_DESKTOP_PORTAL_TEST_HOST_APPID": app_id,
+            "XDG_DESKTOP_PORTAL_TEST_HOST_APPID": self.app_id,
         }
-        files = {}
 
-        if desktop_entry:
-            files[desktop_files_path() / desktop_file] = desktop_entry
+    def _initialize(self):
+        assert self.desktop_file
 
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
-        )
+        if self.desktop_entry:
+            path = desktop_files_path() / self.desktop_file
+            path.write_bytes(self.desktop_entry)
 
-    @classmethod
-    def new_flatpak(
-        cls,
-        app_id: str,
-        instance_id: str | None = None,
-        usb_queries: str | None = None,
-        desktop_entry: bytes | None = None,
-        metadata: bytes | None = None,
-    ):
-        kind = AppInfoKind.FLATPAK
-        desktop_file = f"{app_id}.desktop"
-        env = {
+
+@dataclass
+class AppInfoFlatpak(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+    instance_id: str | None = None
+    usb_queries: str | None = None
+    metadata: bytes | None = None
+
+    def __post_init__(self):
+        if not self.desktop_file:
+            self.desktop_file = f"{self.app_id}.desktop"
+
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "flatpak",
         }
-        files = {}
 
-        if not instance_id:
-            instance_id = "1234567890"
+        if not self.instance_id:
+            self.instance_id = "1234567890"
 
-        if not desktop_entry:
-            desktop_entry = b"""
+        if not self.desktop_entry:
+            self.desktop_entry = b"""
 [Desktop Entry]
 Version=1.0
 Name=Example App
@@ -335,126 +325,125 @@ Exec=true %u
 Type=Application
 """
 
-        files[desktop_files_path() / desktop_file] = desktop_entry
-
-        if not metadata:
+        if not self.metadata:
             metadata_str = f"""
 [Application]
-name={app_id}
+name={self.app_id}
 runtime=org.freedesktop.Platform/x86_64/23.08
 sdk=org.freedesktop.Sdk/x86_64/23.08
-command={app_id}
+command={self.app_id}
 
 [Instance]
-instance-id={instance_id}
+instance-id={self.instance_id}
 
 [Context]
 shared=network;ipc;
 sockets=x11;wayland;pulseaudio;fallback-x11;
 devices=dri;
 """
-            metadata = metadata_str.encode("utf8")
+            self.metadata = metadata_str.encode("utf8")
 
-        if usb_queries:
+        if self.usb_queries:
             metadata_usb_str = f"""
 [USB Devices]
-enumerable-devices={usb_queries}
+enumerable-devices={self.usb_queries}
 """
-            metadata += metadata_usb_str.encode("utf8")
+            self.metadata += metadata_usb_str.encode("utf8")
+
+    def _initialize(self):
+        assert self.desktop_file
+        assert self.desktop_entry
+        assert self.metadata
+
+        path = desktop_files_path() / self.desktop_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.desktop_entry)
 
         metadata_path = Path(os.environ["TMPDIR"]) / "flatpak-metadata"
+        metadata_path.write_bytes(self.metadata)
 
-        files[metadata_path] = metadata
-        env["XDG_DESKTOP_PORTAL_TEST_FLATPAK_METADATA"] = (
+        self._env["XDG_DESKTOP_PORTAL_TEST_FLATPAK_METADATA"] = (
             metadata_path.absolute().as_posix()
         )
 
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
-        )
 
-    @classmethod
-    def new_snap(
-        cls,
-        common_id: str,
-        snap_name: str,
-        app_name: str,
-        desktop_entry: bytes | None = None,
-        metadata: bytes | None = None,
-    ):
-        kind = AppInfoKind.SNAP
-        app_id = f"snap.{snap_name}"
-        desktop_file = f"{snap_name}_{app_name}.desktop"
-        env = {
+@dataclass
+class AppInfoSnap(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+    common_id: str = "org.example.Test"
+    snap_name: str = "test"
+    app_name: str = "test"
+    metadata: bytes | None = None
+
+    def __post_init__(self):
+        self.app_id = f"snap.{self.snap_name}"
+        self.desktop_file = f"{self.snap_name}_{self.app_name}.desktop"
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "snap",
         }
-        files = {}
 
-        if not desktop_entry:
+        if not self.desktop_entry:
             desktop_entry_str = f"""
 [Desktop Entry]
 Version=1.0
 Name=Example App
 Exec=true %u
 Type=Application
-X-SnapInstanceName={snap_name}
-X-SnapAppName={app_name}
+X-SnapInstanceName={self.snap_name}
+X-SnapAppName={self.app_name}
 """
-            desktop_entry = desktop_entry_str.encode("UTF-8")
+            self.desktop_entry = desktop_entry_str.encode("UTF-8")
 
-        files[desktop_files_path() / desktop_file] = desktop_entry
-
-        if not metadata:
+        if not self.metadata:
             metadata_str = f"""
 [Snap Info]
-InstanceName={snap_name}
-AppName={app_name}
-CommonID={common_id}
-DesktopFile={desktop_file}
+InstanceName={self.snap_name}
+AppName={self.app_name}
+CommonID={self.common_id}
+DesktopFile={self.desktop_file}
 """
-            metadata = metadata_str.encode("UTF-8")
+            self.metadata = metadata_str.encode("UTF-8")
+
+    def _initialize(self):
+        assert self.desktop_file
+        assert self.desktop_entry
+        assert self.metadata
+
+        path = desktop_files_path() / self.desktop_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.desktop_entry)
 
         metadata_path = Path(os.environ["TMPDIR"]) / "snap-metadata"
+        metadata_path.write_bytes(self.metadata)
 
-        files[metadata_path] = metadata
-        env["XDG_DESKTOP_PORTAL_TEST_SNAP_METADATA"] = (
+        self._env["XDG_DESKTOP_PORTAL_TEST_SNAP_METADATA"] = (
             metadata_path.absolute().as_posix()
         )
 
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
-        )
 
-    @classmethod
-    def new_linyaps(
-        cls,
-        app_id: str,
-        instance_id: str | None = None,
-        desktop_entry: bytes | None = None,
-        metadata: bytes | None = None,
-    ):
-        kind = AppInfoKind.LINYAPS
-        desktop_file = f"{app_id}.desktop"
-        env = {
+@dataclass
+class AppInfoLinyaps(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+    instance_id: str | None = None
+    metadata: bytes | None = None
+
+    def __post_init__(self):
+        self.desktop_file = f"{self.app_id}.desktop"
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "linyaps",
         }
-        files = {}
 
-        if not instance_id:
-            instance_id = (
+        if not self.instance_id:
+            self.instance_id = (
                 "278575aac695dafe08974feb55c84bba69e862216e980b7ede28c5844e93682c"
             )
 
-        if not desktop_entry:
-            desktop_entry = b"""
+        if not self.desktop_entry:
+            self.desktop_entry = b"""
 [Desktop Entry]
 Version=1.0
 Name=Example App
@@ -462,37 +451,36 @@ Exec=true %u
 Type=Application
 """
 
-        files[desktop_files_path() / desktop_file] = desktop_entry
-
-        if not metadata:
+        if not self.metadata:
             metadata_str = f"""
 [General]
 Linyaps-version=1.10.0
 
 [Application]
-Id={app_id}
+Id={self.app_id}
 
 [Instance]
-Id={instance_id}
+Id={self.instance_id}
 
 [Context]
 Network=shared
 """
-            metadata = metadata_str.encode("utf8")
+            self.metadata = metadata_str.encode("utf8")
+
+    def _initialize(self):
+        assert self.desktop_file
+        assert self.desktop_entry
+        assert self.metadata
+
+        path = desktop_files_path() / self.desktop_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.desktop_entry)
 
         metadata_path = Path(os.environ["TMPDIR"]) / "linyaps-metadata"
+        metadata_path.write_bytes(self.metadata)
 
-        files[metadata_path] = metadata
-        env["XDG_DESKTOP_PORTAL_TEST_LINYAPS_METADATA"] = (
+        self._env["XDG_DESKTOP_PORTAL_TEST_LINYAPS_METADATA"] = (
             metadata_path.absolute().as_posix()
-        )
-
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
         )
 
 

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -8,7 +8,7 @@ from itertools import count
 from typing import Any, Dict, Optional, NamedTuple, Callable, List
 from pathlib import Path
 from enum import Enum, IntEnum
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from urllib.parse import unquote, urlparse
 
 import os
@@ -243,91 +243,78 @@ def desktop_files_path() -> Path:
     return Path(os.environ["XDG_DATA_HOME"]) / "applications"
 
 
-class AppInfoKind(Enum):
-    HOST = 1
-    FLATPAK = 2
-    SNAP = 3
-    LINYAPS = 4
-
-
 @dataclass
 class AppInfo:
     """
-    Interacts with conftest.py via ensure_files and extend_env to make the
-    portal frontend discover the requested XdpAppInfo for incoming connections.
-
     Testing code can use this class to construct a specific XdpAppInfo for the
     xdp_app_info fixture.
+
+    The make it possible to collect AppInfo instances in pytest, construction
+    only fills out the data. The conftest.py file calls _initialize() to
+    properly initialize everything that's needed at run time, and uses some
+    properties to modify how it creates the harness.
     """
 
-    kind: AppInfoKind
     app_id: str
-    desktop_file: str
-    env: dict[str, str] = field(default_factory=dict)
-    files: dict[Path, bytes] = field(default_factory=dict)
+    desktop_file: str | None
 
-    def ensure_files(self) -> None:
-        for path, content in self.files.items():
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(content)
-
-    def extend_env(self, env: dict[str, str]) -> None:
-        for key, val in self.env.items():
-            env[key] = val
+    def __init__(self):
+        self._env = {}
 
     def gapp_info(self) -> GioUnix.DesktopAppInfo:
+        assert self.desktop_file
         desktop_file_path = desktop_files_path() / self.desktop_file
         if not os.path.exists(desktop_file_path):
             return None
 
         return GioUnix.DesktopAppInfo.new_from_filename(str(desktop_file_path))
 
-    @classmethod
-    def new_host(
-        cls,
-        app_id: str,
-        desktop_entry: bytes | None = None,
-    ):
-        kind = AppInfoKind.HOST
-        desktop_file = f"{app_id}.desktop"
-        env = {
+
+@dataclass
+class AppInfoHost(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+
+    def __post_init__(self):
+        if not self.desktop_file:
+            self.desktop_file = f"{self.app_id}.desktop"
+
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "host",
-            "XDG_DESKTOP_PORTAL_TEST_HOST_APPID": app_id,
+            "XDG_DESKTOP_PORTAL_TEST_HOST_APPID": self.app_id,
         }
-        files = {}
 
-        if desktop_entry:
-            files[desktop_files_path() / desktop_file] = desktop_entry
+    def _initialize(self):
+        assert self.desktop_file
 
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
-        )
+        if self.desktop_entry:
+            path = desktop_files_path() / self.desktop_file
+            path.write_bytes(self.desktop_entry)
 
-    @classmethod
-    def new_flatpak(
-        cls,
-        app_id: str,
-        instance_id: str | None = None,
-        usb_queries: str | None = None,
-        desktop_entry: bytes | None = None,
-        metadata: bytes | None = None,
-    ):
-        kind = AppInfoKind.FLATPAK
-        desktop_file = f"{app_id}.desktop"
-        env = {
+
+@dataclass
+class AppInfoFlatpak(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+    instance_id: str | None = None
+    usb_queries: str | None = None
+    metadata: bytes | None = None
+
+    def __post_init__(self):
+        if not self.desktop_file:
+            self.desktop_file = f"{self.app_id}.desktop"
+
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "flatpak",
         }
-        files = {}
 
-        if not instance_id:
-            instance_id = "1234567890"
+        if not self.instance_id:
+            self.instance_id = "1234567890"
 
-        if not desktop_entry:
-            desktop_entry = b"""
+        if not self.desktop_entry:
+            self.desktop_entry = b"""
 [Desktop Entry]
 Version=1.0
 Name=Example App
@@ -335,126 +322,125 @@ Exec=true %u
 Type=Application
 """
 
-        files[desktop_files_path() / desktop_file] = desktop_entry
-
-        if not metadata:
+        if not self.metadata:
             metadata_str = f"""
 [Application]
-name={app_id}
+name={self.app_id}
 runtime=org.freedesktop.Platform/x86_64/23.08
 sdk=org.freedesktop.Sdk/x86_64/23.08
-command={app_id}
+command={self.app_id}
 
 [Instance]
-instance-id={instance_id}
+instance-id={self.instance_id}
 
 [Context]
 shared=network;ipc;
 sockets=x11;wayland;pulseaudio;fallback-x11;
 devices=dri;
 """
-            metadata = metadata_str.encode("utf8")
+            self.metadata = metadata_str.encode("utf8")
 
-        if usb_queries:
+        if self.usb_queries:
             metadata_usb_str = f"""
 [USB Devices]
-enumerable-devices={usb_queries}
+enumerable-devices={self.usb_queries}
 """
-            metadata += metadata_usb_str.encode("utf8")
+            self.metadata += metadata_usb_str.encode("utf8")
+
+    def _initialize(self):
+        assert self.desktop_file
+        assert self.desktop_entry
+        assert self.metadata
+
+        path = desktop_files_path() / self.desktop_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.desktop_entry)
 
         metadata_path = Path(os.environ["TMPDIR"]) / "flatpak-metadata"
+        metadata_path.write_bytes(self.metadata)
 
-        files[metadata_path] = metadata
-        env["XDG_DESKTOP_PORTAL_TEST_FLATPAK_METADATA"] = (
+        self._env["XDG_DESKTOP_PORTAL_TEST_FLATPAK_METADATA"] = (
             metadata_path.absolute().as_posix()
         )
 
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
-        )
 
-    @classmethod
-    def new_snap(
-        cls,
-        common_id: str,
-        snap_name: str,
-        app_name: str,
-        desktop_entry: bytes | None = None,
-        metadata: bytes | None = None,
-    ):
-        kind = AppInfoKind.SNAP
-        app_id = f"snap.{snap_name}"
-        desktop_file = f"{snap_name}_{app_name}.desktop"
-        env = {
+@dataclass
+class AppInfoSnap(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+    common_id: str = "org.example.Test"
+    snap_name: str = "test"
+    app_name: str = "test"
+    metadata: bytes | None = None
+
+    def __post_init__(self):
+        self.app_id = f"snap.{self.snap_name}"
+        self.desktop_file = f"{self.snap_name}_{self.app_name}.desktop"
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "snap",
         }
-        files = {}
 
-        if not desktop_entry:
+        if not self.desktop_entry:
             desktop_entry_str = f"""
 [Desktop Entry]
 Version=1.0
 Name=Example App
 Exec=true %u
 Type=Application
-X-SnapInstanceName={snap_name}
-X-SnapAppName={app_name}
+X-SnapInstanceName={self.snap_name}
+X-SnapAppName={self.app_name}
 """
-            desktop_entry = desktop_entry_str.encode("UTF-8")
+            self.desktop_entry = desktop_entry_str.encode("UTF-8")
 
-        files[desktop_files_path() / desktop_file] = desktop_entry
-
-        if not metadata:
+        if not self.metadata:
             metadata_str = f"""
 [Snap Info]
-InstanceName={snap_name}
-AppName={app_name}
-CommonID={common_id}
-DesktopFile={desktop_file}
+InstanceName={self.snap_name}
+AppName={self.app_name}
+CommonID={self.common_id}
+DesktopFile={self.desktop_file}
 """
-            metadata = metadata_str.encode("UTF-8")
+            self.metadata = metadata_str.encode("UTF-8")
+
+    def _initialize(self):
+        assert self.desktop_file
+        assert self.desktop_entry
+        assert self.metadata
+
+        path = desktop_files_path() / self.desktop_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.desktop_entry)
 
         metadata_path = Path(os.environ["TMPDIR"]) / "snap-metadata"
+        metadata_path.write_bytes(self.metadata)
 
-        files[metadata_path] = metadata
-        env["XDG_DESKTOP_PORTAL_TEST_SNAP_METADATA"] = (
+        self._env["XDG_DESKTOP_PORTAL_TEST_SNAP_METADATA"] = (
             metadata_path.absolute().as_posix()
         )
 
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
-        )
 
-    @classmethod
-    def new_linyaps(
-        cls,
-        app_id: str,
-        instance_id: str | None = None,
-        desktop_entry: bytes | None = None,
-        metadata: bytes | None = None,
-    ):
-        kind = AppInfoKind.LINYAPS
-        desktop_file = f"{app_id}.desktop"
-        env = {
+@dataclass
+class AppInfoLinyaps(AppInfo):
+    app_id: str = "org.example.Test"
+    desktop_file: str | None = None
+    desktop_entry: bytes | None = None
+    instance_id: str | None = None
+    metadata: bytes | None = None
+
+    def __post_init__(self):
+        self.desktop_file = f"{self.app_id}.desktop"
+        self._env = {
             "XDG_DESKTOP_PORTAL_TEST_APP_INFO_KIND": "linyaps",
         }
-        files = {}
 
-        if not instance_id:
-            instance_id = (
+        if not self.instance_id:
+            self.instance_id = (
                 "278575aac695dafe08974feb55c84bba69e862216e980b7ede28c5844e93682c"
             )
 
-        if not desktop_entry:
-            desktop_entry = b"""
+        if not self.desktop_entry:
+            self.desktop_entry = b"""
 [Desktop Entry]
 Version=1.0
 Name=Example App
@@ -462,37 +448,36 @@ Exec=true %u
 Type=Application
 """
 
-        files[desktop_files_path() / desktop_file] = desktop_entry
-
-        if not metadata:
+        if not self.metadata:
             metadata_str = f"""
 [General]
 Linyaps-version=1.10.0
 
 [Application]
-Id={app_id}
+Id={self.app_id}
 
 [Instance]
-Id={instance_id}
+Id={self.instance_id}
 
 [Context]
 Network=shared
 """
-            metadata = metadata_str.encode("utf8")
+            self.metadata = metadata_str.encode("utf8")
+
+    def _initialize(self):
+        assert self.desktop_file
+        assert self.desktop_entry
+        assert self.metadata
+
+        path = desktop_files_path() / self.desktop_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.desktop_entry)
 
         metadata_path = Path(os.environ["TMPDIR"]) / "linyaps-metadata"
+        metadata_path.write_bytes(self.metadata)
 
-        files[metadata_path] = metadata
-        env["XDG_DESKTOP_PORTAL_TEST_LINYAPS_METADATA"] = (
+        self._env["XDG_DESKTOP_PORTAL_TEST_LINYAPS_METADATA"] = (
             metadata_path.absolute().as_posix()
-        )
-
-        return cls(
-            kind=kind,
-            app_id=app_id,
-            desktop_file=desktop_file,
-            env=env,
-            files=files,
         )
 
 


### PR DESCRIPTION
```
This has a few benefits:

* We can construct them at pytest test collection time
* All the fields are clearly spelled out
* We can do a single initialize call to create all the runtime things the app info needs
```

Something I wanted to do for some time now, and will be useful for the Entitlement tests for example.