### PR TITLE
dynamic-launcher: Correct passing icon GVariant around

### DIFF
--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -145,7 +145,8 @@ validate_desktop_file_id (XdpAppInfo  *app_info,
 static gboolean
 validate_serialized_icon (GVariant  *arg_icon_v,
                           char     **icon_format,
-                          char     **icon_size)
+                          char     **icon_size,
+                          GVariant **out_icon_v)
 {
   GBytes *bytes;
   g_autoptr(GIcon) icon = NULL;
@@ -166,11 +167,16 @@ validate_serialized_icon (GVariant  *arg_icon_v,
   bytes = g_bytes_icon_get_bytes (G_BYTES_ICON (icon));
   sealed_icon = xdp_sealed_fd_new_from_bytes (bytes, NULL);
 
-  return sealed_icon &&
-         xdp_validate_icon (sealed_icon,
-                            XDP_ICON_TYPE_DESKTOP,
-                            icon_format,
-                            icon_size);
+  if (sealed_icon == NULL ||
+      !xdp_validate_icon (sealed_icon,
+                          XDP_ICON_TYPE_DESKTOP,
+                          icon_format,
+                          icon_size))
+    return FALSE;
+
+  *out_icon_v = g_steal_pointer (&icon_v);
+
+  return TRUE;
 }
 
 static gboolean
@@ -684,7 +690,7 @@ handle_prepare_install (XdpDbusDynamicLauncher *object,
     }
 
   /* Do some validation on the icon before passing it along */
-  if (!validate_serialized_icon (arg_icon_v, &icon_format, &icon_size))
+  if (!validate_serialized_icon (arg_icon_v, &icon_format, &icon_size, &icon_v))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              XDG_DESKTOP_PORTAL_ERROR,
@@ -759,7 +765,7 @@ handle_request_install_token (XdpDbusDynamicLauncher *object,
       GVariant *launcher_data;
 
       /* Do some validation on the icon before saving it */
-      if (!validate_serialized_icon (arg_icon_v, &icon_format, &icon_size))
+      if (!validate_serialized_icon (arg_icon_v, &icon_format, &icon_size, &icon_v))
         {
           g_dbus_method_invocation_return_error (invocation,
                                                  XDG_DESKTOP_PORTAL_ERROR,


### PR DESCRIPTION
The caller of the request_install_token() encapsulates the icon into a variant, which the validate_serialized_icon() knows about and gets the variant value of the arg_icon_v as the icon variant, but it passed into the g_variant_new() for the launcher_data a NULL icon_v pointer, which causes a crash later in the calls.

```
     g_variant_is_trusted (libglib-2.0.so.0 + 0xca70d)
     g_variant_builder_add_value (libglib-2.0.so.0 + 0xc4d75)
     g_variant_valist_new (libglib-2.0.so.0 + 0xc813b)
     g_variant_new_va (libglib-2.0.so.0 + 0xc8574)
     g_variant_new (libglib-2.0.so.0 + 0xc84c6)
     handle_request_install_token (/usr/libexec/xdg-desktop-portal + 0x51f79)
     _g_dbus_codegen_marshal_BOOLEAN__OBJECT_STRING_STRING_STRING.part.0 (/usr/libexec/xdg-desktop-portal + 0x3cc27)
     g_type_iface_meta_marshal (libgobject-2.0.so.0 + 0xaca7)
     g_closure_invoke (libgobject-2.0.so.0 + 0xa45a)
     signal_emit_unlocked_R (libgobject-2.0.so.0 + 0x2cd9e)
     signal_emitv_unlocked (libgobject-2.0.so.0 + 0x2a60b)
     g_signal_emitv (libgobject-2.0.so.0 + 0x2a370)
     _xdp_dbus_dynamic_launcher_skeleton_handle_method_call (/usr/libexec/xdg-desktop-portal + 0x1a50a)
     dispatch_in_thread_func (libgio-2.0.so.0 + 0x15c6a0)
     g_task_thread_pool_thread (libgio-2.0.so.0 + 0xab04e)
     g_thread_pool_thread_proxy (libglib-2.0.so.0 + 0x9c11c)
     g_thread_proxy (libglib-2.0.so.0 + 0x9b3ed)
     start_thread (libc.so.6 + 0x737b9)
     __clone3 (libc.so.6 + 0xf7acc)
```

Note the callers of the validate_serialized_icon() still did have the icon_v variable declared, but it either was not populated or it was not used.

Reported for gnome-software: https://gitlab.gnome.org/GNOME/gnome-software/-/work_items/2989