### PR TITLE
[1.22] pipewire: Disable loading module-rt

### DIFF
--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -299,7 +299,9 @@ pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
       return NULL;
     }
 
-  remote->context = pw_context_new (pw_main_loop_get_loop (remote->loop), NULL, 0);
+  /* Loading module-rt will invoke the Realtime portal, causing a potential hang */
+  remote->context = pw_context_new (pw_main_loop_get_loop (remote->loop),
+      pw_properties_new ("module.rt", "false", NULL), 0);
   if (!remote->context)
     {
       pipewire_remote_destroy (remote);


### PR DESCRIPTION
Backport of https://github.com/flatpak/xdg-desktop-portal/pull/2012

If the PipeWire daemon restarts, the Camera implementation restarts its connection to PipeWire. As part of that process, it creates a pw_context which causes module-rt to be loaded, which in turn makes a blocking call out to the Realtime portal. Since that blocking call occurs on the main loop, the process is then deadlocked until the blocking DBus call times out.

We don't need the ability to run anything in realtime, so it is okay to just disable loading module-rt. There is also a fix in PipeWire[1] to have a more reasonable timeout for its DBus calls.

[1] https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/aef3d02173d162b7dfce495da9f04d8722d43811