### PR TITLE
Stop using G_GNUC_CONST in _get_type functions

### DIFF
--- a/desktop-portal/account.c
+++ b/desktop-portal/account.c
@@ -39,7 +39,7 @@ struct _AccountClass
   XdpDbusAccountSkeletonClass parent_class;
 };
 
-GType account_get_type (void) G_GNUC_CONST;
+GType account_get_type (void);
 static void account_iface_init (XdpDbusAccountIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Account, account, XDP_DBUS_TYPE_ACCOUNT_SKELETON,

--- a/desktop-portal/background.c
+++ b/desktop-portal/background.c
@@ -78,7 +78,7 @@ struct _BackgroundClass
   XdpDbusBackgroundSkeletonClass parent_class;
 };
 
-GType background_get_type (void) G_GNUC_CONST;
+GType background_get_type (void);
 static void background_iface_init (XdpDbusBackgroundIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Background, background,

--- a/desktop-portal/clipboard.c
+++ b/desktop-portal/clipboard.c
@@ -34,7 +34,7 @@ struct _ClipboardClass
   XdpDbusClipboardSkeletonClass parent_class;
 };
 
-GType clipboard_get_type (void) G_GNUC_CONST;
+GType clipboard_get_type (void);
 static void clipboard_iface_init (XdpDbusClipboardIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Clipboard,

--- a/desktop-portal/dynamic-launcher.c
+++ b/desktop-portal/dynamic-launcher.c
@@ -48,7 +48,7 @@ struct _DynamicLauncherClass
   XdpDbusDynamicLauncherSkeletonClass parent_class;
 };
 
-GType dynamic_launcher_get_type (void) G_GNUC_CONST;
+GType dynamic_launcher_get_type (void);
 static void dynamic_launcher_iface_init (XdpDbusDynamicLauncherIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (DynamicLauncher, dynamic_launcher,

--- a/desktop-portal/email.c
+++ b/desktop-portal/email.c
@@ -40,7 +40,7 @@ struct _EmailClass
   XdpDbusEmailSkeletonClass parent_class;
 };
 
-GType email_get_type (void) G_GNUC_CONST;
+GType email_get_type (void);
 static void email_iface_init (XdpDbusEmailIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Email, email, XDP_DBUS_TYPE_EMAIL_SKELETON,

--- a/desktop-portal/file-chooser.c
+++ b/desktop-portal/file-chooser.c
@@ -40,7 +40,7 @@ struct _FileChooserClass
   XdpDbusFileChooserSkeletonClass parent_class;
 };
 
-GType file_chooser_get_type (void) G_GNUC_CONST;
+GType file_chooser_get_type (void);
 static void file_chooser_iface_init (XdpDbusFileChooserIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (FileChooser, file_chooser,

--- a/desktop-portal/gamemode.c
+++ b/desktop-portal/gamemode.c
@@ -94,7 +94,7 @@ struct _GameModeClass
   XdpDbusGameModeSkeletonClass parent_class;
 };
 
-GType game_mode_get_type (void) G_GNUC_CONST;
+GType game_mode_get_type (void);
 static void game_mode_iface_init (XdpDbusGameModeIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (GameMode, game_mode, XDP_DBUS_TYPE_GAME_MODE_SKELETON,

--- a/desktop-portal/global-shortcuts.c
+++ b/desktop-portal/global-shortcuts.c
@@ -38,7 +38,7 @@ struct _GlobalShortcutsClass
   XdpDbusGlobalShortcutsSkeletonClass parent_class;
 };
 
-GType global_shortcuts_get_type (void) G_GNUC_CONST;
+GType global_shortcuts_get_type (void);
 static void global_shortcuts_iface_init (XdpDbusGlobalShortcutsIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (GlobalShortcuts, global_shortcuts, XDP_DBUS_TYPE_GLOBAL_SHORTCUTS_SKELETON,

--- a/desktop-portal/inhibit.c
+++ b/desktop-portal/inhibit.c
@@ -44,7 +44,7 @@ struct _InhibitClass
   XdpDbusInhibitSkeletonClass parent_class;
 };
 
-GType inhibit_get_type (void) G_GNUC_CONST;
+GType inhibit_get_type (void);
 static void inhibit_iface_init (XdpDbusInhibitIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Inhibit, inhibit, XDP_DBUS_TYPE_INHIBIT_SKELETON,

--- a/desktop-portal/input-capture.c
+++ b/desktop-portal/input-capture.c
@@ -39,7 +39,7 @@ struct _InputCaptureClass
 
 static GQuark quark_request_session;
 
-GType input_capture_get_type (void)  G_GNUC_CONST;
+GType input_capture_get_type (void);
 static void input_capture_iface_init (XdpDbusInputCaptureIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (InputCapture, input_capture, XDP_DBUS_TYPE_INPUT_CAPTURE_SKELETON,

--- a/desktop-portal/location.c
+++ b/desktop-portal/location.c
@@ -48,7 +48,7 @@ typedef struct
   XdpDbusLocationSkeletonClass parent_class;
 } LocationClass;
 
-GType location_get_type (void) G_GNUC_CONST;
+GType location_get_type (void);
 static void location_iface_init (XdpDbusLocationIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Location, location, XDP_DBUS_TYPE_LOCATION_SKELETON,

--- a/desktop-portal/memory-monitor.c
+++ b/desktop-portal/memory-monitor.c
@@ -34,7 +34,7 @@ struct _MemoryMonitorClass
   XdpDbusMemoryMonitorSkeletonClass parent_class;
 };
 
-GType memory_monitor_get_type (void) G_GNUC_CONST;
+GType memory_monitor_get_type (void);
 static void memory_monitor_iface_init (XdpDbusMemoryMonitorIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (MemoryMonitor, memory_monitor,

--- a/desktop-portal/network-monitor.c
+++ b/desktop-portal/network-monitor.c
@@ -30,7 +30,7 @@ struct _NetworkMonitorClass
   XdpDbusNetworkMonitorSkeletonClass parent_class;
 };
 
-GType network_monitor_get_type (void) G_GNUC_CONST;
+GType network_monitor_get_type (void);
 static void network_monitor_iface_init (XdpDbusNetworkMonitorIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (NetworkMonitor, network_monitor,

--- a/desktop-portal/notification.c
+++ b/desktop-portal/notification.c
@@ -159,7 +159,7 @@ call_data_class_init (CallDataClass *klass)
   object_class->finalize = call_data_finalize;
 }
 
-GType notification_get_type (void) G_GNUC_CONST;
+GType notification_get_type (void);
 static void notification_iface_init (XdpDbusNotificationIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Notification, notification,

--- a/desktop-portal/open-uri.c
+++ b/desktop-portal/open-uri.c
@@ -63,7 +63,7 @@ enum {
   LAST_PERM
 };
 
-GType open_uri_get_type (void) G_GNUC_CONST;
+GType open_uri_get_type (void);
 static void open_uri_iface_init (XdpDbusOpenURIIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (OpenURI, open_uri, XDP_DBUS_TYPE_OPEN_URI_SKELETON,

--- a/desktop-portal/power-profile-monitor.c
+++ b/desktop-portal/power-profile-monitor.c
@@ -35,7 +35,7 @@ struct _PowerProfileMonitorClass
   XdpDbusPowerProfileMonitorSkeletonClass parent_class;
 };
 
-GType power_profile_monitor_get_type (void) G_GNUC_CONST;
+GType power_profile_monitor_get_type (void);
 static void power_profile_monitor_iface_init (XdpDbusPowerProfileMonitorIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (PowerProfileMonitor, power_profile_monitor,

--- a/desktop-portal/print.c
+++ b/desktop-portal/print.c
@@ -40,7 +40,7 @@ struct _PrintClass
   XdpDbusPrintSkeletonClass parent_class;
 };
 
-GType print_get_type (void) G_GNUC_CONST;
+GType print_get_type (void);
 static void print_iface_init (XdpDbusPrintIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Print, print, XDP_DBUS_TYPE_PRINT_SKELETON,

--- a/desktop-portal/proxy-resolver.c
+++ b/desktop-portal/proxy-resolver.c
@@ -30,7 +30,7 @@ struct _ProxyResolverClass
   XdpDbusProxyResolverSkeletonClass parent_class;
 };
 
-GType proxy_resolver_get_type (void) G_GNUC_CONST;
+GType proxy_resolver_get_type (void);
 static void proxy_resolver_iface_init (XdpDbusProxyResolverIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (ProxyResolver, proxy_resolver,

--- a/desktop-portal/realtime.c
+++ b/desktop-portal/realtime.c
@@ -34,7 +34,7 @@ struct _RealtimeClass
   XdpDbusRealtimeSkeletonClass parent_class;
 };
 
-GType realtime_get_type (void) G_GNUC_CONST;
+GType realtime_get_type (void);
 static void realtime_iface_init (XdpDbusRealtimeIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Realtime, realtime, XDP_DBUS_TYPE_REALTIME_SKELETON,

--- a/desktop-portal/registry.c
+++ b/desktop-portal/registry.c
@@ -29,7 +29,7 @@ struct _RegistryClass
   XdpDbusHostRegistrySkeletonClass parent_class;
 };
 
-GType registry_get_type (void) G_GNUC_CONST;
+GType registry_get_type (void);
 static void registry_iface_init (XdpDbusHostRegistryIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Registry, registry,

--- a/desktop-portal/remote-desktop.c
+++ b/desktop-portal/remote-desktop.c
@@ -37,7 +37,7 @@ struct _RemoteDesktopClass
   XdpDbusRemoteDesktopSkeletonClass parent_class;
 };
 
-GType remote_desktop_get_type (void) G_GNUC_CONST;
+GType remote_desktop_get_type (void);
 static void remote_desktop_iface_init (XdpDbusRemoteDesktopIface *iface);
 
 static GQuark quark_request_session;

--- a/desktop-portal/screenshot.c
+++ b/desktop-portal/screenshot.c
@@ -52,7 +52,7 @@ struct _ScreenshotClass
   XdpDbusScreenshotSkeletonClass parent_class;
 };
 
-GType screenshot_get_type (void) G_GNUC_CONST;
+GType screenshot_get_type (void);
 static void screenshot_iface_init (XdpDbusScreenshotIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Screenshot, screenshot, XDP_DBUS_TYPE_SCREENSHOT_SKELETON,

--- a/desktop-portal/secret.c
+++ b/desktop-portal/secret.c
@@ -39,7 +39,7 @@ struct _SecretClass
   XdpDbusSecretSkeletonClass parent_class;
 };
 
-GType secret_get_type (void) G_GNUC_CONST;
+GType secret_get_type (void);
 static void secret_iface_init (XdpDbusSecretIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Secret, secret, XDP_DBUS_TYPE_SECRET_SKELETON,

--- a/desktop-portal/settings.c
+++ b/desktop-portal/settings.c
@@ -34,7 +34,7 @@ struct _SettingsClass
   XdpDbusSettingsSkeletonClass parent_class;
 };
 
-GType settings_get_type (void) G_GNUC_CONST;
+GType settings_get_type (void);
 static void settings_iface_init (XdpDbusSettingsIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Settings, settings, XDP_DBUS_TYPE_SETTINGS_SKELETON,

--- a/desktop-portal/trash.c
+++ b/desktop-portal/trash.c
@@ -39,7 +39,7 @@ struct _TrashClass
   XdpDbusTrashSkeletonClass parent_class;
 };
 
-GType trash_get_type (void) G_GNUC_CONST;
+GType trash_get_type (void);
 static void trash_iface_init (XdpDbusTrashIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Trash, trash, XDP_DBUS_TYPE_TRASH_SKELETON,

--- a/desktop-portal/wallpaper.c
+++ b/desktop-portal/wallpaper.c
@@ -37,7 +37,7 @@ struct _WallpaperClass
   XdpDbusWallpaperSkeletonClass parent_class;
 };
 
-GType wallpaper_get_type (void) G_GNUC_CONST;
+GType wallpaper_get_type (void);
 static void wallpaper_iface_init (XdpDbusWallpaperIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (Wallpaper, wallpaper, XDP_DBUS_TYPE_WALLPAPER_SKELETON,


### PR DESCRIPTION
As per g_type_ensure's documentation it is technically incorrect to mark _get_type fns with G_GNUC_CONST since they have side-effects on their first run.

See https://gitlab.gnome.org/GNOME/glib/-/merge_requests/5223 and https://blogs.gnome.org/mcatanzaro/2026/06/29/your-_get_type-function-is-not-g_gnuc_const-part-two/ for more details.