### PR TITLE
ci: Update to Ubuntu 26.04 as image base

### DIFF
--- a/.github/workflows/Containerfile
+++ b/.github/workflows/Containerfile
@@ -2,7 +2,7 @@
 # When this file is changed, or one needs to rebuild the image for another
 # reason, bump the `IMAGE_TAG` in the container.yml workflow.
 
-FROM ubuntu:latest
+FROM ubuntu:26.04
 
 RUN apt update
 RUN apt upgrade -y
@@ -26,8 +26,8 @@ RUN apt install -y --no-install-recommends \
     librsvg2-2 \
     librsvg2-common \
     libgstreamer-plugins-base1.0-dev \
-    gstreamer1.0-plugins-good \
-    libgstreamer-plugins-good1.0-dev \
+    gstreamer1.0-plugins-extra \
+    libgstreamer-plugins-extra1.0-dev \
     gstreamer1.0-tools \
     libgeoclue-2-dev \
     libglib2.0-dev \
@@ -37,7 +37,7 @@ RUN apt install -y --no-install-recommends \
     libsystemd-dev \
     libtool \
     llvm \
-    libclang-rt-18-dev \
+    libclang-rt-dev \
     python3-gi \
     shared-mime-info
 
@@ -49,6 +49,7 @@ RUN apt install -y --no-install-recommends \
     python3-pytest \
     python3-pytest-xdist \
     python3-dbus \
+    python3-dbusmock \
     libumockdev0 \
     libumockdev-dev \
     umockdev \
@@ -56,10 +57,6 @@ RUN apt install -y --no-install-recommends \
 
 # Install pip
 RUN apt install -y --no-install-recommends python3-pip
-
-# Install latest a newer python-dbusmock required for our pytest setup
-# This is installed system-wide
-RUN pip install --prefix=/usr --break-system-packages python-dbusmock">=0.33.0"
 
 # Install doc dependencies
 RUN pip install --user --break-system-packages furo">=2024.04.27" \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
         if: always()
 
       - name: Check Qt annotations
-        run: find -name "*.xml" | xargs -n1 /usr/lib/qt6/bin/qdbusxml2cpp
+        run: find data -name "*.xml" | xargs -n1 /usr/lib/qt6/bin/qdbusxml2cpp
         if: always()
 
       - name: Run pre-commit hooks

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,5 +1,5 @@
 env:
-  IMAGE_TAG: 2025-07-21.3
+  IMAGE_TAG: 2026-06-08.0
 
 on:
   workflow_call:

--- a/doc/fix-rst-dbus.py
+++ b/doc/fix-rst-dbus.py
@@ -38,17 +38,6 @@ def adjust_title(lines):
     lines[3] = f"{adjusted_title}\n"
 
 
-# Temporary fix for '.. {title}:' strings in the generated files. Should be
-# removed after GLib 2.78.4 hits the CI images.
-#
-# See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3751
-def fix_title_template_string(lines):
-    for index, line in enumerate(lines):
-        if line.strip() == ".. _{title}:":
-            next_title = lines[index + 2].strip()
-            lines[index] = f".. _{next_title}:\n"
-
-
 for file in inputs:
     basename = os.path.basename(file)
     fullpath = os.path.join(output_dir, f"{filename_prefix}-{basename}")
@@ -57,7 +46,6 @@ for file in inputs:
         lines = f.readlines()
 
     adjust_title(lines)
-    fix_title_template_string(lines)
 
     with open(fullpath, "w") as f:
         f.writelines(lines)


### PR DESCRIPTION
Now that Ubuntu 26.04 is released, ubuntu:latest is (to be) swapped to use it.
To avoid breakage the tag is changed to explicitly use it.

- Dropped RST generator glib2 workaround
- Make Qt annotations check only the data directory, otherwise gresource will also be parsed.