### PR TITLE
document-portal: Track permission store changes

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -46,6 +46,121 @@ XdpAppInfoRegistry *app_info_registry;
 
 G_LOCK_DEFINE (db);
 
+/* The documents table is not ours alone. The permission store is a separate
+ * process writing the same table, so `flatpak permission-remove`,
+ * `flatpak permission-reset` and any other PermissionStore client can change
+ * an entry behind our back. We keep a private PermissionDb because the FUSE
+ * layer needs a synchronous answer, which means a change we do not observe
+ * leaves us authorizing access the user has already revoked.
+ *
+ * Rather than apply the contents of the Changed signal, treat the entry as
+ * stale and re-read it. The signal carries the state the store held when it
+ * applied the change, so applying it directly means telling our own echoes
+ * apart from external ones, which means pairing signals to writes. Re-reading
+ * needs neither: whoever made the change, the answer is whatever the store
+ * holds now.
+ *
+ * That only holds while the store is not behind us. Our writes to it are
+ * asynchronous, so between applying a change locally and the store
+ * acknowledging it, a re-read would undo what we just applied. A Changed
+ * arriving in that window is therefore recorded, not acted on, and the read
+ * happens once our writes are acknowledged.
+ *
+ * https://github.com/flatpak/xdg-desktop-portal/issues/197
+ */
+typedef struct
+{
+  guint    writes;   /* our writes to the store not yet acknowledged */
+  gboolean reading;  /* a Lookup is in flight */
+  gboolean queued;   /* a Changed arrived while we could not read */
+} EntrySync;
+
+/* id -> EntrySync. Guarded by the db lock. */
+static GHashTable *entry_sync;
+
+static void start_refresh (const char *id, EntrySync *sync);
+
+static EntrySync *
+entry_sync_get (const char *id)
+{
+  EntrySync *sync = g_hash_table_lookup (entry_sync, id);
+
+  if (sync == NULL)
+    {
+      sync = g_new0 (EntrySync, 1);
+      g_hash_table_insert (entry_sync, g_strdup (id), sync);
+    }
+
+  return sync;
+}
+
+static void
+entry_sync_release (const char *id,
+                    EntrySync  *sync)
+{
+  if (sync->writes == 0 && !sync->reading && !sync->queued)
+    g_hash_table_remove (entry_sync, id);
+}
+
+/* Re-read the entry, unless the store is still catching up with us or a read
+ * is already under way. Call with the db lock held. */
+static void
+refresh_entry (const char *id,
+               EntrySync  *sync)
+{
+  if (sync->writes > 0 || sync->reading)
+    {
+      sync->queued = TRUE;
+      return;
+    }
+
+  sync->queued = FALSE;
+  start_refresh (id, sync);
+}
+
+/* One of our writes to the store has been acknowledged, or failed, in which
+ * case it emits no Changed and there is nothing further to wait for. */
+static void
+store_write_cb (GObject      *source_object,
+                GAsyncResult *res,
+                gpointer      user_data)
+{
+  g_autofree char *id = user_data;
+
+  g_autoptr(GVariant) ret = NULL;
+  g_autoptr(GError) error = NULL;
+  EntrySync *sync;
+
+  ret = g_dbus_proxy_call_finish (G_DBUS_PROXY (source_object), res, &error);
+  if (ret == NULL)
+    {
+      g_dbus_error_strip_remote_error (error);
+      g_warning ("Failed to update the permission store for %s: %s", id, error->message);
+    }
+
+  XDP_AUTOLOCK (db);
+
+  sync = g_hash_table_lookup (entry_sync, id);
+  if (sync == NULL)
+    return;
+
+  if (sync->writes > 0)
+    sync->writes--;
+
+  if (sync->writes == 0 && sync->queued && !sync->reading)
+    refresh_entry (id, sync);
+  else
+    entry_sync_release (id, sync);
+}
+
+/* Call with the db lock held. */
+static void
+note_store_write (const char *id)
+{
+  entry_sync_get (id)->writes++;
+}
+
+
 char **
 xdp_list_apps (void)
 {
@@ -92,6 +207,7 @@ do_set_permissions (PermissionDbEntry    *entry,
 
   if (persist_entry (new_entry))
     {
+      note_store_write (doc_id);
       xdg_permission_store_call_set_permission (permission_store,
                                                 TABLE_NAME,
                                                 FALSE,
@@ -99,7 +215,7 @@ do_set_permissions (PermissionDbEntry    *entry,
                                                 app_id,
                                                 perms_s,
                                                 NULL,
-                                                NULL, NULL);
+                                                store_write_cb, g_strdup (doc_id));
     }
 }
 
@@ -268,8 +384,11 @@ portal_delete (GDBusMethodInvocation *invocation,
     permission_db_set_entry (db, id, NULL);
 
     if (persist_entry (entry))
-      xdg_permission_store_call_delete (permission_store, TABLE_NAME,
-                                        id, NULL, NULL, NULL);
+      {
+        note_store_write (id);
+        xdg_permission_store_call_delete (permission_store, TABLE_NAME,
+                                          id, NULL, store_write_cb, g_strdup (id));
+      }
   }
 
   /* All i/o is done now, so drop the lock so we can invalidate the fuse caches */
@@ -451,13 +570,14 @@ do_create_doc (struct stat *parent_st_buf,
     {
       g_autoptr(GVariant) data = permission_db_entry_get_data (entry);
 
+      note_store_write (id);
       xdg_permission_store_call_set (permission_store,
                                      TABLE_NAME,
                                      TRUE,
                                      id,
                                      g_variant_new_array (G_VARIANT_TYPE ("{sas}"), NULL, 0),
                                      g_variant_new_variant (data),
-                                     NULL, NULL, NULL);
+                                     NULL, store_write_cb, g_strdup (id));
     }
 
   return g_steal_pointer (&id);
@@ -1821,6 +1941,242 @@ printerr_handler (const gchar *string)
   fprintf (stderr, "%serror: %s%s\n", prefix, suffix, string);
 }
 
+static gboolean
+permissions_equal (const char **a,
+                   const char **b)
+{
+  gsize i;
+
+  if (a == NULL || b == NULL)
+    return a == b;
+
+  if (g_strv_length ((char **) a) != g_strv_length ((char **) b))
+    return FALSE;
+
+  for (i = 0; a[i] != NULL; i++)
+    {
+      if (!g_strv_contains ((const char * const *) b, a[i]))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+/* Replace our copy of an entry's permissions with the ones the store holds.
+ * Only permissions are taken: the document metadata is ours and the store
+ * keeps a mirror of it. Returns the apps whose permissions changed, whose FUSE
+ * nodes must be invalidated once the db lock is dropped.
+ * Call with the db lock held. */
+static GPtrArray *
+apply_store_permissions (const char *id,
+                         GVariant   *permissions)
+{
+  g_autoptr(PermissionDbEntry) old_entry = NULL;
+  g_autoptr(PermissionDbEntry) new_entry = NULL;
+  g_autofree const char **old_apps = NULL;
+  GPtrArray *changed_apps;
+  GVariantIter iter;
+  const char *app_id;
+  GVariant *app_permissions;
+  gsize i;
+
+  changed_apps = g_ptr_array_new_with_free_func (g_free);
+
+  old_entry = permission_db_lookup (db, id);
+
+  /* An id we do not know about. We cannot usefully add it: the document
+   * metadata is ours and the store only mirrors it. Losing a grant is what
+   * matters here, and that cannot happen for an entry we do not have. */
+  if (old_entry == NULL)
+    return changed_apps;
+
+  old_apps = permission_db_entry_list_apps (old_entry);
+  new_entry = permission_db_entry_ref (old_entry);
+
+  /* Apps the store no longer lists have lost their grant entirely */
+  for (i = 0; old_apps[i] != NULL; i++)
+    {
+      g_autoptr(GVariant) still_listed = NULL;
+
+      still_listed = g_variant_lookup_value (permissions, old_apps[i],
+                                             G_VARIANT_TYPE_STRING_ARRAY);
+      if (still_listed == NULL)
+        {
+          g_autoptr(PermissionDbEntry) prev = g_steal_pointer (&new_entry);
+
+          new_entry = permission_db_entry_remove_app_permissions (prev, old_apps[i]);
+          g_ptr_array_add (changed_apps, g_strdup (old_apps[i]));
+        }
+    }
+
+  g_variant_iter_init (&iter, permissions);
+  while (g_variant_iter_loop (&iter, "{&s@as}", &app_id, &app_permissions))
+    {
+      g_autofree const char **new_perms = NULL;
+      g_autofree const char **old_perms = NULL;
+      g_autoptr(PermissionDbEntry) prev = NULL;
+
+      new_perms = g_variant_get_strv (app_permissions, NULL);
+      old_perms = permission_db_entry_list_permissions (old_entry, app_id);
+
+      if (permissions_equal (old_perms, new_perms))
+        continue;
+
+      prev = g_steal_pointer (&new_entry);
+      new_entry = permission_db_entry_set_app_permissions (prev, app_id, new_perms);
+      g_ptr_array_add (changed_apps, g_strdup (app_id));
+    }
+
+  if (changed_apps->len > 0)
+    permission_db_set_entry (db, id, new_entry);
+
+  return changed_apps;
+}
+
+/* Drop an entry the store no longer has. Call with the db lock held. */
+static GPtrArray *
+forget_entry (const char *id,
+              gboolean   *entry_removed)
+{
+  g_autoptr(PermissionDbEntry) old_entry = NULL;
+  g_autofree const char **old_apps = NULL;
+  GPtrArray *changed_apps;
+  gsize i;
+
+  changed_apps = g_ptr_array_new_with_free_func (g_free);
+  *entry_removed = FALSE;
+
+  old_entry = permission_db_lookup (db, id);
+  if (old_entry == NULL)
+    return changed_apps;
+
+  old_apps = permission_db_entry_list_apps (old_entry);
+  for (i = 0; old_apps[i] != NULL; i++)
+    g_ptr_array_add (changed_apps, g_strdup (old_apps[i]));
+
+  permission_db_set_entry (db, id, NULL);
+  *entry_removed = TRUE;
+
+  return changed_apps;
+}
+
+static void
+refresh_lookup_cb (GObject      *source_object,
+                   GAsyncResult *res,
+                   gpointer      user_data)
+{
+  g_autofree char *id = user_data;
+
+  g_autoptr(GVariant) permissions = NULL;
+  g_autoptr(GVariant) data = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GPtrArray) changed_apps = NULL;
+  gboolean entry_removed = FALSE;
+  gboolean gone = FALSE;
+  EntrySync *sync;
+  gsize i;
+
+  if (!xdg_permission_store_call_lookup_finish (XDG_PERMISSION_STORE (source_object),
+                                                &permissions, &data, res, &error))
+    {
+      g_autofree char *remote_error = g_dbus_error_get_remote_error (error);
+
+      /* Not g_error_matches(): the D-Bus name mapping for
+       * XDG_DESKTOP_PORTAL_ERROR is registered lazily, on first use of the
+       * quark, so a reply decoded before anything in this process has used
+       * that domain lands in G_IO_ERROR instead and the match fails. The wire
+       * name is there either way. */
+      gone = g_strcmp0 (remote_error, "org.freedesktop.portal.Error.NotFound") == 0;
+
+      if (!gone)
+        {
+          /* Leave our copy alone. For a revocation we have already applied it
+           * is the more restrictive of the two, and a transient bus error is
+           * not evidence that a grant is gone. */
+          g_dbus_error_strip_remote_error (error);
+          g_warning ("Failed to re-read permissions for %s: %s", id, error->message);
+        }
+    }
+
+  {
+    XDP_AUTOLOCK (db);
+
+    if (gone)
+      changed_apps = forget_entry (id, &entry_removed);
+    else if (permissions != NULL)
+      changed_apps = apply_store_permissions (id, permissions);
+
+    sync = g_hash_table_lookup (entry_sync, id);
+    if (sync != NULL)
+      {
+        sync->reading = FALSE;
+
+        if (sync->queued)
+          refresh_entry (id, sync);
+        else
+          entry_sync_release (id, sync);
+      }
+  }
+
+  /* All i/o is done now, so drop the lock so we can invalidate the fuse caches */
+  for (i = 0; changed_apps != NULL && i < changed_apps->len; i++)
+    xdp_fuse_invalidate_doc_app (id, g_ptr_array_index (changed_apps, i));
+
+  if (entry_removed)
+    xdp_fuse_invalidate_doc_app (id, NULL);
+}
+
+/* Call with the db lock held. */
+static void
+start_refresh (const char *id,
+               EntrySync  *sync)
+{
+  sync->reading = TRUE;
+  xdg_permission_store_call_lookup (permission_store, TABLE_NAME, id, NULL,
+                                    refresh_lookup_cb, g_strdup (id));
+}
+
+static void
+on_permission_store_changed (XdgPermissionStore *store,
+                             const char         *table_name,
+                             const char         *id,
+                             gboolean            deleted,
+                             GVariant           *data,
+                             GVariant           *permissions,
+                             gpointer            user_data)
+{
+  if (g_strcmp0 (table_name, TABLE_NAME) != 0)
+    return;
+
+  XDP_AUTOLOCK (db);
+
+  refresh_entry (id, entry_sync_get (id));
+}
+
+/* The store restarting is a gap in the Changed stream: whatever happened while
+ * it was away was never announced, and it comes back from whatever reached
+ * disk, which can be behind what it had already told us. Re-read everything we
+ * hold rather than guess which entries moved. */
+static void
+on_permission_store_name_owner_changed (GObject    *object,
+                                        GParamSpec *pspec,
+                                        gpointer    user_data)
+{
+  g_autofree char *owner = NULL;
+  g_auto(GStrv) ids = NULL;
+  gsize i;
+
+  owner = g_dbus_proxy_get_name_owner (G_DBUS_PROXY (object));
+  if (owner == NULL)
+    return;
+
+  XDP_AUTOLOCK (db);
+
+  ids = permission_db_list_ids (db);
+  for (i = 0; ids != NULL && ids[i] != NULL; i++)
+    refresh_entry (ids[i], entry_sync_get (ids[i]));
+}
+
 int
 main (int    argc,
       char **argv)
@@ -1905,6 +2261,15 @@ main (int    argc,
       g_print ("No permission store: %s", error->message);
       exit (4);
     }
+
+  entry_sync = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  /* We are not the only writer of the documents table, so re-read entries the
+   * permission store tells us have changed rather than trusting our copy */
+  g_signal_connect (permission_store, "changed",
+                    G_CALLBACK (on_permission_store_changed), NULL);
+  g_signal_connect (permission_store, "notify::g-name-owner",
+                    G_CALLBACK (on_permission_store_name_owner_changed), NULL);
 
   /* We want do do our custom post-mainloop exit */
   g_dbus_connection_set_exit_on_close (session_bus, FALSE);

--- a/document-portal/permission-db.c
+++ b/document-portal/permission-db.c
@@ -1157,6 +1157,8 @@ remove_permissions (GVariant   *app_permissions,
 
       if (g_strcmp0 (app, child_app_id) != 0)
         g_variant_builder_add_value (&builder, child);
+
+      g_variant_unref (child);
     }
 
   return g_variant_builder_end (&builder);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import chdir
 from pathlib import Path
 from types import ModuleType
@@ -616,6 +616,60 @@ def xdg_permission_store_options() -> xdp.PortalProcessOptions:
     return xdp.PortalProcessOptions()
 
 
+PERMISSION_STORE_BUS_NAME = "org.freedesktop.impl.portal.PermissionStore"
+
+
+def _wait_for_name_owner(
+    dbus_con: dbus.Bus, name: str, owned: bool, timeout: float = 10
+) -> None:
+    deadline = time.monotonic() + timeout
+    while dbus_con.name_has_owner(name) != owned and time.monotonic() < deadline:
+        time.sleep(0.05)
+
+    if dbus_con.name_has_owner(name) != owned:
+        state = "owned" if owned else "unowned"
+        raise TimeoutError(f"{name} did not become {state} within {timeout}s")
+
+
+def _start_permission_store(
+    dbus_con: dbus.Bus,
+    path: Path,
+    env: dict[str, str],
+    options: xdp.PortalProcessOptions,
+) -> subprocess.Popen:
+    if not path.exists():
+        raise FileNotFoundError(f"{path} does not exist")
+
+    env = env.copy()
+    _maybe_add_asan_preload(path, env)
+
+    permission_store = subprocess.Popen(
+        [path],
+        env=env,
+        stdout=subprocess.PIPE if options.capture_stdout else None,
+        stderr=subprocess.PIPE if options.capture_stderr else None,
+    )
+
+    while not dbus_con.name_has_owner(PERMISSION_STORE_BUS_NAME):
+        returncode = permission_store.poll()
+        if returncode is not None:
+            raise subprocess.SubprocessError(
+                f"xdg-permission-store exited with {returncode}"
+            )
+        time.sleep(0.1)
+
+    return permission_store
+
+
+def _stop_permission_store(permission_store: subprocess.Popen) -> None:
+    if permission_store.poll() is None:
+        permission_store.send_signal(signal.SIGHUP)
+        permission_store.wait()
+        # The permission store does not shut down cleanly currently
+        # returncode = permission_store.wait()
+        # assert returncode == 0
+
+
 @pytest.fixture
 def xdg_permission_store(
     dbus_con: dbus.Bus,
@@ -626,35 +680,48 @@ def xdg_permission_store(
     """
     Fixture which starts and eventually stops xdg-permission-store
     """
-    if not xdg_permission_store_path.exists():
-        raise FileNotFoundError(f"{xdg_permission_store_path} does not exist")
-
-    env = xdp_env.copy()
-    _maybe_add_asan_preload(xdg_permission_store_path, env)
-
-    permission_store = subprocess.Popen(
-        [xdg_permission_store_path],
-        env=env,
-        stdout=subprocess.PIPE if xdg_permission_store_options.capture_stdout else None,
-        stderr=subprocess.PIPE if xdg_permission_store_options.capture_stderr else None,
+    permission_store = _start_permission_store(
+        dbus_con, xdg_permission_store_path, xdp_env, xdg_permission_store_options
     )
-
-    while not dbus_con.name_has_owner("org.freedesktop.impl.portal.PermissionStore"):
-        returncode = permission_store.poll()
-        if returncode is not None:
-            raise subprocess.SubprocessError(
-                f"xdg-permission-store exited with {returncode}"
-            )
-        time.sleep(0.1)
 
     yield permission_store
 
-    if permission_store.poll() is None:
-        permission_store.send_signal(signal.SIGHUP)
-        permission_store.wait()
-        # The permission store does not shut down cleanly currently
-        # returncode = permission_store.wait()
-        # assert returncode == 0
+    _stop_permission_store(permission_store)
+
+
+@pytest.fixture
+def restart_xdg_permission_store(
+    dbus_con: dbus.Bus,
+    xdg_permission_store: subprocess.Popen,
+    xdg_permission_store_path: Path,
+    xdp_env: dict[str, str],
+    xdg_permission_store_options: xdp.PortalProcessOptions,
+) -> Iterator[Callable[[], subprocess.Popen]]:
+    """
+    Fixture returning a callable that kills the running xdg-permission-store
+    and brings a fresh one up in its place, as a crash or an upgrade would.
+    """
+    replacements: list[subprocess.Popen] = []
+
+    def restart() -> subprocess.Popen:
+        current = replacements[-1] if replacements else xdg_permission_store
+
+        if current.poll() is None:
+            current.kill()
+            current.wait()
+
+        _wait_for_name_owner(dbus_con, PERMISSION_STORE_BUS_NAME, owned=False)
+
+        permission_store = _start_permission_store(
+            dbus_con, xdg_permission_store_path, xdp_env, xdg_permission_store_options
+        )
+        replacements.append(permission_store)
+        return permission_store
+
+    yield restart
+
+    for permission_store in replacements:
+        _stop_permission_store(permission_store)
 
 
 @pytest.fixture

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -4,6 +4,7 @@
 # This file is formatted with Python Black
 
 import os
+import time
 from pathlib import Path
 
 import dbus
@@ -11,6 +12,17 @@ import pytest
 
 import tests.xdp_doc_utils as xdp_doc
 import tests.xdp_utils as xdp
+
+
+def permission_store_iface(dbus_con: dbus.Bus) -> dbus.Interface:
+    permission_store = dbus_con.get_object(
+        "org.freedesktop.impl.portal.PermissionStore",
+        "/org/freedesktop/impl/portal/PermissionStore",
+    )
+    return dbus.Interface(
+        permission_store,
+        "org.freedesktop.impl.portal.PermissionStore",
+    )
 
 
 @pytest.fixture
@@ -129,6 +141,150 @@ class TestDocuments:
         # Ensure we can make a unique document
         doc_id5 = xdp_doc.export_file(documents_intf, file_path, unique=True)
         assert doc_id5 != doc_id
+
+    def test_external_revocation(
+        self, xdg_permission_store, xdg_document_portal, dbus_con
+    ):
+        """The documents table is shared with the permission store, which is a
+        separate process. A revocation made there, as `flatpak
+        permission-remove` and `flatpak permission-reset` do, has to be
+        honoured by the running document portal rather than only after it is
+        restarted.
+
+        https://github.com/flatpak/xdg-desktop-portal/issues/197
+        """
+        documents_intf = xdp.get_document_portal_iface(dbus_con)
+        mountpoint = xdp_doc.get_mountpoint(documents_intf)
+
+        app_id = "com.test.App1"
+        content = b"content"
+        file_name = "a-file"
+
+        file_path = Path(os.environ["TMPDIR"]) / file_name
+        xdp_doc.write_bytes_atomic(file_path, content)
+
+        # Only persistent documents are mirrored into the permission store,
+        # and so only they can be revoked from outside the document portal
+        with open(file_path.absolute().as_posix(), "r") as file:
+            doc_id = documents_intf.Add(file.fileno(), True, True)
+        assert doc_id
+
+        doc_app_path = mountpoint / "by-app" / app_id / doc_id
+
+        # The app can read and write the document while it holds the grant
+        documents_intf.GrantPermissions(doc_id, app_id, ["read", "write"])
+        assert (doc_app_path / file_name).read_bytes() == content
+        xdp_doc.write_bytes_atomic(doc_app_path / file_name, b"written by app")
+        assert file_path.read_bytes() == b"written by app"
+
+        # Revoke through the permission store rather than through the document
+        # portal, which is what the flatpak CLI does
+        permission_store_iface(dbus_con).DeletePermission("documents", doc_id, app_id)
+
+        # The store notifies us with a Changed signal, so the document portal
+        # is not expected to have caught up the instant the call returns. It is
+        # expected to catch up without being restarted.
+        deadline = time.monotonic() + 10
+        while (doc_app_path / file_name).exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert not (doc_app_path / file_name).exists()
+        assert not doc_app_path.exists()
+
+        with pytest.raises(OSError):
+            (doc_app_path / file_name).write_bytes(b"written after revocation")
+
+        # The document itself is untouched; only the app's grant is gone
+        assert (mountpoint / doc_id / file_name).read_bytes() == b"written by app"
+
+    def test_external_deletion(
+        self, xdg_permission_store, xdg_document_portal, dbus_con
+    ):
+        """Deleting the whole entry from the permission store, rather than one
+        app's permissions, has to be honoured too. The store answers a lookup
+        for a deleted entry with NotFound, which is a different path through
+        the portal than an entry that merely changed.
+        """
+        documents_intf = xdp.get_document_portal_iface(dbus_con)
+        mountpoint = xdp_doc.get_mountpoint(documents_intf)
+
+        app_id = "com.test.App1"
+        content = b"content"
+        file_name = "a-file"
+
+        file_path = Path(os.environ["TMPDIR"]) / file_name
+        xdp_doc.write_bytes_atomic(file_path, content)
+
+        with open(file_path.absolute().as_posix(), "r") as file:
+            doc_id = documents_intf.Add(file.fileno(), True, True)
+        assert doc_id
+
+        doc_app_path = mountpoint / "by-app" / app_id / doc_id
+
+        documents_intf.GrantPermissions(doc_id, app_id, ["read", "write"])
+        assert (doc_app_path / file_name).read_bytes() == content
+
+        permission_store_iface(dbus_con).Delete("documents", doc_id)
+
+        deadline = time.monotonic() + 10
+        while (doc_app_path / file_name).exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert not (doc_app_path / file_name).exists()
+        assert not doc_app_path.exists()
+
+    def test_external_revocation_after_store_restart(
+        self,
+        xdg_permission_store,
+        xdg_document_portal,
+        restart_xdg_permission_store,
+        dbus_con,
+    ):
+        """The permission store can go away and come back under a running
+        document portal, on a crash or an upgrade. The subscription has to
+        survive that, so a revocation made through the instance that replaced
+        it is honoured like any other.
+        """
+        documents_intf = xdp.get_document_portal_iface(dbus_con)
+        mountpoint = xdp_doc.get_mountpoint(documents_intf)
+
+        app_id = "com.test.App1"
+        content = b"content"
+        file_name = "a-file"
+
+        file_path = Path(os.environ["TMPDIR"]) / file_name
+        xdp_doc.write_bytes_atomic(file_path, content)
+
+        with open(file_path.absolute().as_posix(), "r") as file:
+            doc_id = documents_intf.Add(file.fileno(), True, True)
+        assert doc_id
+
+        doc_app_path = mountpoint / "by-app" / app_id / doc_id
+
+        documents_intf.GrantPermissions(doc_id, app_id, ["read", "write"])
+        assert (doc_app_path / file_name).read_bytes() == content
+
+        # The portal mirrors the grant into the store asynchronously. Write it
+        # again from here and wait for the reply: the store answers only once
+        # the table has been written out, so the replacement instance is
+        # guaranteed to load the grant rather than come up without it.
+        permission_store_iface(dbus_con).SetPermission(
+            "documents", True, doc_id, app_id, ["read", "write"]
+        )
+
+        restart_xdg_permission_store()
+
+        permission_store_iface(dbus_con).DeletePermission("documents", doc_id, app_id)
+
+        deadline = time.monotonic() + 10
+        while (doc_app_path / file_name).exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert not (doc_app_path / file_name).exists()
+        assert not doc_app_path.exists()
+
+        # The document itself is untouched; only the app's grant is gone
+        assert (mountpoint / doc_id / file_name).read_bytes() == content
 
     def test_recursive_doc(self, xdg_document_portal, dbus_con):
         documents_intf = xdp.get_document_portal_iface(dbus_con)


### PR DESCRIPTION
Closes #197.

The document portal loads `$XDG_DATA_HOME/flatpak/db/documents` once in `main()` and never observes writes made by the permission store, which is a separate process holding the same table. `flatpak permission-remove` and `flatpak permission-reset` therefore return success and empty the canonical entry, while the running portal keeps authorizing FUSE reads *and* writes for the removed app until it is restarted.

Analysis against current `main` is in https://github.com/flatpak/xdg-desktop-portal/issues/197#issuecomment-5121068375.

Rewritten since the last review. The previous version applied the contents of the `Changed` signal and counted the portal's own writes so it could skip their echoes. @swick asked what happens when the permission store restarts and when a change happens concurrently in both processes. The second question was the real one: the counting scheme identified echoes positionally, so an external change landing inside that window was consumed as though it were ours. That is gone.

### What this does

A `Changed` for the `documents` table marks the entry stale and the portal re-reads it with `Lookup`, rather than applying the payload. The payload carries the state the store held when it applied the change, so applying it directly means telling our own echoes apart from external ones, which means pairing signals to writes. Re-reading needs neither: whoever made the change, the answer is whatever the store holds now.

That only holds while the store is not behind us, and it can be. Our writes to it are asynchronous, so between applying a change locally and the store acknowledging it, a re-read would undo what we just applied. So the portal counts the writes it has outstanding for an entry, and a `Changed` arriving while any of them is unacknowledged is recorded rather than acted on; the read happens once they are all acknowledged.

That is not the echo pairing again. Nothing is matched to anything: signals arriving in any order still produce exactly one read, taken once the store has caught up. It is closer to your dirty-on-`Changed` suggestion, with per-id granularity rather than marking the whole table.

Other details:

- Only permissions are taken. The document metadata is ours and the store keeps a mirror of it.
- The db lock is dropped before invalidating the affected FUSE nodes, as `portal_delete()` already requires.
- Every entry is re-read when the store's name owner reappears. A restart is a gap in the `Changed` stream: whatever happened while it was away was never announced, and it comes back from whatever reached disk, which can be behind what it had already told us.
- A deleted entry is recognised by the wire name of the store's error rather than with `g_error_matches()`. The D-Bus name mapping for `XDG_DESKTOP_PORTAL_ERROR` is registered lazily, on first use of the quark, so a reply decoded before anything in the process has used that domain lands in `G_IO_ERROR` and the match silently fails.

### Limitations

Eventual, not synchronous, consistency. `handle_delete_permission()` emits `Changed` before `ensure_writeout()`, so the portal catches up within a main-loop iteration, but a window remains in which the stale grant is still honoured. Staleness goes from unbounded, until the portal restarts, to bounded by main-loop and bus latency. Closing it completely would mean making one component authoritative for these decisions, which is a much larger change than this.

A restart issues one `Lookup` per held document rather than a single `List`. That is a burst at large table sizes, and `List` is an easy swap if you would prefer it.

### Testing

Three new tests, all of which fail on unpatched `main`:

- `test_external_revocation` revokes through the permission store the way the flatpak CLI does.
- `test_external_revocation_after_store_restart` does the same through an instance that replaced a killed one.
- `test_external_deletion` removes the whole entry rather than one app's permissions. The store answers a later lookup with `NotFound`, which is a different path through the portal.

`tests/conftest.py` grows a `restart_xdg_permission_store` fixture, factored out of the existing one so a restart goes through the same startup path, including the ASAN preload handling.

Results, built as CI builds it (`-Dinstalled-tests=true -Dtests=enabled -Db_sanitize=address -Db_lundef=false -Dwerror=true`):

- No compiler warnings.
- `integration/documents`: 11 passed, repeated 4 times, no flakes. With the same tests against unpatched `main`, 3 failed and 8 passed.
- The installed-tests run, `gnome-desktop-testing-runner xdg-desktop-portal/integration-documents.test`, repeated 10 times: 10 passed.

Only persistent documents are affected: `Add(fd, reuse_existing, persistent)` mirrors an entry into the permission store only when `persistent` is true, so the tests cannot use `export_file()` from the test helpers, which passes `persistent=False`.

Rebased onto current `main`.

### Disclosure

I reported the security impact of this to `flatpak-security@lists.freedesktop.org` on 2026-07-19. The maintainers elected to handle it publicly upstream rather than as an embargoed issue.
