### PR TITLE
Allow service's start even if graphical-session is not reached

### DIFF
--- a/desktop-portal/xdg-desktop-portal.service.in
+++ b/desktop-portal/xdg-desktop-portal.service.in
@@ -4,7 +4,8 @@
 [Unit]
 Description=Portal service
 PartOf=graphical-session.target
-Requisite=graphical-session.target
+Requires=dbus.service
+After=dbus.service
 After=graphical-session.target
 
 [Service]

--- a/desktop-portal/xdg-desktop-portal.service.in
+++ b/desktop-portal/xdg-desktop-portal.service.in
@@ -6,6 +6,10 @@ Description=Portal service
 PartOf=graphical-session.target
 Requires=dbus.service
 After=dbus.service
+# This means correct ordering is only ensured for sessions started with
+# graphical-session.target. Replace the Requires and After above with the
+# following to reliably avoid this race.
+#Requisite=graphical-session.target
 After=graphical-session.target
 
 [Service]

--- a/desktop-portal/xdp-main.c
+++ b/desktop-portal/xdp-main.c
@@ -144,6 +144,12 @@ main (int argc, char *argv[])
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   textdomain (GETTEXT_PACKAGE);
 
+  if (!getenv ("WAYLAND_DISPLAY") && !getenv ("DISPLAY"))
+    {
+      g_critical ("Windowing system environment variables not set; "
+                  "make sure your session integrates with graphical-session.target.");
+    }
+
   dex_init ();
 
   /* Note: if you add any more environment variables here, update

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -492,6 +492,7 @@ def xdp_env(
     env = os.environ.copy()
     env["G_DEBUG"] = "fatal-criticals"
     env["XDG_CURRENT_DESKTOP"] = "test"
+    env["WAYLAND_DISPLAY"] = "wayland-0"
     env["PATH"] = xdp_bin_path.as_posix()
 
     for key, val in xdp_app_info_init.get_xdp_executable_env().items():


### PR DESCRIPTION
Patch by @aleasto, originally released to Ubuntu.

* Allow service's start even if graphical-session is not reached.
    
    While this is not ideal, we need to support desktop environments that do not
    bind to graphical-session.target, at least as a temporary measure.
    
    We keep the After=graphical-session.target stanza, since 'After' will only
    affect the ordering of start operations if both are queued up to start, while
    it is a no-op if graphical-session.target is not pending start.
    
    This partially reverts commit 4d284de29d1d0740c9b80b634631a8f253287680.
    
    Bug: https://github.com/flatpak/xdg-desktop-portal/issues/1983  
    Bug-Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=2481764  
    Bug-Ubuntu: https://launchpad.net/bugs/2144855

cc @jadahl 