### PR TITLE
githooks: Allow exceptions in gitlint's max-line-length rule

### DIFF
--- a/.gitlint.conf/custom-body-max-line-length.py
+++ b/.gitlint.conf/custom-body-max-line-length.py
@@ -4,13 +4,6 @@
 import re
 from gitlint.rules import BodyMaxLineLength
 
-TAGS = [
-    "Signed-off-by",
-    "Co-authored-by",
-    "Fixes",
-    "Closes",
-]
-
 
 class CustomBodyMaxLineLength(BodyMaxLineLength):
     name = "custom-body-max-line-length"
@@ -21,16 +14,16 @@ class CustomBodyMaxLineLength(BodyMaxLineLength):
         if line.startswith(" " * 4):
             return None
 
-        # Ignore reference lines (e.g. [2]: https://example.org/foobar)
-        ret = re.match(r"^\[\d+\] ", line)
-        if ret is not None:
+        # Ignore reference lines, such as:
+        #
+        #     [2]: https://example.org/foobar
+        #     Closes: #XYZ
+        #     Co-authored-by: Example <foo@example.com>
+        #     …
+        #
+        # without ignoring lower-case letters.
+        if re.match(r"^([A-Z]|\[\d+\])\S*: ", line):
             return None
-
-        # Ignore length for tags
-        for tag in TAGS:
-            tag = tag + ": "
-            if line[: len(tag)].lower() == tag.lower():
-                return None
 
         # Otherwise behave as the upstream BodyMaxLineLength rule
         return super().validate(line, commit)


### PR DESCRIPTION
Currently, the rule contains separate exceptions for references
as well as tags, the latter of which are defined inside a fixed
list of keywords. As a consequence, it requires us to manually
update the list, should we add more tags in the future.
For references, they strictly disallow colons (:) after the
closing bracket. For example "\[1\]:" won't work.[1]

This patch consolidates both use cases into one and requires
following with a colon. Anything starting with a capital
letter followed by a string of characters, then followed by a colon
are treated as a tag. Additionally, number inside a bracket,
e.g. "\[1\]" are also treated as a tag.

[1]: https://github.com/flatpak/xdg-desktop-portal/pull/2050#issuecomment-4904784798