### PR TITLE
Revert Service Dependency Regression

### DIFF
--- a/src/xdg-desktop-portal.service.in
+++ b/src/xdg-desktop-portal.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=Portal service
 PartOf=graphical-session.target
-Requisite=graphical-session.target
-After=graphical-session.target
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Revert dependency to `dbus.service` rather than `graphical-session.target`.

This fixes the issue when running on Hyprland for example, the dependency failed job causing the service to not run. #1983

Reverting commit 4d284de29d1d0740c9b80b634631a8f253287680