### PR TITLE
remote-desktop: Fix check_position stream lookup and unknown stream sizes

### DIFF
--- a/desktop-portal/remote-desktop.c
+++ b/desktop-portal/remote-desktop.c
@@ -863,6 +863,15 @@ check_position (XdpSession *session,
       if (screen_cast_stream_get_pipewire_node_id (stream) != node_id)
         continue;
 
+      /* The "size" stream property is optional, and backends omit it for
+       * streams whose size isn't known when the session is started, such as
+       * virtual streams. Without it we have no bounds to validate against,
+       * so accept the position and leave it to the backend; rejecting would
+       * make absolute positioning unusable on those streams.
+       */
+      if (!screen_cast_stream_has_size (stream))
+        return TRUE;
+
       screen_cast_stream_get_size (stream, &width, &height);
 
       return x >= 0.0 && x < width && y >= 0.0 && y < height;

--- a/desktop-portal/remote-desktop.c
+++ b/desktop-portal/remote-desktop.c
@@ -848,7 +848,7 @@ check_notify (XdpSession *session,
 
 static gboolean
 check_position (XdpSession *session,
-                uint32_t stream,
+                uint32_t node_id,
                 double x,
                 double y)
 {
@@ -860,11 +860,12 @@ check_position (XdpSession *session,
       ScreenCastStream *stream = l->data;
       int32_t width, height;
 
+      if (screen_cast_stream_get_pipewire_node_id (stream) != node_id)
+        continue;
+
       screen_cast_stream_get_size (stream, &width, &height);
 
-      if (x >= 0.0 && x < width &&
-          y >= 0.0 && y < height)
-        return TRUE;
+      return x >= 0.0 && x < width && y >= 0.0 && y < height;
     }
 
   return FALSE;

--- a/desktop-portal/screen-cast.c
+++ b/desktop-portal/screen-cast.c
@@ -56,6 +56,7 @@ struct _ScreenCastStream
   uint32_t id;
   int32_t width;
   int32_t height;
+  gboolean has_size;
   uint64_t pipewire_serial;
   gboolean has_pipewire_serial;
 };
@@ -733,6 +734,12 @@ open_pipewire_screen_cast_remote (const char *app_id,
   return remote;
 }
 
+gboolean
+screen_cast_stream_has_size (ScreenCastStream *stream)
+{
+  return stream->has_size;
+}
+
 void
 screen_cast_stream_get_size (ScreenCastStream *stream,
                              int32_t *width,
@@ -762,8 +769,9 @@ collect_screen_cast_stream_data (GVariantIter *streams_iter)
 
       stream = g_new0 (ScreenCastStream, 1);
       stream->id = stream_id;
-      g_variant_lookup (stream_options, "size", "(ii)",
-                        &stream->width, &stream->height);
+      stream->has_size =
+        g_variant_lookup (stream_options, "size", "(ii)",
+                          &stream->width, &stream->height);
       stream->has_pipewire_serial =
         g_variant_lookup (stream_options, "pipewire-serial", "t",
                           &stream->pipewire_serial);

--- a/desktop-portal/screen-cast.h
+++ b/desktop-portal/screen-cast.h
@@ -14,6 +14,8 @@ typedef struct _ScreenCastStream ScreenCastStream;
 
 uint32_t screen_cast_stream_get_pipewire_node_id (ScreenCastStream *stream);
 
+gboolean screen_cast_stream_has_size (ScreenCastStream *stream);
+
 void screen_cast_stream_get_size (ScreenCastStream *stream,
                                   int32_t *width,
                                   int32_t *height);

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -36,6 +36,7 @@ class RemotedesktopParameters:
     streams: bool
     node_id: int
     stream_size: tuple[int, int]
+    omit_stream_size: bool
 
 
 def load(mock, parameters=None):
@@ -55,6 +56,7 @@ def load(mock, parameters=None):
         streams=parameters.get("streams", False),
         node_id=parameters.get("node-id", 42),
         stream_size=parameters.get("stream-size", (1920, 1080)),
+        omit_stream_size=parameters.get("omit-stream-size", False),
     )
 
     mock.AddProperties(
@@ -161,15 +163,14 @@ def Start(
         response.results["devices"] = dbus.UInt32(params.devices)
 
     if params.streams:
-        width, height = params.stream_size
-        stream_properties = dbus.Dictionary(
-            {
-                "size": dbus.Struct(
-                    (dbus.Int32(width), dbus.Int32(height)), signature="ii"
-                )
-            },
-            signature="sv",
-        )
+        stream_properties = dbus.Dictionary({}, signature="sv")
+        # The "size" stream property is optional; a backend omits it for
+        # streams whose size it doesn't know yet, such as virtual streams.
+        if not params.omit_stream_size:
+            width, height = params.stream_size
+            stream_properties["size"] = dbus.Struct(
+                (dbus.Int32(width), dbus.Int32(height)), signature="ii"
+            )
 
         response.results["streams"] = dbus.Array(
             [(dbus.UInt32(params.node_id), stream_properties)],

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -32,6 +32,10 @@ class RemotedesktopParameters:
     force_close: int
     force_clipboard_enabled: bool
     fail_connect_to_eis: bool
+    devices: int
+    streams: bool
+    node_id: int
+    stream_size: tuple[int, int]
 
 
 def load(mock, parameters=None):
@@ -47,6 +51,10 @@ def load(mock, parameters=None):
         force_close=parameters.get("force-close", 0),
         force_clipboard_enabled=parameters.get("force-clipboard-enabled", False),
         fail_connect_to_eis=parameters.get("fail-connect-to-eis", False),
+        devices=parameters.get("devices", 0),
+        streams=parameters.get("streams", False),
+        node_id=parameters.get("node-id", 42),
+        stream_size=parameters.get("stream-size", (1920, 1080)),
     )
 
     mock.AddProperties(
@@ -148,6 +156,25 @@ def Start(
     response = Response(params.response, {})
     if params.force_clipboard_enabled:
         response.results["clipboard_enabled"] = True
+
+    if params.devices:
+        response.results["devices"] = dbus.UInt32(params.devices)
+
+    if params.streams:
+        width, height = params.stream_size
+        stream_properties = dbus.Dictionary(
+            {
+                "size": dbus.Struct(
+                    (dbus.Int32(width), dbus.Int32(height)), signature="ii"
+                )
+            },
+            signature="sv",
+        )
+
+        response.results["streams"] = dbus.Array(
+            [(dbus.UInt32(params.node_id), stream_properties)],
+            signature="(ua{sv})",
+        )
 
     if params.expect_close:
         request.wait_for_close()

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -17,6 +17,16 @@ def required_templates():
     return {"remotedesktop": {}}
 
 
+# Must match the "node-id" and "stream-size" defaults of the remotedesktop
+# template.
+STREAM_NODE_ID = 42
+STREAM_WIDTH = 1920
+STREAM_HEIGHT = 1080
+
+# DEVICE_TYPE_POINTER | DEVICE_TYPE_TOUCHSCREEN
+DEVICES_POINTER_TOUCH = 0x2 | 0x4
+
+
 class TestRemoteDesktop:
     def test_version(self, portals, dbus_con):
         xdp.check_version(dbus_con, "RemoteDesktop", 2)
@@ -253,3 +263,94 @@ class TestRemoteDesktop:
                 "Session is not allowed to call Notify"
                 in excinfo.value.get_dbus_message()
             )
+
+    def start_session_with_stream(self, dbus_con):
+        """
+        Create, configure and start a RemoteDesktop session. The remotedesktop
+        template is expected to be parametrized to hand out devices and a
+        stream.
+        """
+        remotedesktop_intf = xdp.get_portal_iface(dbus_con, "RemoteDesktop")
+
+        request = xdp.Request(dbus_con, remotedesktop_intf)
+        response = request.call(
+            "CreateSession",
+            options={"session_handle_token": "session_token0"},
+        )
+        assert response
+        assert response.response == 0
+
+        session = xdp.Session.from_response(dbus_con, response)
+
+        request = xdp.Request(dbus_con, remotedesktop_intf)
+        response = request.call(
+            "SelectDevices",
+            session_handle=session.handle,
+            options={"types": dbus.UInt32(DEVICES_POINTER_TOUCH)},
+        )
+        assert response
+        assert response.response == 0
+
+        request = xdp.Request(dbus_con, remotedesktop_intf)
+        response = request.call(
+            "Start",
+            session_handle=session.handle,
+            parent_window="",
+            options={},
+        )
+        assert response
+        assert response.response == 0
+
+        return remotedesktop_intf, session
+
+    @pytest.mark.parametrize(
+        "template_params",
+        ({"remotedesktop": {"devices": DEVICES_POINTER_TOUCH, "streams": True}},),
+    )
+    def test_notify_absolute_position(self, portals, dbus_con):
+        remotedesktop_intf, session = self.start_session_with_stream(dbus_con)
+        options = dbus.Dictionary({}, signature="sv")
+
+        remotedesktop_intf.NotifyPointerMotionAbsolute(
+            session.handle, options, STREAM_NODE_ID, 100.0, 200.0
+        )
+        remotedesktop_intf.NotifyTouchDown(
+            session.handle, options, STREAM_NODE_ID, 0, 100.0, 200.0
+        )
+
+    @pytest.mark.parametrize(
+        "template_params",
+        ({"remotedesktop": {"devices": DEVICES_POINTER_TOUCH, "streams": True}},),
+    )
+    @pytest.mark.parametrize(
+        "x, y",
+        (
+            (-1.0, 0.0),
+            (0.0, -1.0),
+            (STREAM_WIDTH, 0.0),
+            (0.0, STREAM_HEIGHT),
+        ),
+    )
+    def test_notify_absolute_position_out_of_bounds(self, portals, dbus_con, x, y):
+        remotedesktop_intf, session = self.start_session_with_stream(dbus_con)
+        options = dbus.Dictionary({}, signature="sv")
+
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            remotedesktop_intf.NotifyPointerMotionAbsolute(
+                session.handle, options, STREAM_NODE_ID, x, y
+            )
+        assert "Invalid position" in excinfo.value.get_dbus_message()
+
+    @pytest.mark.parametrize(
+        "template_params",
+        ({"remotedesktop": {"devices": DEVICES_POINTER_TOUCH, "streams": True}},),
+    )
+    def test_notify_absolute_position_unknown_stream(self, portals, dbus_con):
+        remotedesktop_intf, session = self.start_session_with_stream(dbus_con)
+        options = dbus.Dictionary({}, signature="sv")
+
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            remotedesktop_intf.NotifyPointerMotionAbsolute(
+                session.handle, options, STREAM_NODE_ID + 1, 100.0, 200.0
+            )
+        assert "Invalid position" in excinfo.value.get_dbus_message()

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -343,6 +343,35 @@ class TestRemoteDesktop:
 
     @pytest.mark.parametrize(
         "template_params",
+        (
+            {
+                "remotedesktop": {
+                    "devices": DEVICES_POINTER_TOUCH,
+                    "streams": True,
+                    "omit-stream-size": True,
+                }
+            },
+        ),
+    )
+    def test_notify_absolute_position_without_stream_size(self, portals, dbus_con):
+        """
+        The "size" stream property is optional and backends omit it for streams
+        whose size they don't know when the session is started, e.g. virtual
+        streams. There is nothing to validate the position against then, so it
+        must not be rejected.
+        """
+        remotedesktop_intf, session = self.start_session_with_stream(dbus_con)
+        options = dbus.Dictionary({}, signature="sv")
+
+        remotedesktop_intf.NotifyPointerMotionAbsolute(
+            session.handle, options, STREAM_NODE_ID, 100.0, 200.0
+        )
+        remotedesktop_intf.NotifyTouchDown(
+            session.handle, options, STREAM_NODE_ID, 0, 100.0, 200.0
+        )
+
+    @pytest.mark.parametrize(
+        "template_params",
         ({"remotedesktop": {"devices": DEVICES_POINTER_TOUCH, "streams": True}},),
     )
     def test_notify_absolute_position_unknown_stream(self, portals, dbus_con):


### PR DESCRIPTION
Fixes #2077

`check_position()` has two independent bugs, one commit each.

## 1. The `stream` parameter was never used

The loop variable shadowed the parameter, so the check accepted a position
that fell inside *any* of the session's streams instead of the one the
caller named.

This makes the check **stricter**: a position that is only in bounds for a
different stream of the session, or a node id that doesn't belong to the
session at all, is now rejected.

## 2. An absent `size` was treated as a zero-sized stream

`size` is Optional in the ScreenCast interface, and a backend leaves it out
for streams whose size it doesn't know at `Start()`, which is the case for
virtual streams. `collect_screen_cast_stream_data()` then left the recorded
size at `(0, 0)`, and `x < width` never holds for `width == 0`, so every
absolute position was rejected. `NotifyPointerMotionAbsolute`,
`NotifyTouchDown` and `NotifyTouchMotion` failed with "Invalid position" on
every call, leaving relative pointer motion as the only usable input.

The fix records whether the backend actually reported a size, mirroring the
existing `has_pipewire_serial` handling, and skips the bounds check when it
didn't, rather than treating `(0, 0)` as a sentinel.

## Testing

There was no coverage of absolute positioning at all. Added four cases:
in-bounds, out-of-bounds, unknown node id, and a stream without a `size`
property. The two that pin the bugs above fail on `main` and pass here.

## Open question

Should the portal be doing this bounds check at all, or is the compositor
the authority? It can only validate against what the backend chose to
report, and rejecting by default breaks the legitimate case. If you'd
rather the backend always reported a size, that's a mutter-side fix and
commit 2 could be dropped; commit 1 stands either way.
