### PR TITLE
remote-desktop: Handle D-Bus proxy reconnection when backend restarts

### DIFF
--- a/src/remote-desktop.c
+++ b/src/remote-desktop.c
@@ -1639,13 +1639,104 @@ remote_desktop_iface_init (XdpDbusRemoteDesktopIface *iface)
 }
 
 static void
+on_impl_g_name_owner_notified (GObject    *object,
+                                GParamSpec *pspec,
+                                gpointer    user_data);
+
+static void
+remote_desktop_reconnect_impl (RemoteDesktop *remote_desktop);
+
+static void
 remote_desktop_dispose (GObject *object)
 {
   RemoteDesktop *remote_desktop = (RemoteDesktop *) object;
 
+  /* Signal handler on impl is auto-disconnected when impl is finalized */
   g_clear_object (&remote_desktop->impl);
 
   G_OBJECT_CLASS (remote_desktop_parent_class)->dispose (object);
+}
+
+static void
+on_impl_g_name_owner_notified (GObject    *object,
+                                GParamSpec *pspec,
+                                gpointer    user_data)
+{
+  RemoteDesktop *remote_desktop = (RemoteDesktop *) user_data;
+  GDBusProxy *proxy = G_DBUS_PROXY (object);
+  const char *name_owner;
+
+  g_assert (remote_desktop != NULL);
+  g_assert (G_IS_DBUS_PROXY (proxy));
+
+  name_owner = g_dbus_proxy_get_name_owner (proxy);
+
+  if (name_owner == NULL)
+    {
+      g_debug ("RemoteDesktop backend disconnected");
+      g_object_set_data (G_OBJECT (remote_desktop), "impl-was-connected",
+                         GINT_TO_POINTER (TRUE));
+      return;
+    }
+
+  /* name_owner is non-NULL: backend has connected (or reconnected) */
+  if (g_object_get_data (G_OBJECT (remote_desktop), "impl-was-connected"))
+    {
+      g_debug ("RemoteDesktop backend reconnected, recreating proxy");
+      remote_desktop_reconnect_impl (remote_desktop);
+    }
+  else
+    {
+      g_debug ("RemoteDesktop backend connected: %s", name_owner);
+      g_object_set_data (G_OBJECT (remote_desktop), "impl-was-connected",
+                         GINT_TO_POINTER (TRUE));
+    }
+}
+
+static void
+remote_desktop_reconnect_impl (RemoteDesktop *remote_desktop)
+{
+  GDBusConnection *connection;
+  const char *dbus_name;
+  g_autoptr(XdpDbusImplRemoteDesktop) new_impl = NULL;
+  g_autoptr(XdpDbusImplRemoteDesktop) old_impl = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_assert (remote_desktop != NULL);
+  g_assert (remote_desktop->impl != NULL);
+
+  connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (remote_desktop->impl));
+  dbus_name = g_dbus_proxy_get_name (G_DBUS_PROXY (remote_desktop->impl));
+
+  new_impl = xdp_dbus_impl_remote_desktop_proxy_new_sync (connection,
+                                                           G_DBUS_PROXY_FLAGS_NONE,
+                                                           dbus_name,
+                                                           DESKTOP_DBUS_PATH,
+                                                           NULL,
+                                                           &error);
+  if (new_impl == NULL)
+    {
+      g_warning ("Failed to reconnect remote desktop proxy: %s", error->message);
+      return;
+    }
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (new_impl), G_MAXINT);
+
+  /* Swap the impl - old impl will be finalized when nothing else refs it.
+   * Keep a ref on the old impl during the swap so signal emission can finish. */
+  old_impl = remote_desktop->impl;
+  remote_desktop->impl = g_object_ref (new_impl);
+
+  /* Re-bind the available-device-types property on the new impl */
+  g_object_bind_property (G_OBJECT (remote_desktop->impl), "available-device-types",
+                          G_OBJECT (remote_desktop), "available-device-types",
+                          G_BINDING_SYNC_CREATE);
+
+  /* Connect the name-owner signal on the new proxy */
+  g_signal_connect (remote_desktop->impl, "notify::g-name-owner",
+                    G_CALLBACK (on_impl_g_name_owner_notified), remote_desktop);
+
+  g_debug ("RemoteDesktop backend reconnected successfully");
 }
 
 
@@ -1710,6 +1801,9 @@ init_remote_desktop (XdpContext *context)
     }
 
   remote_desktop = remote_desktop_new (context, impl);
+
+  g_signal_connect (remote_desktop->impl, "notify::g-name-owner",
+                    G_CALLBACK (on_impl_g_name_owner_notified), remote_desktop);
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&remote_desktop)),

--- a/src/screen-cast.c
+++ b/src/screen-cast.c
@@ -1097,13 +1097,110 @@ screen_cast_iface_init (XdpDbusScreenCastIface *iface)
 }
 
 static void
+on_impl_g_name_owner_notified (GObject    *object,
+                                GParamSpec *pspec,
+                                gpointer    user_data);
+
+static void
+screen_cast_reconnect_impl (ScreenCast *screen_cast);
+
+static void
 screen_cast_dispose (GObject *object)
 {
   ScreenCast *screen_cast = (ScreenCast *) object;
 
+  /* Signal handler on impl is auto-disconnected when impl is finalized */
   g_clear_object (&screen_cast->impl);
 
   G_OBJECT_CLASS (screen_cast_parent_class)->dispose (object);
+}
+
+static void
+on_impl_g_name_owner_notified (GObject    *object,
+                                GParamSpec *pspec,
+                                gpointer    user_data)
+{
+  ScreenCast *screen_cast = (ScreenCast *) user_data;
+  GDBusProxy *proxy = G_DBUS_PROXY (object);
+  const char *name_owner;
+
+  g_assert (screen_cast != NULL);
+  g_assert (G_IS_DBUS_PROXY (proxy));
+
+  name_owner = g_dbus_proxy_get_name_owner (proxy);
+
+  if (name_owner == NULL)
+    {
+      g_debug ("ScreenCast backend disconnected");
+      g_object_set_data (G_OBJECT (screen_cast), "impl-was-connected",
+                         GINT_TO_POINTER (TRUE));
+      return;
+    }
+
+  /* name_owner is non-NULL: backend has connected (or reconnected) */
+  if (g_object_get_data (G_OBJECT (screen_cast), "impl-was-connected"))
+    {
+      g_debug ("ScreenCast backend reconnected, recreating proxy");
+      screen_cast_reconnect_impl (screen_cast);
+    }
+  else
+    {
+      g_debug ("ScreenCast backend connected: %s", name_owner);
+      g_object_set_data (G_OBJECT (screen_cast), "impl-was-connected",
+                         GINT_TO_POINTER (TRUE));
+    }
+}
+
+static void
+screen_cast_reconnect_impl (ScreenCast *screen_cast)
+{
+  GDBusConnection *connection;
+  const char *dbus_name;
+  g_autoptr(XdpDbusImplScreenCast) new_impl = NULL;
+  g_autoptr(XdpDbusImplScreenCast) old_impl = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_assert (screen_cast != NULL);
+  g_assert (screen_cast->impl != NULL);
+
+  connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (screen_cast->impl));
+  dbus_name = g_dbus_proxy_get_name (G_DBUS_PROXY (screen_cast->impl));
+
+  new_impl = xdp_dbus_impl_screen_cast_proxy_new_sync (connection,
+                                                        G_DBUS_PROXY_FLAGS_NONE,
+                                                        dbus_name,
+                                                        DESKTOP_DBUS_PATH,
+                                                        NULL,
+                                                        &error);
+  if (new_impl == NULL)
+    {
+      g_warning ("Failed to reconnect screen cast proxy: %s", error->message);
+      return;
+    }
+
+  g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (new_impl), G_MAXINT);
+
+  /* Swap the impl - old impl will be finalized when nothing else refs it */
+  old_impl = screen_cast->impl;
+  screen_cast->impl = g_object_ref (new_impl);
+
+  /* Re-bind properties on the new impl */
+  g_object_bind_property (G_OBJECT (screen_cast->impl), "available-source-types",
+                          G_OBJECT (screen_cast), "available-source-types",
+                          G_BINDING_SYNC_CREATE);
+
+  if (xdp_dbus_impl_screen_cast_get_version (screen_cast->impl) >= 2)
+    {
+      g_object_bind_property (G_OBJECT (screen_cast->impl), "available-cursor-modes",
+                              G_OBJECT (screen_cast), "available-cursor-modes",
+                              G_BINDING_SYNC_CREATE);
+    }
+
+  /* Connect the name-owner signal on the new proxy */
+  g_signal_connect (screen_cast->impl, "notify::g-name-owner",
+                    G_CALLBACK (on_impl_g_name_owner_notified), screen_cast);
+
+  g_debug ("ScreenCast backend reconnected successfully");
 }
 
 static void
@@ -1178,6 +1275,9 @@ init_screen_cast (XdpContext *context)
     }
 
   screen_cast = screen_cast_new (context, impl);
+
+  g_signal_connect (screen_cast->impl, "notify::g-name-owner",
+                    G_CALLBACK (on_impl_g_name_owner_notified), screen_cast);
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&screen_cast)),


### PR DESCRIPTION
## Summary

- Monitor `g-name-owner` on the impl D-Bus proxy for `RemoteDesktop` and `ScreenCast`
- Recreate the proxy when the backend reconnects after a restart
- Without this, if a portal backend (e.g. `xdg-desktop-portal-hyprland`) restarts, async D-Bus calls through the stale proxy silently never complete

## Background

`xdg-desktop-portal` creates D-Bus proxies to backend implementations once at startup with `G_DBUS_PROXY_FLAGS_NONE`. If the backend restarts (e.g., crashes and gets re-spawned by D-Bus activation), the proxy holds a stale connection to the old process. Async D-Bus calls through a stale proxy never complete — the callback silently never fires because `g_dbus_proxy_set_default_timeout()` is set to `G_MAXINT`.

## Implementation

Both `remote-desktop.c` and `screen-cast.c` get the same treatment:

1. **Signal handler** `on_impl_g_name_owner_notified()` — watches `notify::g-name-owner` on the proxy:
   - On disconnect (name_owner → NULL): sets a `"impl-was-connected"` flag
   - On reconnection (NULL → name_owner with flag set): triggers proxy recreation
   - On first connection: just records the flag (initial startup)

2. **Reconnect helper** — creates a fresh proxy with the same connection/bus-name/path, re-binds properties, and wires the signal on the new proxy. The old proxy is safely held via `g_autoptr` during the swap so in-flight signal emission completes cleanly.

3. Signal is connected in `init_remote_desktop()` / `init_screen_cast()` right after the portal object is created.

## Test plan

- [x] Build passes with zero warnings (verified: `meson setup build -Dtests=disabled && ninja`)
- [x] Restart portal backend and verify new D-Bus calls succeed instead of hanging