### PR TITLE
xdp: Switch to a new versioning scheme

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,7 +21,7 @@ body:
     label: "XDG Desktop Portal version"
     description: "What version of XDG Desktop Portal are you using?"
     options:
-    - "1.23"
+    - "23"
     - "1.22"
     - "1.20"
     - Git

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 -->
 
-Changes in 1.23.0
+Changes in 23.0
 =================
 Released: Not yet
 

--- a/RELEASE_HOWTO.md
+++ b/RELEASE_HOWTO.md
@@ -18,9 +18,8 @@ $ ninja -C ${builddir} xdg-desktop-portal-update-po
 $ git add po/
 $ git commit -m "Update translations"
 ```
-- If this is the first release of a new stable release series, update
-  `SECURITY.md`. It should list the development branch, new stable branch, and
-  old stable branch as currently maintained.
+- Update `SECURITY.md`
+- Update `.github/ISSUE_TEMPLATE/bug-report.yml`
 - Add your changelog to the `NEWS.md` file
 ```sh
 $ # Find PRs for the release
@@ -37,7 +36,6 @@ $ git commit -m ${version}
 $ git push -u ${fork} release-${version}
 ```
 - Open a pull request
-
 - Merge the pull request and wait for it to reach the `main` branch or the
   stable branch
 
@@ -47,21 +45,20 @@ $ git push -u ${fork} release-${version}
 
 Make sure that:
  - You're on the `main` branch, or a stable branch;
- - The tip of the branch is a release commit (e.g. `1.19.4`)
+ - The tip of the branch is a release commit (e.g. `23.0`)
  - The version in `meson.build` is correct
 
 Then create the tag:
-
 ```sh
-$ git evtag sign ${version}
+$ git evtag sign ${version} # Use ${version} as the tag message
 $ git push -u origin ${version}
 ```
 
-Copy paste the release notes from NEWS.md into the tag message when running
-`git evtag`.
-
 ### Post-Release
 
+Create the version branch: `git branch xdg-desktop-portal-${version}`
+
+On main and on the version branch:
 - Update version number in `meson.build` to the next release version
 - Start a new section in `NEWS.md`
 ```md
@@ -71,19 +68,5 @@ Released: Not yet
 
 ...
 ```
-
 - Commit the changes as "Post-release version bump" and push to the
-  corresponding branch
-
-### Post-Branching
-
-After creating a stable branch:
- 
-- Update version number in `meson.build` to the next unstable release version.
-  For example if the created stable branch name is xdg-desktop-portal-1.N, bump
-  the version to 1.N+1.0. Commit as "Post-branching version bump".
-- Update `.github/ISSUE_TEMPLATE/bug-report.yml`. It should list the
-  development version, and the currently maintained stable versions, under "XDG
-  Desktop Portal version".
-- Update the pending entry in NEWS.md to refer to the next unstable version.
-- Push changes to the `main` branch.
+  corresponding branches

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,5 @@ please check
 
 | Version   | Supported          | Status
 | --------  | ------------------ | ------------------------------------------------------------- |
-| 1.23.x    | :white_check_mark: | Development branch, releases may include non-security changes |
 | 1.22.x    | :white_check_mark: | Stable branch, recommended for use in distributions           |
-| 1.20.x    | :white_check_mark: | Old stable branch, still maintained                           |
-| <= 1.18.x | :x:                | Older branches, no longer supported                           |
+| <= 1.20.x | :x:                | Older branches, no longer supported                           |

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 project(
   'xdg-desktop-portal',
   'c',
-  version: '1.23.0',
+  version: '23.0',
   meson_version: '>= 1.1',
   license: 'LGPL-2.0-or-later',
   default_options: [


### PR DESCRIPTION
We currently have something which resembles semantic versioning, but the minor releases are stable when the number if even, and unstable when the number is odd.

This also means the first number is fixed at 1 because we never break backwards compatibility.

A lot of people get confused by the odd/even scheme. Distros like Fedora have been shipping unstable releases. Distros like Arch have not been testing any of the unstable releases. Systems like GNOME OS have started shipping xdp from git main in their nightly where we will notice when something went wrong immediately.

Releases are work. Doing them needs to have a benefit. It does not seem like there is any benefit for us to do the unstable releases.

Given that unstable releases are a waste of time and that the major version is fixed, this commit changes the project over to a scheme where...

* all releases are stable releases
* the version number is major.minor
* minor versions get released to deal with security issues and bugs
* only the latest major release is supported

The next release will be version 23.0 because we would have releases 1.23.0 in the old versioning scheme.