### PR TITLE
xdp: Keep the invocation's XdpAppInfo alive for its lifetime

### DIFF
--- a/desktop-portal/xdp-context.c
+++ b/desktop-portal/xdp-context.c
@@ -225,7 +225,8 @@ authorize_callback (GDBusInterfaceSkeleton *interface,
       return FALSE;
     }
 
-  g_object_set_data (G_OBJECT (invocation), "xdp-app-info", app_info);
+  g_object_set_data_full (G_OBJECT (invocation), "xdp-app-info",
+                          g_object_ref (app_info), g_object_unref);
 
   if (method_needs_request (invocation))
     {


### PR DESCRIPTION
## Summary

Fixes a heap use-after-free that aborts the **entire** `xdg-desktop-portal`
process. The per-invocation `XdpAppInfo` is stored on the
`GDBusMethodInvocation` without taking a reference, so it is owned only by the
app-info registry (one ref per D-Bus sender). When the caller disconnects while
a threaded method handler is mid-flight, the registry frees the object and the
handler then reads freed memory.

## Root cause

`authorize_callback()` (`desktop-portal/xdp-context.c`) stored it ref-less:

```c
g_object_set_data (G_OBJECT (invocation), "xdp-app-info", app_info); // no ref
```

Lifetime is then owned solely by the app-info registry
(`shared/xdp-app-info-registry.c`), which drops its ref on peer disconnect
(`on_peer_disconnect()` → `xdp_app_info_registry_delete()` → `g_hash_table_remove()`).

Method handlers run on gdbus worker threads
(`G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD`) and
borrow the pointer via `xdp_invocation_get_app_info()`. The Realtime portal's
`MakeThreadHighPriorityWithPID` borrows it, blocks in
`xdp_get_permission_sync()`, then calls `map_pid()` → `xdp_app_info_get_pidns()`,
whose `GMutexLocker` unlocks a mutex inside the freed object — GLib
`Attempt to unlock mutex that was not locked` → `abort()`.

Downstream: on KDE/Wayland the abort orphans an active InputCapture session
(e.g. Deskflow) with no owner left to release it, and the compositor keeps input
diverted — the desktop renders but accepts no keyboard/mouse input until the
compositor is restarted. That is how this was first hit (a PipeWire audio-stack
restart fires a burst of `MakeThreadHighPriorityWithPID` while the client
reconnects, widening the race).

## Reproduction (deterministic, AddressSanitizer, current `main`)

Built `main` with `-Db_sanitize=address`, isolated on a private session bus (no
RealtimeKit needed — the `rtkit_proxy` is created non-NULL even when absent). A
mock `org.freedesktop.impl.portal.PermissionStore` with a delayed `Lookup()`
widens the real window (the synchronous `xdp_get_permission_sync()`); a client
calls `MakeThreadHighPriorityWithPID` and disconnects mid-`Lookup`:

```
==ERROR: AddressSanitizer: heap-use-after-free  READ of size 8  thread T5 (gdbus worker)
  #0 xdp_app_info_get_pidns                      shared/xdp-app-info.c:525
  #1 map_pid                                     desktop-portal/realtime.c:57
  #2 handle_make_thread_high_priority_with_pid   desktop-portal/realtime.c:188
freed by thread T0 (main loop):
  g_object_unref  <-  g_hash_table_remove
  xdp_app_info_registry_delete                   shared/xdp-app-info-registry.c:122
  on_peer_disconnect                             desktop-portal/xdp-context.c:304
previously allocated by thread T5:
  authorize_callback                             desktop-portal/xdp-context.c:215
SUMMARY: AddressSanitizer: heap-use-after-free shared/xdp-app-info.c:525 in xdp_app_info_get_pidns
```

## The fix

Have the invocation own a reference for its lifetime. `app_info` is still used
later in `authorize_callback()`, so an extra ref is taken rather than
`g_steal_pointer()`:

```c
g_object_set_data_full (G_OBJECT (invocation), "xdp-app-info",
                        g_object_ref (app_info), g_object_unref);
```

With this applied, the same reproducer runs cleanly — no ASan report — and the
Realtime handler instead completes on a live `app_info`.

## Notes

- This fixes the general pattern (any threaded handler that borrows `app_info`
  across a blocking call), not only the Realtime portal.
- No regression test is included since the trigger is a race, but the reproducer
  above is deterministic; I'm happy to add a test, or provide the full ASan log
  / a core dump, if that would help review.
