### PR TITLE
data: Remove unused `session_id`/`session` key from interfaces

### DIFF
--- a/data/org.freedesktop.impl.portal.InputCapture.xml
+++ b/data/org.freedesktop.impl.portal.InputCapture.xml
@@ -42,10 +42,6 @@
 
         The following results get returned in the @results vardict:
 
-        * ``session_id`` (``s``)
-
-          The session id. A string representing the created input capture session.
-
         * ``capabilities`` (``u``)
 
           The capabilities available to this session. This is always a

--- a/data/org.freedesktop.impl.portal.RemoteDesktop.xml
+++ b/data/org.freedesktop.impl.portal.RemoteDesktop.xml
@@ -29,11 +29,7 @@
         org.freedesktop.portal.ScreenCast), but may only be started and stopped
         with this interface.
 
-        The following results get returned in the @results vardict:
-
-        * ``session`` (``s``)
-
-          The session id. A string representing the created screen cast session.
+        There are currently no supported keys in the @results vardict.
     -->
     <method name="CreateSession">
       <arg type="o" name="handle" direction="in"/>

--- a/data/org.freedesktop.impl.portal.ScreenCast.xml
+++ b/data/org.freedesktop.impl.portal.ScreenCast.xml
@@ -25,11 +25,7 @@
 
         Create a screen cast session.
 
-        The following results get returned in the @results vardict:
-
-        * ``session_id`` (``s``)
-
-          The session id. A string representing the created screen cast session.
+        There are currently no supported keys in the @results vardict.
     -->
     <method name="CreateSession">
       <arg type="o" name="handle" direction="in"/>


### PR DESCRIPTION
https://github.com/flatpak/xdg-desktop-portal/pull/1464 previously made this change for `GlobalShortcuts`. It looks like `InputCapture`, `RemoteDesktop`, and `ScreenCast` need the same thing.

This does not appear to ever be read by `xdg-desktop-portal` for any of these interfaces, nor does `xdg-desktop-portal-gnome` set it.