### PR TITLE
xdp: resolve directories properly

### DIFF
--- a/src/file-chooser.c
+++ b/src/file-chooser.c
@@ -515,7 +515,8 @@ handle_open_file (XdpDbusFileChooser *object,
     if (current_folder)
       {
         const char *path_from_app = g_variant_get_bytestring (current_folder);
-        g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app);
+        g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app,
+                                                                       XDP_RESOLVE_DOCUMENT_TO_DIRECTORY);
 
         g_variant_builder_add (&options, "{sv}", "current_folder",
                               g_variant_new_bytestring (host_path));
@@ -646,7 +647,8 @@ handle_save_file (XdpDbusFileChooser *object,
     if (current_file)
       {
         const char *path_from_app = g_variant_get_bytestring (current_file);
-        g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app);
+        g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app,
+                                                                       XDP_RESOLVE_DOCUMENT_TO_FILE);
 
         g_variant_builder_add (&options, "{sv}", "current_file",
                               g_variant_new_bytestring (host_path));
@@ -659,7 +661,8 @@ handle_save_file (XdpDbusFileChooser *object,
     if (current_folder)
       {
         const char *path_from_app = g_variant_get_bytestring (current_folder);
-        g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app);
+        g_autofree char *host_path = xdp_resolve_document_portal_path (path_from_app,
+                                                                       XDP_RESOLVE_DOCUMENT_TO_DIRECTORY);
 
         g_variant_builder_add (&options, "{sv}", "current_folder",
                               g_variant_new_bytestring (host_path));

--- a/src/open-uri.c
+++ b/src/open-uri.c
@@ -696,7 +696,7 @@ handle_open_in_thread_func (GTask *task,
 
       if (path != NULL)
         {
-          char *resolved_path = xdp_resolve_document_portal_path (path);
+          char *resolved_path = xdp_resolve_document_portal_path (path, XDP_RESOLVE_DOCUMENT_TO_FILE);
           g_clear_pointer (&path, g_free);
           path = g_steal_pointer (&resolved_path);
         }
@@ -737,7 +737,7 @@ handle_open_in_thread_func (GTask *task,
           g_autoptr(GDBusConnection) bus = NULL;
           g_autofree char *real_path = NULL;
 
-          real_path = xdp_resolve_document_portal_path (path);
+          real_path = xdp_resolve_document_portal_path (path, XDP_RESOLVE_DOCUMENT_TO_DIRECTORY);
           item_uri = g_filename_to_uri (real_path, NULL, NULL);
 
           bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &local_error);

--- a/src/xdp-documents.c
+++ b/src/xdp-documents.c
@@ -292,11 +292,13 @@ xdp_looks_like_document_portal_path (const char  *path,
 }
 
 char *
-xdp_resolve_document_portal_path (const char *path)
+xdp_resolve_document_portal_path (const char                 *path,
+                                  XdpResolveDocumentStrategy  strategy)
 {
   g_autofree char *docid = NULL;
   g_autofree char *suffix_path = NULL;
   g_autofree char *host_path = NULL;
+  g_autofree char *resolved_path = NULL;
 
   if (!xdp_looks_like_document_portal_path (path, &docid, &suffix_path))
     return g_strdup (path);
@@ -305,5 +307,14 @@ xdp_resolve_document_portal_path (const char *path)
   if (!host_path)
     return g_strdup (path);
 
-  return g_strconcat (host_path, suffix_path, NULL);
+  resolved_path = g_strconcat (host_path, suffix_path, NULL);
+
+  if (strategy == XDP_RESOLVE_DOCUMENT_TO_DIRECTORY)
+    {
+      char *last_dir_separator = strrchr (resolved_path, G_DIR_SEPARATOR);
+      if (last_dir_separator)
+        *last_dir_separator = '\0';
+    }
+
+  return g_steal_pointer (&resolved_path);
 }

--- a/src/xdp-documents.h
+++ b/src/xdp-documents.h
@@ -44,4 +44,10 @@ char *xdp_register_document (const char        *uri,
 
 char *xdp_get_real_path_for_doc_id (const char *doc_id);
 
-char * xdp_resolve_document_portal_path (const char *path);
+typedef enum {
+  XDP_RESOLVE_DOCUMENT_TO_FILE,
+  XDP_RESOLVE_DOCUMENT_TO_DIRECTORY
+} XdpResolveDocumentStrategy;
+
+char * xdp_resolve_document_portal_path (const char                 *path,
+                                         XdpResolveDocumentStrategy  strategy);


### PR DESCRIPTION
Since sometime last year, I have generally been presented with an error message whenever opening a file upload file chooser in Epiphany (for example, when trying to attach any file on GitHub). It looks like this:

Oops! Something went wrong.

Unable to find “/home/mcatanzaro/example.txt”. Please check the spelling and try again.

The problem lies in how the file chooser portal resolves document portal paths to host system paths. Say the user uses the document portal to open the aforementioned /home/mcatanzaro/example.txt. That is a host system path. The corresponding document portal path will look different, say /run/user/1000/doc/99bfa7fa/example.txt. Epiphany then trims off the final component and saves /run/user/1000/doc/99bfa7fa as the last opened directory. Later, the user tries to open a different file. Epiphany remembers the last upload directory and passes it to GtkFileDialog, which provides it to xdg-desktop-portal via the current_folder option. Finally, in handle_open_file(), xdg-desktop-portal looks at the current_folder option and resolves it from a document portal path to a host path. The result is, perhaps surprisingly, /home/mcatanzaro/example.txt. That's right: we provided a directory, but got back a regular file instead! Definitely not what the application wanted, and yet it's arguably the most reasonable behavior, because of course the path /run/user/1000/doc/99bfa7fa definitely corresponds to the regular file /home/mcatanzaro/example.txt, and it would be a little weird for it to resolve to just /home/mcatanzaro, right?

Perhaps we really should resolve the parent directory of a full document portal path to the parent on the host filesystem. I'm not sure. I'm definitely not smart enough to reason about what might possibly break if we were to try changing that. Fortunately, there's no need, because xdg-desktop-portal always knows whether it wants a folder or a file, so it can simply indicate what it wants.

This refines: d037b5c3f91b68ca208a9a41b6e18e6a3a659e05