### PR TITLE
githooks: Run when podman and docker are both installed

### DIFF
--- a/githooks/build
+++ b/githooks/build
@@ -7,6 +7,6 @@ set -eo pipefail
 IMAGE=xdg-desktop-portal-check:latest
 
 PREFIX="${TOOLBOX_PATH:+flatpak-spawn --host}"
-CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker')"
+CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker | head -n 1')"
 
 $CMD build -f containerfiles/check.containerfile -t "${IMAGE}" .

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -7,7 +7,7 @@ set -eo pipefail
 IMAGE=xdg-desktop-portal-check:latest
 
 PREFIX="${TOOLBOX_PATH:+flatpak-spawn --host}"
-CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker')"
+CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker | head -n 1')"
 
 if ! $CMD inspect "${IMAGE}" >/dev/null; then
   "$(dirname "$0")"/build

--- a/githooks/gitlint
+++ b/githooks/gitlint
@@ -7,7 +7,7 @@ set -eo pipefail
 IMAGE=xdg-desktop-portal-check:latest
 
 PREFIX="${TOOLBOX_PATH:+flatpak-spawn --host}"
-CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker')"
+CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker | head -n 1')"
 
 if ! $CMD inspect "${IMAGE}" >/dev/null; then
   "$(dirname "$0")"/build

--- a/githooks/run
+++ b/githooks/run
@@ -7,7 +7,7 @@ set -eo pipefail
 IMAGE=xdg-desktop-portal-check:latest
 
 PREFIX="${TOOLBOX_PATH:+flatpak-spawn --host}"
-CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker')"
+CMD="${PREFIX} $(${PREFIX} sh -c 'command -v podman docker | head -n 1')"
 
 if ! $CMD inspect "${IMAGE}" >/dev/null; then
   "$(dirname "$0")"/build


### PR DESCRIPTION
When both `podman` and `docker` are available, `command -v podman docker` produces

```
/usr/bin/podman
/usr/bin/docker
```

which causes the container run execution to expand to `/usr/bin/podman /usr/bin/docker inspect xdg-desktop-portal:latest ...`.

Selecting the first in the output fixes the issue