### PR TITLE
pipewire,xdp: Refactor property keys under XDP namespace

### DIFF
--- a/desktop-portal/camera.c
+++ b/desktop-portal/camera.c
@@ -18,6 +18,7 @@
 #include "xdp-impl-dbus.h"
 #include "xdp-permissions.h"
 #include "xdp-portal-config.h"
+#include "xdp-pw-keys.h"
 #include "xdp-request.h"
 #include "xdp-utils.h"
 
@@ -219,8 +220,8 @@ open_pipewire_camera_remote (const char *app_id,
   struct pw_properties *pipewire_properties;
 
   pipewire_properties =
-    pw_properties_new ("pipewire.access.xdg-desktop-portal.app_id", app_id,
-                       "pipewire.access.xdg-desktop-portal.media_roles", "Camera",
+    pw_properties_new (XDP_PW_KEY_APP_ID, app_id,
+                       XDP_PW_KEY_MEDIA_ROLES, "Camera",
                        NULL);
   remote = pipewire_remote_new_sync (pipewire_properties,
                                      NULL, NULL, NULL, NULL,
@@ -416,8 +417,8 @@ create_pipewire_remote (Camera *camera,
       return FALSE;
     }
 
-  pipewire_properties = pw_properties_new ("pipewire.access.xdg-desktop-portal.is_portal", "true",
-                                           "xdg-desktop-portal.monitor", "Camera",
+  pipewire_properties = pw_properties_new (XDP_PW_NAMESPACE ".is_portal", "true",
+                                           XDP_PW_NAMESPACE ".monitor", "Camera",
                                            NULL);
   camera->pipewire_remote = pipewire_remote_new_sync (pipewire_properties,
                                                       global_added_cb,

--- a/desktop-portal/meson.build
+++ b/desktop-portal/meson.build
@@ -142,6 +142,7 @@ xdg_desktop_portal_deps = common_deps + [
 
 incs_xdg_desktop_portal = [
   common_includes,
+  xdp_pipewire_includes,
   xdp_utils_includes,
   include_directories('.'),
   include_directories('../document-portal'),

--- a/desktop-portal/screen-cast.c
+++ b/desktop-portal/screen-cast.c
@@ -18,6 +18,7 @@
 #include "xdp-impl-dbus.h"
 #include "xdp-permissions.h"
 #include "xdp-portal-config.h"
+#include "xdp-pw-keys.h"
 #include "xdp-request.h"
 #include "xdp-session-persistence.h"
 #include "xdp-session.h"
@@ -691,8 +692,8 @@ open_pipewire_screen_cast_remote (const char *app_id,
   PipeWireRemote *remote;
   g_autoptr(GArray) permission_items = NULL;
 
-  pipewire_properties = pw_properties_new ("pipewire.access.xdg-desktop-portal.app_id", app_id,
-                                           "pipewire.access.xdg-desktop-portal.media_roles", "",
+  pipewire_properties = pw_properties_new (XDP_PW_KEY_APP_ID, app_id,
+                                           XDP_PW_KEY_MEDIA_ROLES, "",
                                            NULL);
   remote = pipewire_remote_new_sync (pipewire_properties,
                                      NULL, NULL, NULL, NULL,

--- a/doc/pipewire.rst
+++ b/doc/pipewire.rst
@@ -37,7 +37,7 @@ at the `session manager  <https://docs.pipewire.org/page_session_manager.html>`_
 level.
 
 An object manager watches for clients with ``PW_KEY_ACCESS`` set to
-``"xdg-desktop-portal"`` and ``PW_KEY_ACCESS_XDP_APP_ID`` assigned to a value.
+``"xdg-desktop-portal"`` and ``XDP_PW_KEY_APP_ID`` assigned to a value.
 
 Camera
 """"""
@@ -45,7 +45,7 @@ Camera
 A node is considered a camera if ``PW_KEY_MEDIA_ROLE`` is set to ``"Camera"``
 and ``PW_KEY_MEDIA_CLASS`` to ``"Video/Source"``.
 
-If xdg-desktop-portal assigned ``PW_KEY_ACCESS_XDP_MEDIA_ROLES`` to ``"Camera"``
+If xdg-desktop-portal assigned ``XDP_PW_KEY_MEDIA_ROLES`` to ``"Camera"``
 to the PipeWire client, access to every node considered as camera will be
 granted to the client.
 

--- a/meson.build
+++ b/meson.build
@@ -257,9 +257,9 @@ pkgconfig.generate(
 
 subdir('data')
 subdir('shared')
+subdir('pipewire')
 subdir('desktop-portal')
 subdir('document-portal')
-subdir('pipewire')
 subdir('po')
 subdir('doc')
 

--- a/pipewire/meson.build
+++ b/pipewire/meson.build
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
+xdp_pipewire_includes = [include_directories('.')]
+
 subdir('pw-module')
 subdir('wp-plugin')
 

--- a/pipewire/pw-module/meson.build
+++ b/pipewire/pw-module/meson.build
@@ -9,6 +9,7 @@ xdp_pipewire_module = shared_library(
   'xdg-desktop-portal',
   xdp_pipewire_module_sources,
   dependencies: [pipewire_dep, libdbus_dep],
+  include_directories: xdp_pipewire_includes,
   install: true,
   install_dir: pipewire_module_dir,
 )

--- a/pipewire/pw-module/module-portal.c
+++ b/pipewire/pw-module/module-portal.c
@@ -25,6 +25,8 @@
 #include <spa/utils/result.h>
 #include <spa/support/dbus.h>
 
+#include "xdp-pw-keys.h"
+
 #define NAME "xdg-desktop-portal"
 
 #define PORTAL_SERVICE_NAME "org.freedesktop.portal.Desktop"
@@ -120,7 +122,7 @@ context_check_access(void *data, struct pw_impl_client *client)
 	if (pid != impl->portal_pid)
 		return;
 
-	items[0] = SPA_DICT_ITEM_INIT(PW_KEY_ACCESS, "xdg-desktop-portal");
+	items[0] = SPA_DICT_ITEM_INIT(PW_KEY_ACCESS, XDP_PW_ACCESS);
 	pw_impl_client_update_properties(client, &SPA_DICT_INIT(items, 1));
 
 	pw_log_info("%p: portal managed client %p added", impl, client);

--- a/pipewire/wp-plugin/meson.build
+++ b/pipewire/wp-plugin/meson.build
@@ -18,6 +18,7 @@ xdp_wireplumber_module = shared_library(
   'xdg-desktop-portal',
   xdp_wireplumber_module_sources,
   dependencies: [wireplumber_dep, pipewire_dep],
+  include_directories: xdp_pipewire_includes,
   install: true,
   install_dir: wireplumber_module_dir,
 )

--- a/pipewire/wp-plugin/xdp-wp-permission-manager.c
+++ b/pipewire/wp-plugin/xdp-wp-permission-manager.c
@@ -11,6 +11,7 @@
 #include <wp/wp.h>
 
 #include "xdp-impl-dbus.h"
+#include "xdp-pw-keys.h"
 
 WP_DEFINE_LOCAL_LOG_TOPIC ("m-xdp-permission-manager");
 
@@ -43,9 +44,6 @@ typedef enum
 
 static GParamSpec *props[PROP_CONNECTION + 1] = { NULL, };
 
-#define PW_KEY_ACCESS_XDP_APP_ID PW_KEY_ACCESS ".xdg-desktop-portal.app_id"
-#define PW_KEY_ACCESS_XDP_MEDIA_ROLES PW_KEY_ACCESS ".xdg-desktop-portal.media_roles"
-
 static void
 update_client_camera_permission (XdpWpPermissionManager *self,
                                  WpClient               *client,
@@ -62,7 +60,7 @@ update_client_camera_permission (XdpWpPermissionManager *self,
     iter && g_variant_iter_next (iter, "s", &value) && (g_strcmp0 (value, "yes") == 0);
 
   roles = wp_pipewire_object_get_property (WP_PIPEWIRE_OBJECT (client),
-                                           PW_KEY_ACCESS_XDP_MEDIA_ROLES);
+                                           XDP_PW_KEY_MEDIA_ROLES);
 
   if (!roles)
     {
@@ -127,7 +125,7 @@ update_camera_permissions (XdpWpPermissionManager *self,
       g_autoptr (GVariantIter) value = NULL;
 
       app_id = wp_pipewire_object_get_property (WP_PIPEWIRE_OBJECT (client),
-                                                PW_KEY_ACCESS_XDP_APP_ID);
+                                                XDP_PW_KEY_APP_ID);
 
       if (app_id)
         {
@@ -152,7 +150,7 @@ update_camera_permissions (XdpWpPermissionManager *self,
           g_autoptr (GVariantIter) value = NULL;
 
           app_id = wp_pipewire_object_get_property (WP_PIPEWIRE_OBJECT (client),
-                                                    PW_KEY_ACCESS_XDP_APP_ID);
+                                                    XDP_PW_KEY_APP_ID);
 
           if (app_id)
             {
@@ -247,9 +245,9 @@ xdp_wp_permission_manager_constructed (GObject *object)
                                   WP_CONSTRAINT_TYPE_PW_PROPERTY,
                                   PW_KEY_ACCESS,
                                   "=s",
-                                  "xdg-desktop-portal",
+                                  XDP_PW_ACCESS,
                                   WP_CONSTRAINT_TYPE_PW_PROPERTY,
-                                  PW_KEY_ACCESS_XDP_APP_ID,
+                                  XDP_PW_KEY_APP_ID,
                                   "+",
                                   NULL);
 

--- a/pipewire/xdp-pw-keys.h
+++ b/pipewire/xdp-pw-keys.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors */
+
+#pragma once
+
+#define XDP_PW_NAMESPACE "xdg-desktop-portal"
+#define XDP_PW_ACCESS XDP_PW_NAMESPACE
+
+#define XDP_PW_KEY_APP_ID XDP_PW_NAMESPACE ".app_id"
+#define XDP_PW_KEY_MEDIA_ROLES XDP_PW_NAMESPACE ".media_roles"


### PR DESCRIPTION
Centralize common keys in one header file and move away from PipeWire namespace for xdp custom properties.

PS: Tested under GNOME OS with a self-made sysext (Camera, ScreenCast)