### PR TITLE
PipeWire-related miscellaneous changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       packages: write
     with:
-      image: xdg-desktop-portal:2026-06-23.1
+      image: xdg-desktop-portal:2026-07-21.1
       containerfile: containerfiles/build.containerfile
 
   check-container:

--- a/containerfiles/build.containerfile
+++ b/containerfiles/build.containerfile
@@ -36,8 +36,10 @@ RUN apt install -y --no-install-recommends \
     libglib2.0-dev \
     libgudev-1.0-dev \
     libjson-glib-dev \
+    pipewire \
     libpipewire-0.3-dev \
     libdbus-1-dev \
+    wireplumber \
     libwireplumber-0.5-dev \
     libsystemd-dev \
     libtool \

--- a/pipewire/wp-plugin/xdp-wp-plugin.c
+++ b/pipewire/wp-plugin/xdp-wp-plugin.c
@@ -92,10 +92,11 @@ xdp_wp_plugin_disable (WpPlugin *plugin)
 {
   XdpWpPlugin *self = XDP_WP_PLUGIN (plugin);
 
-  g_clear_object (&self->permission_manager);
-
   g_signal_handler_disconnect (self->dbus_connection_plugin,
                                self->dbus_changed_signal_id);
+
+  g_clear_object (&self->permission_manager);
+
   g_clear_object (&self->dbus_connection_plugin);
 
   wp_object_update_features (WP_OBJECT (self), 0, WP_PLUGIN_FEATURE_ENABLED);


### PR DESCRIPTION
Pulled from #2070 since they can be isolated from the other commits.

1. Fixes the clear order for correctness and to avoid any issue even if it's really unlikely to ever happen.
2. Add daemons in the build container
   The mentioned PR makes PipeWire client config required to run test (creating a non-connected client reads the config file), and on the long-term we might need fixture for both in the testing suite