### PR TITLE
ci: Skip redundant tests in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Create dist tarball
         run: |
           ls -la
-          timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson dist -C _build --include-subprojects
+          timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson dist -C _build --include-subprojects --no-tests
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
`meson dist` runs tests by default, but we already run the same tests in both the clang and gcc steps, so we don't need to run them again. This saves about 7 minutes on every PR run.

The release workflow does not include a separate test run, so we preserve the behavior there.