### PR TITLE
[1.20] secret: Init asynchronously

### DIFF
--- a/src/secret.c
+++ b/src/secret.c
@@ -192,26 +192,50 @@ secret_class_init (SecretClass *klass)
 }
 
 GDBusInterfaceSkeleton *
-secret_create (GDBusConnection *connection,
-	       const char      *dbus_name)
+secret_create_finish (GAsyncResult  *result,
+                      GError       **error)
 {
+  GTask *task = G_TASK (result);
+
+  return g_task_propagate_pointer (task, error);
+}
+
+static void
+proxy_created_cb (GObject      *source_object,
+                  GAsyncResult *result,
+                  gpointer      user_data)
+{
+  g_autoptr(GTask) task = G_TASK (user_data);
   g_autoptr(GError) error = NULL;
 
-  impl = xdp_dbus_impl_secret_proxy_new_sync (connection,
-                                              G_DBUS_PROXY_FLAGS_NONE,
-                                              dbus_name,
-                                              DESKTOP_PORTAL_OBJECT_PATH,
-                                              NULL,
-                                              &error);
-  if (impl == NULL)
+  impl = xdp_dbus_impl_secret_proxy_new_finish (result, &error);
+  if (!impl)
     {
-      g_warning ("Failed to create secret proxy: %s", error->message);
-      return NULL;
+      g_task_return_error (task, g_steal_pointer (&error));
+      return;
     }
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (impl), G_MAXINT);
 
   secret = g_object_new (secret_get_type (), NULL);
+  g_task_return_pointer (task, secret, g_object_unref);
+}
 
-  return G_DBUS_INTERFACE_SKELETON (secret);
+void
+secret_create_async (GDBusConnection     *connection,
+                     const char          *dbus_name,
+                     GCancellable        *cancellable,
+                     GAsyncReadyCallback  callback,
+                     gpointer             user_data)
+{
+  g_autoptr(GTask) task = NULL;
+
+  task = g_task_new (NULL, cancellable, callback, user_data);
+  xdp_dbus_impl_secret_proxy_new (connection,
+                                  G_DBUS_PROXY_FLAGS_NONE,
+                                  dbus_name,
+                                  DESKTOP_PORTAL_OBJECT_PATH,
+                                  cancellable,
+                                  proxy_created_cb,
+                                  g_steal_pointer (&task));
 }

--- a/src/secret.h
+++ b/src/secret.h
@@ -24,5 +24,11 @@
 
 #include <gio/gio.h>
 
-GDBusInterfaceSkeleton * secret_create (GDBusConnection *connection,
-					const char *dbus_name);
+GDBusInterfaceSkeleton * secret_create_finish (GAsyncResult  *result,
+                                               GError       **error);
+
+void secret_create_async (GDBusConnection     *connection,
+                          const char          *dbus_name,
+                          GCancellable        *cancellable,
+                          GAsyncReadyCallback  callback,
+                          gpointer             user_data);

--- a/src/xdg-desktop-portal.c
+++ b/src/xdg-desktop-portal.c
@@ -87,6 +87,8 @@ static GOptionEntry entries[] = {
 
 XdpDbusImplLockdown *lockdown;
 
+static GCancellable *cancellable;
+
 static void
 message_handler (const gchar *log_domain,
                  GLogLevelFlags log_level,
@@ -239,6 +241,27 @@ exit_with_status (int status)
 }
 
 static void
+secret_impl_created_cb (GObject      *source_object,
+                        GAsyncResult *result,
+                        gpointer      user_data)
+{
+  GDBusConnection *connection;
+  g_autoptr(GDBusInterfaceSkeleton) skeleton = NULL;
+  g_autoptr(GError) error = NULL;
+
+  skeleton = secret_create_finish (result, &error);
+  if (!skeleton)
+    {
+      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        g_warning ("Failed to create secret proxy: %s", error->message);
+      return;
+    }
+
+  connection = G_DBUS_CONNECTION (user_data);
+  export_portal_implementation (connection, g_steal_pointer (&skeleton));
+}
+
+static void
 on_bus_acquired (GDBusConnection *connection,
                  const gchar     *name,
                  gpointer         user_data)
@@ -369,8 +392,8 @@ on_bus_acquired (GDBusConnection *connection,
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.Secret");
   if (implementation != NULL)
-    export_portal_implementation (connection,
-                                  secret_create (connection, implementation->dbus_name));
+    secret_create_async (connection, implementation->dbus_name,
+                         cancellable, secret_impl_created_cb, connection);
 
   implementation = find_portal_implementation ("org.freedesktop.impl.portal.GlobalShortcuts");
   if (implementation != NULL)
@@ -510,6 +533,8 @@ main (int argc, char *argv[])
 
   g_set_prgname (argv[0]);
 
+  cancellable = g_cancellable_new ();
+
   load_portal_configuration (opt_verbose);
   load_installed_portals (opt_verbose);
 
@@ -537,6 +562,9 @@ main (int argc, char *argv[])
                              on_name_lost,
                              NULL,
                              NULL);
+
+  g_cancellable_cancel (cancellable);
+  g_clear_object (&cancellable);
 
   g_main_loop_run (loop);
 


### PR DESCRIPTION
When run in a nested D-Bus session, the secret portal backend tends to fail to launch due to another secret service running within the same $XDG_RUNTIME_DIR. Handle this without blocking by initializing the secret portal asynchronously.

Based on an earlier version of
https://github.com/flatpak/xdg-desktop-portal/pull/1814.