### PR TITLE
ScreenCast: Add audio stream support

### DIFF
--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -25,7 +25,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 6 of this interface.
+      This documentation describes version 7 of this interface.
   -->
   <interface name="org.freedesktop.impl.portal.ScreenCast">
     <!--
@@ -75,6 +75,20 @@
         * ``multiple`` (``b``)
 
           Whether to allow selecting multiple sources. Default is no.
+
+        * ``audio`` (``b``)
+
+          Whether to request audio streams associated with the selected sources.
+          Default is no.
+
+          If set to true, the application is capable of receiving audio streams
+          returned by the org.freedesktop.impl.portal.ScreenCast.Start() method.
+          The portal implementation may still return no audio streams if none are
+          available, if it cannot determine a suitable audio source, or if the
+          active portal backend implements an older interface version that does
+          not support audio.
+
+          This option was added in version 7 of this interface.
 
         * ``cursor_mode`` (``u``)
 
@@ -146,7 +160,7 @@
 
           An array of PipeWire streams. Each stream consists of a PipeWire
           node ID (the first element in the tuple, and a Vardict of
-          properties.
+          properties).
 
           Since version 6 of this interface, the node ID in the stream
           tuple is deprecated for stream targeting. PipeWire node IDs can
@@ -154,11 +168,24 @@
           ``pipewire-serial`` property from the stream properties dict
           and ``PW_KEY_TARGET_OBJECT`` for connecting to streams.
 
-          The array will contain a single stream if 'multiple' (see
-          SelectSources) was set to 'false', or at least one stream if
+          The array will contain streams for a single source if 'multiple' (see
+          SelectSources) was set to 'false', or at least one source's streams if
           'multiple' was set to 'true' as part of the SelectSources method.
 
+          Since version 7, a single selected source may be represented by
+          multiple media streams: one video stream and optionally one associated
+          audio stream.
+
           Each stream contains the following properties:
+
+          * ``media_type`` (``s``)
+
+            The type of media carried by this stream. Valid values are
+            ``video`` and ``audio``.
+
+            If this property is absent, the stream is a video stream.
+
+            This property was added in version 7 of this interface.
 
           * ``position`` (``(ii)``)
 

--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -25,7 +25,7 @@
 
       The Screen cast portal allows to create screen cast sessions.
 
-      This documentation describes version 6 of this interface.
+      This documentation describes version 7 of this interface.
   -->
   <interface name="org.freedesktop.portal.ScreenCast">
     <!--
@@ -97,6 +97,20 @@
         * ``multiple`` (``b``)
 
           Whether to allow selecting multiple sources. Default is no.
+
+        * ``audio`` (``b``)
+
+          Whether to request audio streams associated with the selected sources.
+          Default is no.
+
+          If set to true, the application is capable of receiving audio streams
+          returned by the :ref:`org.freedesktop.portal.ScreenCast.Start` method.
+          The portal implementation may still return no audio streams if none are
+          available, if it cannot determine a suitable audio source, or if the
+          active portal backend implements an older interface version that does
+          not support audio.
+
+          This option was added in version 7 of this interface.
 
         * ``cursor_mode`` (``u``)
 
@@ -183,7 +197,7 @@
 
           An array of PipeWire streams. Each stream consists of a PipeWire
           node ID (the first element in the tuple, and a Vardict of
-          properties.
+          properties).
 
           Since version 6 of this interface, the node ID in the stream
           tuple is deprecated for stream targeting. PipeWire node IDs can
@@ -195,13 +209,26 @@
           streams. Backends must continue to populate the node ID for
           compatibility with clients that do not support version 6.
 
-          The array will contain a single stream if 'multiple' (see
+          The array will contain streams for a single source if 'multiple' (see
           org.freedesktop.portal.ScreenCast.SelectSources())
-          was set to 'false', or at least one stream if
+          was set to 'false', or at least one source's streams if
           'multiple' was set to 'true' as part of the
           org.freedesktop.portal.ScreenCast.SelectSources() method.
 
+          Since version 7, a single selected source may be represented by
+          multiple media streams: one video stream and optionally one associated
+          audio stream.
+
           Each stream contains the following properties:
+
+          * ``media_type`` (``s``)
+
+            The type of media carried by this stream. Valid values are
+            ``video`` and ``audio``.
+
+            If this property is absent, the stream is a video stream.
+
+            This property was added in version 7 of this interface.
 
           * ``id`` (``s``)
 

--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -874,10 +874,17 @@ check_position (XdpSession *session,
 
   for (l = remote_desktop_session->streams; l; l = l->next)
     {
-      ScreenCastStream *stream = l->data;
+      ScreenCastStream *candidate = l->data;
       int32_t width, height;
 
-      screen_cast_stream_get_size (stream, &width, &height);
+      if (screen_cast_stream_get_pipewire_node_id (candidate) != stream)
+        continue;
+
+      if (screen_cast_stream_get_stream_type (candidate) !=
+          SCREEN_CAST_STREAM_TYPE_VIDEO)
+        continue;
+
+      screen_cast_stream_get_size (candidate, &width, &height);
 
       if (x >= 0.0 && x < width &&
           y >= 0.0 && y < height)

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -73,6 +73,7 @@ struct _ScreenCastStream
   int32_t height;
   uint64_t pipewire_serial;
   gboolean has_pipewire_serial;
+  ScreenCastStreamType stream_type;
 };
 
 G_DEFINE_TYPE_WITH_CODE (ScreenCast, screen_cast,
@@ -485,7 +486,27 @@ static XdpOptionKey screen_cast_select_sources_options[] = {
   { "cursor_mode", G_VARIANT_TYPE_UINT32, validate_cursor_mode },
   { "restore_token", G_VARIANT_TYPE_STRING, validate_restore_token },
   { "persist_mode", G_VARIANT_TYPE_UINT32, validate_persist_mode },
+  { "audio", G_VARIANT_TYPE_BOOLEAN, NULL },
 };
+
+static void
+strip_v7_options_for_older_backend (ScreenCast *screen_cast,
+                                    GVariant **in_out_options)
+{
+  GVariantDict options_dict;
+  g_autoptr(GVariant) old_options = NULL;
+
+  if (xdp_dbus_impl_screen_cast_get_version (screen_cast->impl) >= 7)
+    return;
+
+  if (!xdp_variant_contains_key (*in_out_options, "audio"))
+    return;
+
+  old_options = g_steal_pointer (in_out_options);
+  g_variant_dict_init (&options_dict, old_options);
+  g_variant_dict_remove (&options_dict, "audio");
+  *in_out_options = g_variant_ref_sink (g_variant_dict_end (&options_dict));
+}
 
 static gboolean
 replace_screen_cast_restore_token_with_data (XdpSession *session,
@@ -639,6 +660,7 @@ handle_select_sources (XdpDbusScreenCast *object,
     }
 
   options = g_variant_ref_sink (g_variant_builder_end (&options_builder));
+  strip_v7_options_for_older_backend (screen_cast, &options);
 
   /* If 'restore_token' is passed, lookup the corresponding data in the
    * permission store and / or the GHashTable with transient permissions.
@@ -678,6 +700,12 @@ uint32_t
 screen_cast_stream_get_pipewire_node_id (ScreenCastStream *stream)
 {
   return stream->id;
+}
+
+ScreenCastStreamType
+screen_cast_stream_get_stream_type (ScreenCastStream *stream)
+{
+  return stream->stream_type;
 }
 
 static void
@@ -764,6 +792,20 @@ screen_cast_stream_free (ScreenCastStream *stream)
   g_free (stream);
 }
 
+static ScreenCastStreamType
+parse_screen_cast_stream_type (const char *media_type)
+{
+  if (media_type == NULL || g_strcmp0 (media_type, "video") == 0)
+    return SCREEN_CAST_STREAM_TYPE_VIDEO;
+
+  if (g_strcmp0 (media_type, "audio") == 0)
+    return SCREEN_CAST_STREAM_TYPE_AUDIO;
+
+  g_warning ("Unknown screen cast stream media_type '%s', assuming video",
+             media_type);
+  return SCREEN_CAST_STREAM_TYPE_VIDEO;
+}
+
 GList *
 collect_screen_cast_stream_data (GVariantIter *streams_iter)
 {
@@ -775,9 +817,12 @@ collect_screen_cast_stream_data (GVariantIter *streams_iter)
                               &stream_id, &stream_options))
     {
       ScreenCastStream *stream;
+      const char *media_type = NULL;
 
       stream = g_new0 (ScreenCastStream, 1);
       stream->id = stream_id;
+      g_variant_lookup (stream_options, "media_type", "&s", &media_type);
+      stream->stream_type = parse_screen_cast_stream_type (media_type);
       g_variant_lookup (stream_options, "size", "(ii)",
                         &stream->width, &stream->height);
       stream->has_pipewire_serial =
@@ -1135,7 +1180,7 @@ screen_cast_new (XdpContext            *context,
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (screen_cast->impl), G_MAXINT);
 
   xdp_dbus_screen_cast_set_version (XDP_DBUS_SCREEN_CAST (screen_cast),
-                                    MIN (xdp_dbus_impl_screen_cast_get_version (screen_cast->impl), 6));
+                                    MIN (xdp_dbus_impl_screen_cast_get_version (screen_cast->impl), 7));
 
   g_object_bind_property (G_OBJECT (screen_cast->impl), "available-source-types",
                           G_OBJECT (screen_cast), "available-source-types",

--- a/src/screen-cast.h
+++ b/src/screen-cast.h
@@ -28,7 +28,15 @@
 
 typedef struct _ScreenCastStream ScreenCastStream;
 
+typedef enum _ScreenCastStreamType
+{
+  SCREEN_CAST_STREAM_TYPE_VIDEO,
+  SCREEN_CAST_STREAM_TYPE_AUDIO,
+} ScreenCastStreamType;
+
 uint32_t screen_cast_stream_get_pipewire_node_id (ScreenCastStream *stream);
+
+ScreenCastStreamType screen_cast_stream_get_stream_type (ScreenCastStream *stream);
 
 void screen_cast_stream_get_size (ScreenCastStream *stream,
                                   int32_t *width,


### PR DESCRIPTION
Closes #957 
## Summary

  This adds frontend API support for requesting audio alongside video in the ScreenCast portal.

  The ScreenCast interface is bumped to version 6 and gains a new `audio` option in `SelectSources()`. When supported by the backend, `Start()` may now return multiple PipeWire streams for a selected source, with each stream carrying a `media_type` property of either `"video"` or `"audio"`.
## Details

  - Add an `audio` boolean option to `SelectSources()`.
  - Add `media_type` stream metadata returned by `Start()`.
  - Default streams without `media_type` to video for compatibility with existing backends.
  - Strip the `audio` option before forwarding requests to ScreenCast backends older than v6.
  - Track stream media type internally with `ScreenCastStreamType`.