### PR TITLE
pipewire: Disable loading module-rt

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
 [general]
-ignore=title-must-not-contain-word, body-min-length, body-is-missing, author-valid-email
+ignore=title-must-not-contain-word, body-max-line-length, body-min-length, body-is-missing, author-valid-email
 ignore-merge-commits=true
-extra-path=.gitlint.conf/commit-msg-rules.py
+extra-path=.gitlint.conf/
 
 [ignore-by-title]
 regex=^Merge

--- a/.gitlint.conf/co-authored-by-coding-agent.py
+++ b/.gitlint.conf/co-authored-by-coding-agent.py
@@ -9,7 +9,7 @@ CODING_AGENTS = [
 ]
 
 
-class SignedOffBy(CommitRule):
+class CoAuthoredByCodingAgent(CommitRule):
     """Try to stop people from adding Co-Authored-By: AGENT_NAME
     and instead use the kernel convention of the Assisted-by tag.
     """

--- a/.gitlint.conf/custom-body-max-line-length.py
+++ b/.gitlint.conf/custom-body-max-line-length.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+
+import re
+from gitlint.rules import BodyMaxLineLength
+
+TAGS = [
+    "Signed-off-by",
+    "Co-authored-by",
+    "Fixes",
+    "Closes",
+]
+
+
+class CustomBodyMaxLineLength(BodyMaxLineLength):
+    name = "custom-body-max-line-length"
+    id = "UC2"
+
+    def validate(self, line, commit):
+        # Ignore quoted content
+        if line.startswith(" " * 4):
+            return None
+
+        # Ignore reference lines (e.g. [2]: https://example.org/foobar)
+        ret = re.match(r"^\[\d+\] ", line)
+        if ret is not None:
+            return None
+
+        # Ignore length for tags
+        for tag in TAGS:
+            tag = tag + ": "
+            if line[: len(tag)].lower() == tag.lower():
+                return None
+
+        # Otherwise behave as the upstream BodyMaxLineLength rule
+        return super().validate(line, commit)

--- a/desktop-portal/pipewire.c
+++ b/desktop-portal/pipewire.c
@@ -283,7 +283,9 @@ pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
       return NULL;
     }
 
-  remote->context = pw_context_new (pw_main_loop_get_loop (remote->loop), NULL, 0);
+  /* Loading module-rt will invoke the Realtime portal, causing a potential hang */
+  remote->context = pw_context_new (pw_main_loop_get_loop (remote->loop),
+      pw_properties_new ("module.rt", "false", NULL), 0);
   if (!remote->context)
     {
       pipewire_remote_destroy (remote);


### PR DESCRIPTION
If the PipeWire daemon restarts, the Camera implementation restarts its connection to PipeWire. As part of that process, it creates a pw_context which causes module-rt to be loaded, which in makes a blocking call out to the Realtime portal. Since that blocking call occurs on the main loop, the process is then deadlocked until the blocking DBus call times out.

We don't need the ability to run anything in realtime, so it is okay to just disable loading module-rt. In parallel, we'll make PipeWire have a more reasonable timeout for its DBus calls as well.