### PR TITLE
document-portal: fix open-file for atypical XDG_RUNTIME_DIR

### DIFF
--- a/desktop-portal/account.c
+++ b/desktop-portal/account.c
@@ -85,7 +85,11 @@ send_response_in_thread_func (GTask        *task,
       if (xdp_app_info_is_host (request->app_info))
         ruri = g_strdup (image);
       else
-        ruri = xdp_register_document (image, xdp_app_info_get_id (request->app_info), XDP_DOCUMENT_FLAG_NONE, &error);
+        ruri = xdp_register_document (image,
+                                      xdp_app_info_get_id (request->app_info),
+                                      xdp_app_info_get_gappinfo (request->app_info),
+                                      XDP_DOCUMENT_FLAG_NONE,
+                                      &error);
 
       if (ruri == NULL)
         {

--- a/desktop-portal/background.c
+++ b/desktop-portal/background.c
@@ -790,7 +790,7 @@ enable_autostart_sync (XdpAppInfo          *app_info,
   g_autofree char *path = NULL;
   g_autoptr(GKeyFile) keyfile = NULL;
   const char *appid = xdp_app_info_get_id (app_info);
-  GAppInfo *info = xdp_app_info_get_gappinfo (app_info);
+  GDesktopAppInfo *info = xdp_app_info_get_gappinfo (app_info);
 
   if (g_strcmp0 (appid, "") == 0)
     {
@@ -831,7 +831,7 @@ enable_autostart_sync (XdpAppInfo          *app_info,
   g_key_file_set_string (keyfile,
                          G_KEY_FILE_DESKTOP_GROUP,
                          G_KEY_FILE_DESKTOP_KEY_NAME,
-                         info ? g_app_info_get_name (info) : appid);
+                         info ? g_app_info_get_name (G_APP_INFO (info)) : appid);
   g_key_file_set_string (keyfile,
                          G_KEY_FILE_DESKTOP_GROUP,
                          "X-XDP-Autostart",

--- a/desktop-portal/file-chooser.c
+++ b/desktop-portal/file-chooser.c
@@ -113,7 +113,11 @@ send_response_in_thread_func (GTask        *task,
           if (xdp_app_info_is_host (request->app_info))
             ruri = g_strdup (uris[i]);
           else
-            ruri = xdp_register_document (uris[i], xdp_app_info_get_id (request->app_info), flags, &error);
+            ruri = xdp_register_document (uris[i],
+                                          xdp_app_info_get_id (request->app_info),
+                                          xdp_app_info_get_gappinfo (request->app_info),
+                                          flags,
+                                          &error);
 
           if (ruri == NULL)
             {

--- a/desktop-portal/location.c
+++ b/desktop-portal/location.c
@@ -513,7 +513,7 @@ handle_start_in_thread_func (GTask *task,
     {
       const char *app_id = xdp_app_info_get_id (request->app_info);
       const char *app_name = xdp_app_info_get_app_display_name (request->app_info);
-      GAppInfo *app_info = xdp_app_info_get_gappinfo (request->app_info);
+      GDesktopAppInfo *app_info = xdp_app_info_get_gappinfo (request->app_info);
       guint access_response = 2;
       g_autoptr(GVariant) access_results = NULL;
       g_autoptr(XdpDbusImplRequest) impl_request = NULL;

--- a/desktop-portal/open-uri.c
+++ b/desktop-portal/open-uri.c
@@ -232,7 +232,7 @@ launch_application_with_uri (const char *choice_id,
       if (writable)
         flags |= XDP_DOCUMENT_FLAG_WRITABLE;
 
-      ruri = xdp_register_document (uri, app_id, flags, &local_error);
+      ruri = xdp_register_document (uri, app_id, info, flags, &local_error);
       if (ruri == NULL)
         {
           g_warning ("Error registering %s for %s: %s", uri, app_id, local_error->message);

--- a/desktop-portal/screenshot.c
+++ b/desktop-portal/screenshot.c
@@ -116,7 +116,11 @@ send_response_in_thread_func (GTask *task,
       if (xdp_app_info_is_host (request->app_info))
         ruri = g_strdup (uri);
       else
-        ruri = xdp_register_document (uri, xdp_app_info_get_id (request->app_info), XDP_DOCUMENT_FLAG_DELETABLE, &error);
+        ruri = xdp_register_document (uri,
+                                      xdp_app_info_get_id (request->app_info),
+                                      xdp_app_info_get_gappinfo (request->app_info),
+                                      XDP_DOCUMENT_FLAG_DELETABLE,
+                                      &error);
 
       if (ruri == NULL)
         g_warning ("Failed to register %s: %s", uri, error->message);

--- a/desktop-portal/xdp-documents.c
+++ b/desktop-portal/xdp-documents.c
@@ -54,6 +54,7 @@ xdp_init_document_proxy (GDBusConnection  *connection,
 char *
 xdp_register_document (const char        *uri,
                        const char        *app_id,
+                       GDesktopAppInfo   *app_info,
                        XdpDocumentFlags   flags,
                        GError           **error)
 {
@@ -72,6 +73,7 @@ xdp_register_document (const char        *uri,
   int version;
   gboolean handled_permissions = FALSE;
   DocumentAddFullFlags full_flags;
+  g_autofree char *fuse_path = NULL;
 
   g_return_val_if_fail (app_id != NULL && *app_id != '\0', NULL);
 
@@ -201,7 +203,9 @@ xdp_register_document (const char        *uri,
       return g_filename_to_uri (doc_path, NULL, error);
     }
 
-  doc_path = g_build_filename (documents_mountpoint, doc_id, basename, NULL);
+  fuse_path = xdp_desktop_app_info_get_doc_mountpoint (app_info);
+  doc_path = g_build_filename (fuse_path, doc_id, basename, NULL);
+
   return g_filename_to_uri (doc_path, NULL, error);
 }
 

--- a/desktop-portal/xdp-documents.h
+++ b/desktop-portal/xdp-documents.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <gio/gdesktopappinfo.h>
 #include <gio/gio.h>
 
 #include "xdp-types.h"
@@ -21,6 +22,7 @@ gboolean xdp_init_document_proxy (GDBusConnection  *connection,
 
 char *xdp_register_document (const char        *uri,
                              const char        *app_id,
+                             GDesktopAppInfo   *app_info,
                              XdpDocumentFlags   flags,
                              GError           **error);
 

--- a/shared/xdp-app-info-private.h
+++ b/shared/xdp-app-info-private.h
@@ -36,6 +36,6 @@ struct _XdpAppInfoClass
                                          GKeyFile    *key_file,
                                          GError     **error);
 
-  GAppInfo * (*create_gappinfo) (XdpAppInfo *app_info);
+  GDesktopAppInfo * (*create_gappinfo) (XdpAppInfo *app_info);
 };
 

--- a/shared/xdp-app-info-snap.c
+++ b/shared/xdp-app-info-snap.c
@@ -36,14 +36,13 @@ typedef enum
 
 static GParamSpec *properties [PROP_DESKTOP_FILE + 1];
 
-static GAppInfo *
+static GDesktopAppInfo *
 xdp_app_info_snap_create_gappinfo (XdpAppInfo *app_info)
 {
   XdpAppInfoSnap *app_info_snap = XDP_APP_INFO_SNAP (app_info);
-  g_autoptr(GAppInfo) gappinfo = NULL;
+  g_autoptr(GDesktopAppInfo) gappinfo = NULL;
 
-  gappinfo =
-    G_APP_INFO (g_desktop_app_info_new (app_info_snap->desktop_file));
+  gappinfo = g_desktop_app_info_new (app_info_snap->desktop_file);
 
   return g_steal_pointer (&gappinfo);
 }

--- a/shared/xdp-app-info.c
+++ b/shared/xdp-app-info.c
@@ -43,7 +43,7 @@ typedef struct _XdpAppInfoPrivate
   char *instance;
 
   /* app info */
-  GAppInfo *gappinfo;
+  GDesktopAppInfo *gappinfo;
 
   /* calling process */
   int pidfd;
@@ -105,15 +105,15 @@ g_initable_init_iface (GInitableIface *iface)
   iface->init = xdp_app_info_initable_init;
 }
 
-static GAppInfo *
+static GDesktopAppInfo *
 xdp_app_info_real_create_gappinfo (XdpAppInfo *app_info)
 {
   XdpAppInfoPrivate *priv = xdp_app_info_get_instance_private (app_info);
-  g_autoptr(GAppInfo) gappinfo = NULL;
+  g_autoptr(GDesktopAppInfo) gappinfo = NULL;
   g_autofree char *desktop_id = NULL;
 
   desktop_id = g_strconcat (priv->id, ".desktop", NULL);
-  gappinfo = G_APP_INFO (g_desktop_app_info_new (desktop_id));
+  gappinfo = g_desktop_app_info_new (desktop_id);
 
   return g_steal_pointer (&gappinfo);
 }
@@ -397,7 +397,7 @@ xdp_app_info_get_app_display_name (XdpAppInfo *app_info)
   XdpAppInfoPrivate *priv = xdp_app_info_get_instance_private (app_info);
 
   if (priv->gappinfo)
-    return g_app_info_get_display_name (priv->gappinfo);
+    return g_app_info_get_display_name (G_APP_INFO (priv->gappinfo));
 
   if (g_strcmp0 (priv->id, "") != 0)
     return priv->id;
@@ -476,7 +476,7 @@ xdp_app_info_get_sender (XdpAppInfo *app_info)
   return priv->sender;
 }
 
-GAppInfo *
+GDesktopAppInfo *
 xdp_app_info_get_gappinfo (XdpAppInfo *app_info)
 {
   XdpAppInfoPrivate *priv;

--- a/shared/xdp-app-info.h
+++ b/shared/xdp-app-info.h
@@ -48,7 +48,7 @@ const char * xdp_app_info_get_app_display_name (XdpAppInfo *app_info);
 
 const char * xdp_app_info_get_engine_display_name (XdpAppInfo *app_info);
 
-GAppInfo * xdp_app_info_get_gappinfo (XdpAppInfo *app_info);
+GDesktopAppInfo * xdp_app_info_get_gappinfo (XdpAppInfo *app_info);
 
 gboolean xdp_app_info_is_valid_sub_app_id (XdpAppInfo *app_info,
                                            const char *sub_app_id);

--- a/shared/xdp-utils.c
+++ b/shared/xdp-utils.c
@@ -1511,3 +1511,17 @@ xdp_desktop_app_info_is_sandboxed (GDesktopAppInfo *info)
 
   return FALSE;
 }
+
+char *
+xdp_desktop_app_info_get_doc_mountpoint (GDesktopAppInfo *info)
+{
+  {
+    g_autofree char *flatpak_id =
+      g_desktop_app_info_get_string (info, "X-Flatpak");
+
+    if (flatpak_id && *flatpak_id)
+      return g_build_filename ("/run/flatpak/doc", NULL);
+  }
+
+  return g_build_filename (g_get_user_runtime_dir (), "doc", NULL);
+}

--- a/shared/xdp-utils.h
+++ b/shared/xdp-utils.h
@@ -205,5 +205,8 @@ gboolean xdp_desktop_app_info_is_sandboxed (GDesktopAppInfo *info);
 /* Returns the sandboxed app ID, or the desktop file basename as fallback */
 char * xdp_desktop_app_info_get_app_id (GDesktopAppInfo *info);
 
+/* Returns the document fuse mountpoint */
+char * xdp_desktop_app_info_get_doc_mountpoint (GDesktopAppInfo *info);
+
 #define XDP_EXPORT_TEST XDP_EXPORT
 #define XDP_EXPORT __attribute__((visibility("default"))) extern

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -8,6 +8,7 @@ import tests.xdp_utils as xdp
 import pytest
 import os
 from pathlib import Path
+import re
 
 
 ACCOUNT_DATA = {
@@ -22,6 +23,7 @@ def required_templates():
     image = Path(os.environ["XDG_DATA_HOME"]) / "account-image.png"
     image.write_text("image contents")
     ACCOUNT_DATA["image"] = f"file://{image.absolute().as_posix()}"
+    ACCOUNT_DATA["document"] = f"file:///run/flatpak/doc/[^/]+/{image.name}"
 
     return {
         "account": {
@@ -56,7 +58,10 @@ class TestAccount:
         assert response.results["id"] == ACCOUNT_DATA["id"]
         assert response.results["name"] == ACCOUNT_DATA["name"]
         assert response.results["image"]
-        assert xdp.uri_same_file(ACCOUNT_DATA["image"], response.results["image"])
+        if isinstance(xdp_app_info, xdp.AppInfoFlatpak):
+            assert re.match(ACCOUNT_DATA["document"], response.results["image"])
+        else:
+            assert xdp.uri_same_file(ACCOUNT_DATA["image"], response.results["image"])
 
         # Check the impl portal was called with the right args
         method_calls = mock_intf.GetMethodCalls("GetUserInformation")

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -11,6 +11,7 @@ from enum import Flag
 from typing import Any
 import os
 from pathlib import Path
+import re
 
 
 SCREENSHOT_DATA = dbus.Dictionary(
@@ -48,6 +49,7 @@ def required_templates():
     image = Path(os.environ["XDG_DATA_HOME"]) / "screenshot-image.png"
     image.write_text("image contents")
     SCREENSHOT_DATA["uri"] = f"file://{image.absolute().as_posix()}"
+    SCREENSHOT_DATA["document"] = f"file:///run/flatpak/doc/[^/]+/{image.name}"
 
     return {
         "access": {},
@@ -219,7 +221,10 @@ class TestScreenshot:
         assert response
         assert response.response == 0
 
-        assert xdp.uri_same_file(SCREENSHOT_DATA["uri"], response.results["uri"])
+        if isinstance(xdp_app_info, xdp.AppInfoFlatpak):
+            assert re.match(SCREENSHOT_DATA["document"], response.results["uri"])
+        else:
+            assert xdp.uri_same_file(SCREENSHOT_DATA["uri"], response.results["uri"])
 
         # Check the impl portal was called with the right args
         method_calls = mock_intf.GetMethodCalls("Screenshot")

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -318,13 +318,15 @@ class AppInfoFlatpak(AppInfo):
             self.instance_id = "1234567890"
 
         if not self.desktop_entry:
-            self.desktop_entry = b"""
+            desktop_entry_str = f"""
 [Desktop Entry]
 Version=1.0
 Name=Example App
 Exec=true %u
 Type=Application
+X-Flatpak={self.app_id}
 """
+            self.desktop_entry = desktop_entry_str.encode("UTF-8")
 
         if not self.metadata:
             metadata_str = f"""


### PR DESCRIPTION
When the XDG_RUNTIME_DIR is not the typical /run/user/UID, the whole file picker then portals fails to give an accessible path to the app:

https://github.com/flatpak/flatpak/issues/6494
https://github.com/flatpak/flatpak/issues/5573

The document portal correctly create the mount point, and handle the request as it should. The problem is that portals are not mapping the paths back to the internal path /run/flatpak/doc.

documents_mountpoint is the host path. When using the typical path /run/user/UID/doc, it works because this runtime dir is also mounted in the bwrap, but this is not the documented /run/flatpak/doc/ path:

doc/documents-and-fuse.rst:


> FUSE
> ----
> 
> Inside the Flatpak sandbox, files for which the app has permission to access are
> available at ``/run/flatpak/doc``.


This xdp_register_document method is only used by portals, to call the desktop portal. The portals then return those paths directly. I think we can just enforce the expected path prefix here.