### PR TITLE
RFC: add keyboard_layout key in RemoteDesktop

### DIFF
--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -106,6 +106,14 @@
 
           This option was added in version 2 of this interface.
 
+        * ``keyboard_layout`` (``s``)
+          Optional key. What the keyboard layout is used after start a remoting task
+
+          If it is not set, the keyboard layout will follow the controlled side. For
+          example, if the controlled side is using us keyboard, the connection will also
+          use us keyboard. If the key is set, when the controlled side is using jp keyboard,
+          controlling side can still use us keyboard to control the desktop.
+
         For available device types, see the AvailableDeviceTypes property.
     -->
     <method name="SelectDevices">


### PR DESCRIPTION
I think it is good to let controlling side can use the keyboard layout they want. We will always meet the case that the controlled side is using a different keyboard layout, and xdg-desktop-portal can only know the keyboard_layout of controlled side, it will never know what keyboard_layout is the controlling side using. So I submitted the rcf

solved: https://github.com/flatpak/xdg-desktop-portal/issues/2009