### PR TITLE
Screenshot: Add target selection API

### DIFF
--- a/data/org.freedesktop.impl.portal.Screenshot.xml
+++ b/data/org.freedesktop.impl.portal.Screenshot.xml
@@ -27,7 +27,7 @@
 
       This screenshot portal lets sandboxed applications request a screenshot.
 
-      This documentation describes version 2 of this interface.
+      This documentation describes version 3 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.Screenshot">
     <!--
@@ -51,6 +51,20 @@
 
           Hint whether the dialog should offer customization before taking a screenshot.
           Defaults to no.
+
+        * ``target`` (``u``)
+
+          The screenshot target. It is a single target value, not a bitmask, and
+          must be one of the targets advertised in AvailableTargets. If this option
+          is omitted, the backend should preserve the previous Screenshot
+          behavior. Available targets are:
+
+          - ``1``: Screen: The entire screen.
+          - ``2``: Window: A window selected by the user.
+          - ``4``: Area: An area selected by the user.
+          - ``8``: Active Window: The currently active window.
+
+          This option was added in version 3 of this interface.
 
         * ``permission_store_checked`` (``b``)
 
@@ -104,6 +118,19 @@
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
 
+    <!--
+        AvailableTargets:
+
+        A bitmask of available screenshot targets. Available targets are:
+
+        - ``1``: Screen: The entire screen.
+        - ``2``: Window: A window selected by the user.
+        - ``4``: Area: An area selected by the user.
+        - ``8``: Active Window: The currently active window.
+
+        This property was added in version 3 of this interface.
+    -->
+    <property name="AvailableTargets" type="u" access="read"/>
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.portal.Screenshot.xml
+++ b/data/org.freedesktop.portal.Screenshot.xml
@@ -31,7 +31,7 @@
       may involve adding it to the :ref:`Documents
       portal<org.freedesktop.portal.Documents>`).
 
-      This documentation describes **version 2** of this interface.
+      This documentation describes **version 3** of this interface.
   -->
   <interface name="org.freedesktop.portal.Screenshot">
     <!--
@@ -58,6 +58,21 @@
 
           Hint whether the dialog should offer customization before taking a screenshot.
           Default is no.  **Since version 2.**
+
+        * ``target`` (``u``)
+
+          The screenshot target. It is a single target value, not a bitmask, and
+          must be one of the targets advertised in
+          :ref:`org.freedesktop.portal.Screenshot:AvailableTargets`. If this
+          option is omitted, the portal preserves the previous Screenshot
+          behavior. Available targets are:
+
+          - ``1``: Screen: The entire screen.
+          - ``2``: Window: A window selected by the user.
+          - ``4``: Area: An area selected by the user.
+          - ``8``: Active Window: The currently active window.
+
+          This option was added in version 3 of this interface.
 
         The following results get returned via the :ref:`org.freedesktop.portal.Request::Response`
         signal:
@@ -100,6 +115,19 @@
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
     </method>
+    <!--
+        AvailableTargets:
+
+        A bitmask of available screenshot targets. Available targets are:
+
+        - ``1``: Screen: The entire screen.
+        - ``2``: Window: A window selected by the user.
+        - ``4``: Area: An area selected by the user.
+        - ``8``: Active Window: The currently active window.
+
+        This property was added in version 3 of this interface.
+    -->
+    <property name="AvailableTargets" type="u" access="read"/>
     <property name="version" type="u" access="read"/>
   </interface>
 </node>

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -26,6 +26,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -43,6 +44,14 @@
 #include "xdp-portal-config.h"
 #include "xdp-request.h"
 #include "xdp-utils.h"
+
+typedef enum
+{
+  SCREENSHOT_TARGET_SCREEN = 1u << 0,
+  SCREENSHOT_TARGET_WINDOW = 1u << 1,
+  SCREENSHOT_TARGET_AREA = 1u << 2,
+  SCREENSHOT_TARGET_ACTIVE_WINDOW = 1u << 3,
+} ScreenshotTarget;
 
 typedef struct _Screenshot Screenshot;
 typedef struct _ScreenshotClass ScreenshotClass;
@@ -185,9 +194,52 @@ screenshot_done (GObject *source,
   g_task_run_in_thread (task, send_response_in_thread_func);
 }
 
-static XdpOptionKey screenshot_options[] = {
+static gboolean
+validate_screenshot_target (Screenshot *screenshot,
+                            uint32_t    target,
+                            GError    **error)
+{
+  uint32_t available_targets;
+
+  switch (target)
+    {
+    case SCREENSHOT_TARGET_SCREEN:
+    case SCREENSHOT_TARGET_WINDOW:
+    case SCREENSHOT_TARGET_AREA:
+    case SCREENSHOT_TARGET_ACTIVE_WINDOW:
+      break;
+    default:
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "Invalid screenshot target %x", target);
+      return FALSE;
+    }
+
+  available_targets =
+    xdp_dbus_screenshot_get_available_targets (XDP_DBUS_SCREENSHOT (screenshot));
+  if (!(available_targets & target))
+    {
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                   "Unavailable screenshot target %x", target);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+validate_screenshot_target_filter (const char  *key,
+                                   GVariant    *value,
+                                   GVariant    *options,
+                                   gpointer     user_data,
+                                   GError     **error)
+{
+  return validate_screenshot_target (user_data, g_variant_get_uint32 (value), error);
+}
+
+static XdpOptionKey screenshot_options_v3[] = {
   { "modal", G_VARIANT_TYPE_BOOLEAN, NULL },
-  { "interactive", G_VARIANT_TYPE_BOOLEAN, NULL }
+  { "interactive", G_VARIANT_TYPE_BOOLEAN, NULL },
+  { "target", G_VARIANT_TYPE_UINT32, validate_screenshot_target_filter }
 };
 
 static gboolean
@@ -315,7 +367,10 @@ handle_screenshot_in_thread_func (GTask *task,
   g_autoptr(XdpDbusImplRequest) impl_request = NULL;
   g_auto(GVariantBuilder) opt_builder =
     G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+  GVariantIter options_iter;
   GVariant *options;
+  const char *key;
+  GVariant *value;
   gboolean permission_store_checked = FALSE;
   gboolean interactive;
   gboolean modal;
@@ -363,9 +418,13 @@ handle_screenshot_in_thread_func (GTask *task,
 
   xdp_request_set_impl_request (request, impl_request);
 
-  xdp_filter_options (options, &opt_builder,
-                      screenshot_options, G_N_ELEMENTS (screenshot_options),
-                      NULL, NULL);
+  g_variant_iter_init (&options_iter, options);
+  while (g_variant_iter_next (&options_iter, "{&sv}", &key, &value))
+    {
+      g_variant_builder_add (&opt_builder, "{sv}", key, value);
+      g_clear_pointer (&value, g_variant_unref);
+    }
+
   if (permission_store_checked)
     {
       g_variant_builder_add (&opt_builder, "{sv}", "permission_store_checked",
@@ -390,15 +449,29 @@ handle_screenshot (XdpDbusScreenshot *object,
                    const gchar *arg_parent_window,
                    GVariant *arg_options)
 {
+  Screenshot *screenshot = (Screenshot *) object;
   XdpRequest *request = xdp_request_from_invocation (invocation);
+  g_auto(GVariantBuilder) opt_builder =
+    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+  g_autoptr(GVariant) options = NULL;
   g_autoptr(GTask) task = NULL;
+  g_autoptr(GError) error = NULL;
 
   g_debug ("Handle Screenshot");
+
+  if (!xdp_filter_options (arg_options, &opt_builder,
+                           screenshot_options_v3, G_N_ELEMENTS (screenshot_options_v3),
+                           screenshot, &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+  options = g_variant_ref_sink (g_variant_builder_end (&opt_builder));
 
   g_object_set_data_full (G_OBJECT (request), "parent-window", g_strdup (arg_parent_window), g_free);
   g_object_set_data_full (G_OBJECT (request),
                           "options",
-                          g_variant_ref (arg_options),
+                          g_steal_pointer (&options),
                           (GDestroyNotify)g_variant_unref);
 
   xdp_request_export (request, g_dbus_method_invocation_get_connection (invocation));
@@ -545,7 +618,14 @@ screenshot_new (XdpDbusImplScreenshot *impl,
     MAX (xdp_dbus_impl_screenshot_get_version (screenshot->impl), 2);
 
   xdp_dbus_screenshot_set_version (XDP_DBUS_SCREENSHOT (screenshot),
-                                   MIN (screenshot->impl_version, 2));
+                                   MIN (screenshot->impl_version, 3));
+
+  if (screenshot->impl_version >= 3)
+    {
+      g_object_bind_property (G_OBJECT (screenshot->impl), "available-targets",
+                              G_OBJECT (screenshot), "available-targets",
+                              G_BINDING_SYNC_CREATE);
+    }
 
   return screenshot;
 }

--- a/tests/templates/screenshot.py
+++ b/tests/templates/screenshot.py
@@ -13,7 +13,8 @@ BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
 SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.impl.portal.Screenshot"
-VERSION = 2
+VERSION = 3
+AVAILABLE_TARGETS = 1 | 2 | 4 | 8
 
 
 logger = init_logger(__name__)
@@ -43,6 +44,9 @@ def load(mock, parameters={}):
         dbus.Dictionary(
             {
                 "version": dbus.UInt32(parameters.get("version", VERSION)),
+                "AvailableTargets": dbus.UInt32(
+                    parameters.get("available-targets", AVAILABLE_TARGETS)
+                ),
             }
         ),
     )

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -6,6 +6,7 @@ import tests.xdp_utils as xdp
 
 import dbus
 import pytest
+from enum import Flag
 from typing import Any
 import os
 from pathlib import Path
@@ -18,6 +19,27 @@ SCREENSHOT_DATA = dbus.Dictionary(
     },
     signature="sv",
 )
+
+
+class ScreenshotTarget(Flag):
+    SCREEN = 1
+    WINDOW = 2
+    AREA = 4
+    ACTIVE_WINDOW = 8
+
+
+SCREENSHOT_TARGETS_GOOD = tuple(target.value for target in ScreenshotTarget)
+SCREENSHOT_TARGETS_BAD = (
+    0,
+    (ScreenshotTarget.SCREEN | ScreenshotTarget.WINDOW).value,
+    16,
+)
+SCREENSHOT_TARGETS_ALL = (
+    ScreenshotTarget.SCREEN
+    | ScreenshotTarget.WINDOW
+    | ScreenshotTarget.AREA
+    | ScreenshotTarget.ACTIVE_WINDOW
+).value
 
 
 @pytest.fixture
@@ -46,7 +68,132 @@ class TestScreenshot:
         )
 
     def test_version(self, portals, dbus_con):
+        xdp.check_version(dbus_con, "Screenshot", 3)
+
+    def test_available_targets(self, portals, dbus_con):
+        properties_intf = dbus.Interface(
+            xdp.get_xdp_dbus_object(dbus_con), "org.freedesktop.DBus.Properties"
+        )
+        available_targets = properties_intf.Get(
+            "org.freedesktop.portal.Screenshot",
+            "AvailableTargets",
+        )
+        assert int(available_targets) == SCREENSHOT_TARGETS_ALL
+
+    @pytest.mark.parametrize("target", SCREENSHOT_TARGETS_GOOD)
+    def test_screenshot_target(
+        self, xdg_document_portal, portals, dbus_con, xdp_app_info, target
+    ):
+        app_id = xdp_app_info.app_id
+        screenshot_intf = xdp.get_portal_iface(dbus_con, "Screenshot")
+        mock_intf = xdp.get_mock_iface(dbus_con)
+
+        request = xdp.Request(dbus_con, screenshot_intf)
+        response = request.call(
+            "Screenshot",
+            parent_window="",
+            options={
+                "interactive": True,
+                "target": dbus.UInt32(target),
+            },
+        )
+
+        assert response
+        assert response.response == 0
+
+        method_calls = mock_intf.GetMethodCalls("Screenshot")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert args[1] == app_id
+        assert args[2] == ""
+        assert args[3]["target"] == target
+
+    @pytest.mark.parametrize("target", SCREENSHOT_TARGETS_BAD)
+    def test_screenshot_invalid_target(self, portals, dbus_con, target):
+        screenshot_intf = xdp.get_portal_iface(dbus_con, "Screenshot")
+
+        request = xdp.Request(dbus_con, screenshot_intf)
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            request.call(
+                "Screenshot",
+                parent_window="",
+                options={
+                    "interactive": True,
+                    "target": dbus.UInt32(target),
+                },
+            )
+
+        e = excinfo.value
+        assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
+        assert "Invalid screenshot target" in e.get_dbus_message()
+
+    @pytest.mark.parametrize(
+        "template_params",
+        (
+            {
+                "screenshot": {
+                    "available-targets": ScreenshotTarget.SCREEN.value,
+                    "results": SCREENSHOT_DATA,
+                },
+            },
+        ),
+    )
+    def test_screenshot_unavailable_target(self, portals, dbus_con):
+        screenshot_intf = xdp.get_portal_iface(dbus_con, "Screenshot")
+
+        request = xdp.Request(dbus_con, screenshot_intf)
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            request.call(
+                "Screenshot",
+                parent_window="",
+                options={
+                    "interactive": True,
+                    "target": dbus.UInt32(ScreenshotTarget.WINDOW.value),
+                },
+            )
+
+        e = excinfo.value
+        assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
+        assert "Unavailable screenshot target" in e.get_dbus_message()
+
+    @pytest.mark.parametrize(
+        "template_params",
+        (
+            {
+                "screenshot": {
+                    "version": 2,
+                    "results": SCREENSHOT_DATA,
+                },
+            },
+        ),
+    )
+    def test_screenshot_options_forwarded_to_v2_backend(
+        self, xdg_document_portal, portals, dbus_con
+    ):
         xdp.check_version(dbus_con, "Screenshot", 2)
+
+        screenshot_intf = xdp.get_portal_iface(dbus_con, "Screenshot")
+        mock_intf = xdp.get_mock_iface(dbus_con)
+
+        request = xdp.Request(dbus_con, screenshot_intf)
+        response = request.call(
+            "Screenshot",
+            parent_window="",
+            options={
+                "modal": False,
+                "interactive": True,
+            },
+        )
+
+        assert response
+        assert response.response == 0
+
+        method_calls = mock_intf.GetMethodCalls("Screenshot")
+        assert len(method_calls) > 0
+        _, args = method_calls[-1]
+        assert not args[3]["modal"]
+        assert args[3]["interactive"]
+        assert "target" not in args[3]
 
     @pytest.mark.parametrize("modal", [True, False])
     @pytest.mark.parametrize("interactive", [True, False])


### PR DESCRIPTION
## Summary

This picks up the Screenshot target-selection API work from the closed PR #1415 and addresses the review feedback from that thread.

- add Screenshot portal version 3 with a `target` option
- add public and implementation `AvailableTargets` properties
- validate requested targets before forwarding them to v3 backends
- preserve v2 backend compatibility by not forwarding `target` to v2 implementations
- add integration coverage for valid, invalid, unavailable, and v2-compatible target handling

## API Notes

`target` is a single requested target value, not a bitmask. `AvailableTargets` is the advertised bitmask of backend-supported targets.

Supported values are:

- `1`: screen
- `2`: window
- `4`: area

If `target` is omitted, the portal preserves previous Screenshot behavior. Public Screenshot version is capped at version 3, and v2 backends continue to expose public version 2.

This is intended as the API plumbing for the target-selection part of #1065. It does not fully resolve broader screenshot-tool parity requests such as delay, pointer visibility, decorations, or deterministic coordinate-region capture.

## Testing

- `git diff --check`
- `xmllint --noout data/org.freedesktop.impl.portal.Screenshot.xml data/org.freedesktop.portal.Screenshot.xml`
- `pre-commit run --show-diff-on-failure --color=always --all-files` in the project CI container
- `meson test -C /tmp/build-xdp-review-final integration/screenshot --print-errorlogs` in the project CI container
- full suite previously run in the project CI container: 26 passed, 1 skipped, 0 failed