### PR TITLE
Fix PipeWire and WirePlumber issues

### DIFF
--- a/pipewire/pipewire.conf
+++ b/pipewire/pipewire.conf
@@ -7,10 +7,9 @@ context.properties = {
     module.portal = false
 }
 
-context.modules = {
+context.modules = [
     { name = libxdg-desktop-portal
         flags = [ ifexists ]
         condition = [ { module.xdp-desktop-portal = !false } ]
     }
-
-}
+]

--- a/pipewire/wp-plugin/xdp-wp-permission-manager.c
+++ b/pipewire/wp-plugin/xdp-wp-permission-manager.c
@@ -35,10 +35,11 @@ struct _XdpWpPermissionManager
 
 G_DEFINE_FINAL_TYPE (XdpWpPermissionManager, xdp_wp_permission_manager, G_TYPE_OBJECT);
 
-enum {
-  PROP_CORE,
+typedef enum
+{
+  PROP_CORE = 1,
   PROP_CONNECTION,
-};
+} XdpWpPermissionManagerProps;
 
 static GParamSpec *props[PROP_CONNECTION + 1] = { NULL, };
 
@@ -217,7 +218,7 @@ xdp_wp_permission_manager_set_property (GObject      *object,
 {
   XdpWpPermissionManager *self = XDP_WP_PERMISSION_MANAGER (object);
 
-  switch (property_id)
+  switch ((XdpWpPermissionManagerProps)property_id)
     {
     case PROP_CORE:
       self->core = g_object_ref (g_value_get_object (value));
@@ -226,9 +227,6 @@ xdp_wp_permission_manager_set_property (GObject      *object,
     case PROP_CONNECTION:
       self->connection = g_object_ref (g_value_get_object (value));
       break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
     }
 }
 


### PR DESCRIPTION
* pipewire: Fix drop-in configuration

   For some reason `{}` was working when I tested at the time of my old testing
   Was an array with `[]` since a real while, so there no need to worry about compat.
   https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/90b0410280da65f5b8f879da7f204735b6d27cb1
* pipewire: Fix WirePlumber module properties enum

   I blame gobject-linter on that one, since CI forced me to swap approach but didn't caught that I missed to add `= 1`.