### PR TITLE
xdp-session: Remove g_assert(session->token != NULL) — dead code, crashes portal instead of returning error

### DIFF
--- a/desktop-portal/xdp-session.c
+++ b/desktop-portal/xdp-session.c
@@ -277,7 +277,6 @@ xdp_session_initable_init (GInitable     *initable,
   int i;
 
   g_assert (session->sender != NULL);
-  g_assert (session->token != NULL);
   g_assert (session->context != NULL);
 
   sender_escaped = g_strdup (session->sender + 1);


### PR DESCRIPTION
## Summary

Removes `g_assert(session->token != NULL)` in `xdp_session_initable_init` — the assertion aborts the portal process when a session is created without `session_handle_token`, making the graceful error code below it unreachable.

## Details

The `g_assert` at `desktop-portal/xdp-session.c:279` fires when a session is created without `session_handle_token` in the GObject construction properties. The same code immediately after (lines 290-294) already handles this case gracefully with `g_set_error(error, ..., "Missing token"); return FALSE;`.

By removing the assertion, the graceful fallback becomes reachable and the portal returns a proper D-Bus error instead of aborting.

## Related

Fixes #2037 — this is the same root cause as #1314 (GlobalShortcuts 'Missing token') but manifests as a crash instead of a graceful error.

## Testing

- Triggered by creating any portal session without `session_handle_token`
- After fix: returns `Missing token` error via D-Bus
- Before fix: `SIGABRT`, portal process crashes