### PR TITLE
background: Find apps when monitoring starts

### DIFF
--- a/desktop-portal/background.c
+++ b/desktop-portal/background.c
@@ -696,6 +696,14 @@ monitor_background_in_thread (GTask        *task,
                               GCancellable *cancellable)
 {
   Background *background = source_object;
+  gboolean initial_check = GPOINTER_TO_INT (task_data);
+
+  if (initial_check)
+    {
+      check_background_apps (background);
+      g_task_return_boolean (task, TRUE);
+      return;
+    }
 
   /* We check twice, to avoid killing unlucky apps hit at a bad time */
   sleep (5);
@@ -717,7 +725,8 @@ monitor_background_in_thread (GTask        *task,
   g_task_return_boolean (task, TRUE);
 }
 
-static void monitor_background (Background *background);
+static void monitor_background (Background *background,
+                                gboolean    initial_check);
 
 static void
 on_monitor_background_done (GObject      *object,
@@ -735,12 +744,13 @@ on_monitor_background_done (GObject      *object,
   if (background->check_queued)
     {
       background->check_queued = FALSE;
-      monitor_background (background);
+      monitor_background (background, FALSE);
     }
 }
 
 static void
-monitor_background (Background *background)
+monitor_background (Background *background,
+                    gboolean    initial_check)
 {
   if (background->monitor_task)
     {
@@ -753,6 +763,9 @@ monitor_background (Background *background)
                                          on_monitor_background_done,
                                          NULL);
   g_task_set_source_tag (background->monitor_task, monitor_background);
+  g_task_set_task_data (background->monitor_task,
+                        GINT_TO_POINTER (initial_check),
+                        NULL);
   g_task_set_return_on_cancel (background->monitor_task, TRUE);
   g_task_run_in_thread (background->monitor_task, monitor_background_in_thread);
 }
@@ -763,7 +776,7 @@ on_running_apps_changed (gpointer data)
   Background *background = data;
 
   g_debug ("Running app windows changed, wake up monitor thread");
-  monitor_background (background);
+  monitor_background (background, FALSE);
 }
 
 static void
@@ -772,7 +785,7 @@ on_instances_changed (gpointer data)
   Background *background = data;
 
   g_debug ("Running instances changed, wake up monitor thread");
-  monitor_background (background);
+  monitor_background (background, FALSE);
 }
 
 gboolean
@@ -1464,6 +1477,7 @@ init_background (XdpContext *context)
     }
 
   background = background_new (background_impl, access_impl, background_monitor);
+  monitor_background (background, TRUE);
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&background)),

--- a/desktop-portal/background.c
+++ b/desktop-portal/background.c
@@ -696,16 +696,12 @@ monitor_background_in_thread (GTask        *task,
                               GCancellable *cancellable)
 {
   Background *background = source_object;
-  gboolean initial_check = GPOINTER_TO_INT (task_data);
 
-  if (initial_check)
-    {
-      check_background_apps (background);
-      g_task_return_boolean (task, TRUE);
-      return;
-    }
+  check_background_apps (background);
 
-  /* We check twice, to avoid killing unlucky apps hit at a bad time */
+  /* First discover existing apps, then check after delays to avoid killing
+   * unlucky apps hit at a bad time.
+   */
   sleep (5);
 
   if (!g_task_set_return_on_cancel (task, FALSE))
@@ -725,8 +721,7 @@ monitor_background_in_thread (GTask        *task,
   g_task_return_boolean (task, TRUE);
 }
 
-static void monitor_background (Background *background,
-                                gboolean    initial_check);
+static void monitor_background (Background *background);
 
 static void
 on_monitor_background_done (GObject      *object,
@@ -744,13 +739,12 @@ on_monitor_background_done (GObject      *object,
   if (background->check_queued)
     {
       background->check_queued = FALSE;
-      monitor_background (background, FALSE);
+      monitor_background (background);
     }
 }
 
 static void
-monitor_background (Background *background,
-                    gboolean    initial_check)
+monitor_background (Background *background)
 {
   if (background->monitor_task)
     {
@@ -763,9 +757,6 @@ monitor_background (Background *background,
                                          on_monitor_background_done,
                                          NULL);
   g_task_set_source_tag (background->monitor_task, monitor_background);
-  g_task_set_task_data (background->monitor_task,
-                        GINT_TO_POINTER (initial_check),
-                        NULL);
   g_task_set_return_on_cancel (background->monitor_task, TRUE);
   g_task_run_in_thread (background->monitor_task, monitor_background_in_thread);
 }
@@ -776,7 +767,7 @@ on_running_apps_changed (gpointer data)
   Background *background = data;
 
   g_debug ("Running app windows changed, wake up monitor thread");
-  monitor_background (background, FALSE);
+  monitor_background (background);
 }
 
 static void
@@ -785,7 +776,7 @@ on_instances_changed (gpointer data)
   Background *background = data;
 
   g_debug ("Running instances changed, wake up monitor thread");
-  monitor_background (background, FALSE);
+  monitor_background (background);
 }
 
 gboolean
@@ -1431,6 +1422,8 @@ background_new (XdpDbusImplBackground *background_impl,
                                G_CONNECT_SWAPPED);
     }
 
+  monitor_background (background);
+
   return g_steal_pointer (&background);
 }
 
@@ -1477,7 +1470,6 @@ init_background (XdpContext *context)
     }
 
   background = background_new (background_impl, access_impl, background_monitor);
-  monitor_background (background, TRUE);
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&background)),

--- a/tests/templates/background.py
+++ b/tests/templates/background.py
@@ -25,6 +25,7 @@ logger = init_logger(__name__)
 @dataclass
 class BackgroundParameters:
     delay: int
+    app_states: dict[str, int]
 
 
 def load(mock, parameters={}):
@@ -33,6 +34,7 @@ def load(mock, parameters={}):
     assert not hasattr(mock, "background_params")
     mock.background_params = BackgroundParameters(
         delay=parameters.get("delay", 200),
+        app_states=parameters.get("app-states", {}),
     )
 
 
@@ -46,9 +48,16 @@ def GetAppState(self, cb_success, cb_error):
     logger.debug("GetAppState()")
     params = self.background_params
 
-    # FIXME: implement?
     def reply():
-        cb_success({})
+        cb_success(
+            dbus.Dictionary(
+                {
+                    app_id: dbus.UInt32(state, variant_level=1)
+                    for app_id, state in params.app_states.items()
+                },
+                signature="sv",
+            )
+        )
 
     logger.debug(f"scheduling delay of {params.delay}")
     GLib.timeout_add(params.delay, reply)

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -12,9 +12,47 @@ from pathlib import Path
 from gi.repository import GLib
 
 
+BACKGROUND_MONITOR_BUS_NAME = "org.freedesktop.background.Monitor"
+BACKGROUND_MONITOR_IFACE = "org.freedesktop.background.Monitor"
+BACKGROUND_MONITOR_PATH = "/org/freedesktop/background/monitor"
+BACKGROUND_STATE = 0
+
+
 @pytest.fixture
 def required_templates():
     return {"background": {}}
+
+
+@pytest.fixture
+def running_flatpak_instance(xdp_app_info_init):
+    app_info = xdp_app_info_init
+    assert isinstance(app_info, xdp.AppInfoFlatpak)
+
+    instance_dir = (
+        Path(os.environ["XDG_RUNTIME_DIR"]) / ".flatpak" / app_info.instance_id
+    )
+    instance_dir.mkdir(mode=0o700, parents=True)
+
+    pid = os.getpid()
+    (instance_dir / "pid").write_text(f"{pid}\n")
+    (instance_dir / "bwrapinfo.json").write_text(f'{{"child-pid": {pid}}}\n')
+    (instance_dir / "info").write_text(
+        f"""
+[Application]
+name={app_info.app_id}
+runtime=org.freedesktop.Platform/x86_64/23.08
+
+[Instance]
+instance-id={app_info.instance_id}
+"""
+    )
+
+    return app_info
+
+
+@pytest.fixture
+def portals_with_running_flatpak(running_flatpak_instance, portals):
+    return None
 
 
 class TestBackground:
@@ -38,6 +76,39 @@ class TestBackground:
 
     def test_version(self, portals, dbus_con):
         xdp.check_version(dbus_con, "Background", 2)
+
+    @pytest.mark.parametrize("xdp_app_info", (xdp.AppInfoFlatpak(),))
+    @pytest.mark.parametrize(
+        "template_params",
+        (
+            {
+                "background": {
+                    "app-states": {
+                        "org.example.Test": BACKGROUND_STATE,
+                    }
+                }
+            },
+        ),
+    )
+    def test_monitor_lists_background_apps_on_startup(
+        self, portals_with_running_flatpak, dbus_con, xdp_app_info
+    ):
+        obj = dbus_con.get_object(BACKGROUND_MONITOR_BUS_NAME, BACKGROUND_MONITOR_PATH)
+        properties_intf = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
+
+        for _ in range(20):
+            background_apps = properties_intf.Get(
+                BACKGROUND_MONITOR_IFACE, "BackgroundApps"
+            )
+            if any(app["app_id"] == xdp_app_info.app_id for app in background_apps):
+                break
+
+            xdp.wait(100)
+
+        background_apps = properties_intf.Get(
+            BACKGROUND_MONITOR_IFACE, "BackgroundApps"
+        )
+        assert any(app["app_id"] == xdp_app_info.app_id for app in background_apps)
 
     def test_request_background(self, portals, dbus_con, xdp_app_info):
         app_id = xdp_app_info.app_id


### PR DESCRIPTION
## Summary

- Discover existing background applications when the background monitor starts, instead of running a special portal-initialization check.
- Start the monitor cycle after the backend `RunningApplicationsChanged` signal and Flatpak instance directory monitor are connected.
- Add a regression that creates a pre-existing Flatpak instance and verifies `BackgroundApps` is populated on startup.

Fixes #1947.

## Testing

- `git diff --check`
- `PYTHONPYCACHEPREFIX=<tmp> python3 -m py_compile tests/test_background.py tests/templates/background.py`
- Not run locally: `meson test -C _build integration/background --print-errorlogs` (local environment does not have pytest or a configured Meson build dir)
