### PR TITLE
doc: Shorten interface member names in HTML

### DIFF
--- a/doc/fix-rst-dbus.py
+++ b/doc/fix-rst-dbus.py
@@ -27,7 +27,7 @@ def is_section_label(line):
     return False
 
 
-def split_sections(lines, output_prefix):
+def split_sections(lines, output_prefix, interface_name):
     """Split Properties, Methods, Signals into separate fragment files.
 
     Returns (desc_lines, found_sections)."""
@@ -58,7 +58,11 @@ def split_sections(lines, output_prefix):
         with open(fragment_path, "w") as f:
             heading_written = False
             skip_transition = False
+            skip_next = False
             for line in section_lines:
+                if skip_next:
+                    skip_next = False
+                    continue
                 if is_section_label(line):
                     continue
                 # Convert ---- overline+underline to ~~~~ underline-only
@@ -79,6 +83,17 @@ def split_sections(lines, output_prefix):
                         skip_transition = False
                         continue
                     skip_transition = False
+                if line.startswith(interface_name):
+                    member_name = (
+                        line.removeprefix(interface_name)
+                        .removeprefix("::")
+                        .removeprefix(":")
+                        .removeprefix(".")
+                    ).strip()
+                    f.write(f"{member_name}\n")
+                    f.write(f"{'^' * len(member_name)}\n")
+                    skip_next = True
+                    continue
                 f.write(line)
 
     return desc_lines, set(sections.keys())
@@ -145,7 +160,7 @@ for file in inputs:
         lines = f.readlines()
 
     adjust_title(lines)
-    desc_lines, found_sections = split_sections(lines, output_prefix)
+    desc_lines, found_sections = split_sections(lines, output_prefix, interface_name)
     out = strip_description_heading(desc_lines)
 
     has_includes = any(line.strip().startswith(".. include::") for line in out)

--- a/doc/fix-rst-dbus.py
+++ b/doc/fix-rst-dbus.py
@@ -27,7 +27,7 @@ def is_section_label(line):
     return False
 
 
-def split_sections(lines, output_prefix):
+def split_sections(lines, output_prefix, interface_name):
     """Split Properties, Methods, Signals into separate fragment files.
 
     Returns (desc_lines, found_sections)."""
@@ -58,9 +58,45 @@ def split_sections(lines, output_prefix):
         with open(fragment_path, "w") as f:
             heading_written = False
             skip_transition = False
+            skip_next = False
+            member_anchor = None
             for line in section_lines:
+                if skip_next:
+                    skip_next = False
+                    continue
                 if is_section_label(line):
                     continue
+
+                # Shorten member names
+                if line.startswith(".. _") and line[len(".. _") :].startswith(
+                    interface_name
+                ):
+                    member_anchor = line
+                    continue
+                if member_anchor:
+                    # Skip until we find the title of the member
+                    if line == "" or not line.startswith(interface_name):
+                        continue
+                    else:
+                        # Preserve the original anchor, but change the title
+                        f.write(f".. _{line.rstrip()}:\n\n")
+                        member_name_with_symbol = line.removeprefix(interface_name)
+                        member_name = (
+                            member_name_with_symbol.removeprefix("::")
+                            .removeprefix(":")
+                            .removeprefix(".")
+                        ).strip()
+
+                        # Differentiate methods from signals and properties.
+                        if member_name_with_symbol.startswith("."):
+                            member_name += "()"
+
+                        f.write(f"{member_name}\n")
+                        f.write(f"{'^' * len(member_name)}\n")
+                        skip_next = True
+                        member_anchor = None
+                        continue
+
                 # Convert ---- overline+underline to ~~~~ underline-only
                 if not heading_written and set(line.strip()) == {"-"}:
                     continue
@@ -106,6 +142,9 @@ def adjust_title(lines):
 
     lines[3] = f"{adjusted_title}\n"
 
+    # Insert interface name after stripping from title.
+    lines.insert(9, f"**{title}**")
+
 
 inputs = sys.argv[3:]
 
@@ -143,7 +182,8 @@ for file in inputs:
         lines = f.readlines()
 
     adjust_title(lines)
-    desc_lines, found_sections = split_sections(lines, output_prefix)
+
+    desc_lines, found_sections = split_sections(lines, output_prefix, interface_name)
     out = strip_description_heading(desc_lines)
 
     prefix = f"{filename_prefix}-{interface_name}"


### PR DESCRIPTION
While working on the docs for the credential portal (which are almost complete!), I noticed that the interface name is repeated throughout the method, signal and property members, but the actual interface name by itself never appears on the page (since we replace the title with the shortened name). The lack of the interface name was confusing to me when I began working with portals, and the length of the member names is especially noticeable in the right-side table-of-contents.

I'm wondering if it would be desirable to have a shortened name for the interface members too. 

Removing this would require having some sort of convention/automation to include the interface name somewhere.

I tried it out, and it looks decent in the main page and the table of contents, and the anchors all stay the same, so no broken links.

Here's a visual diff:
Left: After, Right: Before

<img width="1920" height="944" alt="image" src="https://github.com/user-attachments/assets/bbc37ee2-59e0-47e3-af75-6660ad35abc3" />
