### PR TITLE
Minor improvements to type checking and pre-commit configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       packages: write
     with:
-      image: xdg-desktop-portal-checks:2026-07-07.1
+      image: xdg-desktop-portal-checks:2026-07-30.1
       containerfile: containerfiles/check.containerfile
 
   build-and-test:

--- a/.gitlint.conf/custom-body-max-line-length.py
+++ b/.gitlint.conf/custom-body-max-line-length.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
 import re
+
 from gitlint.rules import BodyMaxLineLength
 
 

--- a/containerfiles/pre-commit-config.yaml
+++ b/containerfiles/pre-commit-config.yaml
@@ -23,13 +23,13 @@ repos:
       entry: /usr/lib/qt6/bin/qdbusxml2cpp
       files: data/.+\.xml$
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.0
+  rev: v0.16.0
   hooks:
     - id: ruff
     - id: ruff-format
       args: [ --check ]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.1
+  rev: v2.3.0
   hooks:
     - id: mypy
       additional_dependencies:

--- a/desktop-portal/generate-method-info.py
+++ b/desktop-portal/generate-method-info.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
 import argparse
-import xml.etree.ElementTree as ElementTree
+from xml.etree import ElementTree
 
 
 def quote(s: str):
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
     print('#include "glib.h"')
     print('#include "xdp-method-info.h"')
-    print("")
+    print()
     print("static const XdpMethodInfo method_info[] = {")
 
     for file in args.file:
@@ -66,11 +66,11 @@ if __name__ == "__main__":
 
     print("  { .interface = NULL },")
     print("};")
-    print("")
+    print()
     print(
         "const XdpMethodInfo *xdp_method_info_get_all (void) { return method_info; };"
     )
-    print("")
+    print()
     print(
         "unsigned int xdp_method_info_get_count (void) { return G_N_ELEMENTS(method_info) - 1; };"
     )

--- a/doc/copy-subdir.py
+++ b/doc/copy-subdir.py
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
 import os
-import sys
 import shutil
+import sys
 
 subdir = os.environ["MESON_SUBDIR"]
 

--- a/doc/copy-subtree.py
+++ b/doc/copy-subtree.py
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
 import os
-import sys
 import shutil
+import sys
 
 subdir = os.environ["MESON_SUBDIR"]
 

--- a/doc/fix-rst-dbus.py
+++ b/doc/fix-rst-dbus.py
@@ -102,9 +102,7 @@ def adjust_title(lines):
 
     # CamelCase → Camel Case
     if adjusted_title not in ["OpenURI", "ScreenCast"]:
-        adjusted_title = "".join(
-            map(lambda x: x if x.islower() else f" {x}", adjusted_title)
-        )
+        adjusted_title = "".join(x if x.islower() else f" {x}" for x in adjusted_title)
 
     lines[3] = f"{adjusted_title}\n"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def ensure_environment_set() -> None:
 
     for env_var in env_vars:
         if not os.getenv(env_var):
-            raise Exception(f"{env_var} must be set")
+            raise OSError(f"{env_var} must be set")
 
 
 def ensure_umockdev_loaded() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,29 +3,28 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-from typing import Any, Dict, Iterator, Optional
-from types import ModuleType
-
-import pytest
-import dbus
-import dbusmock
 import os
+import shutil
+import signal
+import subprocess
 import sys
 import tempfile
-import subprocess
 import time
-import signal
-import shutil
-
-from pathlib import Path
+from collections.abc import Iterator
 from contextlib import chdir
+from pathlib import Path
+from types import ModuleType
+from typing import Any
 
+import dbus
+import dbusmock
 import gi
+import pytest
+
+import tests.xdp_utils as xdp
 
 gi.require_version("UMockdev", "1.0")
-from gi.repository import UMockdev  # noqa E402
+from gi.repository import UMockdev
 
 
 def pytest_configure() -> None:
@@ -95,7 +94,7 @@ def xdg_document_portal_path() -> Path:
 
 
 @pytest.fixture(autouse=True)
-def create_test_dirs(umockdev: Optional[UMockdev.Testbed]) -> Iterator[None]:
+def create_test_dirs(umockdev: UMockdev.Testbed | None) -> Iterator[None]:
     # The umockdev argument is to make sure the testbed
     # is created before we create the tmpdir
     env_dirs = [
@@ -168,7 +167,7 @@ def create_xdp_executables(
 
 
 @pytest.fixture
-def xdg_data_home_files() -> Dict[str, bytes]:
+def xdg_data_home_files() -> dict[str, bytes]:
     """
     Default fixture which can be used to create files in the temporary
     XDG_DATA_HOME directory of the test.
@@ -178,7 +177,7 @@ def xdg_data_home_files() -> Dict[str, bytes]:
 
 @pytest.fixture(autouse=True)
 def ensure_xdg_data_home(
-    create_test_dirs: Any, xdg_data_home_files: Dict[str, bytes]
+    create_test_dirs: Any, xdg_data_home_files: dict[str, bytes]
 ) -> None:
     files = xdg_data_home_files
     for name, content in files.items():
@@ -189,7 +188,7 @@ def ensure_xdg_data_home(
 
 
 @pytest.fixture
-def xdg_desktop_portal_dir_files() -> Dict[str, bytes]:
+def xdg_desktop_portal_dir_files() -> dict[str, bytes]:
     """
     Default fixture which can be used to create files in the temporary
     XDG_DESKTOP_PORTAL_DIR directory of the test.
@@ -198,7 +197,7 @@ def xdg_desktop_portal_dir_files() -> Dict[str, bytes]:
 
 
 @pytest.fixture
-def xdg_desktop_portal_dir_default_files() -> Dict[str, bytes]:
+def xdg_desktop_portal_dir_default_files() -> dict[str, bytes]:
     files = {}
 
     portals = [
@@ -241,8 +240,8 @@ Interfaces={}
 @pytest.fixture(autouse=True)
 def ensure_xdg_desktop_portal_dir(
     create_test_dirs: Any,
-    xdg_desktop_portal_dir_files: Dict[str, bytes],
-    xdg_desktop_portal_dir_default_files: Dict[str, bytes],
+    xdg_desktop_portal_dir_files: dict[str, bytes],
+    xdg_desktop_portal_dir_default_files: dict[str, bytes],
 ) -> None:
     files = xdg_desktop_portal_dir_default_files | xdg_desktop_portal_dir_files
     for name, content in files.items():
@@ -266,7 +265,7 @@ def create_test_dbus() -> Iterator[dbusmock.DBusTestCase]:
 
 
 @pytest.fixture(autouse=True)
-def create_dbus_monitor(create_test_dbus) -> Iterator[Optional[subprocess.Popen]]:
+def create_dbus_monitor(create_test_dbus) -> Iterator[subprocess.Popen | None]:
     if not os.getenv("XDP_DBUS_MONITOR"):
         yield None
         return
@@ -338,8 +337,8 @@ def _terminate_servers(
 def _start_template(
     busses: dict[dbusmock.BusType, dict[str, dbusmock.SpawnedMock]],
     template: str,
-    bus_name: Optional[str],
-    params: Dict[str, Any] = {},
+    bus_name: str | None,
+    params: dict[str, Any] = {},
 ) -> None:
     """
     Start the template and potentially start a server for it
@@ -488,7 +487,7 @@ def xdp_env(
     xdp_overwrite_env: dict[str, str],
     xdp_app_info_init: xdp.AppInfo,
     xdp_bin_path: Path,
-    umockdev: Optional[UMockdev.Testbed],
+    umockdev: UMockdev.Testbed | None,
 ) -> dict[str, str]:
     env = os.environ.copy()
     env["G_DEBUG"] = "fatal-criticals"
@@ -692,11 +691,11 @@ def portals(templates: Any, xdg_desktop_portal: Any, xdg_permission_store: Any) 
     Fixture which starts the required templates, xdg-desktop-portal,
     xdg-document-portal and xdg-permission-store. Most tests require this.
     """
-    return None
+    return
 
 
 @pytest.fixture
-def umockdev() -> Optional[UMockdev.Testbed]:
+def umockdev() -> UMockdev.Testbed | None:
     """
     Default fixture providing a umockdev testbed
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,7 +312,7 @@ def _get_main_obj_for_module(
             [],
             dbus_interface=dbusmock.MOCK_IFACE,
         )
-    except Exception:
+    except dbus.exceptions.DBusException:
         pass
 
     bustype.wait_for_bus_object(module.BUS_NAME, module.MAIN_OBJ)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,7 +338,7 @@ def _start_template(
     busses: dict[dbusmock.BusType, dict[str, dbusmock.SpawnedMock]],
     template: str,
     bus_name: str | None,
-    params: dict[str, Any] = {},
+    params: dict[str, Any] | None = None,
 ) -> None:
     """
     Start the template and potentially start a server for it
@@ -361,6 +361,8 @@ def _start_template(
         server = _get_server_for_module(busses, module, bustype)
         main_obj = _get_main_obj_for_module(server, module, bustype)
 
+        if params is None:
+            params = {}
         main_obj.AddTemplate(
             template,
             dbus.Dictionary(params, signature="sv"),

--- a/tests/templates/access.py
+++ b/tests/templates/access.py
@@ -26,7 +26,9 @@ class AccessParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "access_params")

--- a/tests/templates/access.py
+++ b/tests/templates/access.py
@@ -4,11 +4,11 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
 from dataclasses import dataclass
 
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/account.py
+++ b/tests/templates/account.py
@@ -28,7 +28,9 @@ class AccountParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "account_params")

--- a/tests/templates/account.py
+++ b/tests/templates/account.py
@@ -4,12 +4,12 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
-import dbus
 from dataclasses import dataclass
 
+import dbus
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/appchooser.py
+++ b/tests/templates/appchooser.py
@@ -27,7 +27,9 @@ class AppchooserParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "appchooser_params")

--- a/tests/templates/appchooser.py
+++ b/tests/templates/appchooser.py
@@ -4,11 +4,11 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
 from dataclasses import dataclass
 
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/background.py
+++ b/tests/templates/background.py
@@ -27,7 +27,9 @@ class BackgroundParameters:
     delay: int
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "background_params")

--- a/tests/templates/background.py
+++ b/tests/templates/background.py
@@ -4,13 +4,13 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import init_logger
-
-import dbus.service
-import dbus
-from gi.repository import GLib
 from dataclasses import dataclass
 
+import dbus
+import dbus.service
+from gi.repository import GLib
+
+from tests.templates.xdp_utils import init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/clipboard.py
+++ b/tests/templates/clipboard.py
@@ -30,7 +30,9 @@ class ClipboardParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "clipboard_params")

--- a/tests/templates/clipboard.py
+++ b/tests/templates/clipboard.py
@@ -68,7 +68,7 @@ def RequestClipboard(self, session_handle, options, cb_success, cb_error):
         else:
             logger.debug(f"scheduling delay of {params.delay}")
             GLib.timeout_add(params.delay, cb_success)
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         cb_error(e)
 
@@ -89,7 +89,7 @@ def SetSelection(self, session_handle, options, cb_success, cb_error):
         else:
             logger.debug(f"scheduling delay of {params.delay}")
             GLib.timeout_add(params.delay, cb_success)
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         cb_error(e)
 
@@ -117,7 +117,7 @@ def SelectionWrite(self, session_handle, serial, cb_success, cb_error):
 
             logger.debug(f"scheduling delay of {params.delay}")
             GLib.timeout_add(params.delay, reply)
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         cb_error(e)
 
@@ -138,7 +138,7 @@ def SelectionWriteDone(self, session_handle, serial, success, cb_success, cb_err
         else:
             logger.debug(f"scheduling delay of {params.delay}")
             GLib.timeout_add(params.delay, cb_success)
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         cb_error(e)
 
@@ -166,6 +166,6 @@ def SelectionRead(self, session_handle, mime_type, cb_success, cb_error):
 
             logger.debug(f"scheduling delay of {params.delay}")
             GLib.timeout_add(params.delay, reply)
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         cb_error(e)

--- a/tests/templates/clipboard.py
+++ b/tests/templates/clipboard.py
@@ -105,8 +105,8 @@ def SelectionWrite(self, session_handle, serial, cb_success, cb_error):
         logger.debug(f"SelectionWrite({session_handle}, {serial})")
         params = self.clipboard_params
 
-        temp_file = tempfile.TemporaryFile()
-        fd = dbus.types.UnixFd(temp_file.fileno())
+        with tempfile.TemporaryFile() as temp_file:
+            fd = dbus.types.UnixFd(temp_file.fileno())
 
         if params.expect_close:
             cb_success(fd)
@@ -154,8 +154,8 @@ def SelectionRead(self, session_handle, mime_type, cb_success, cb_error):
         logger.debug(f"SelectionRead({session_handle}, {mime_type})")
         params = self.clipboard_params
 
-        temp_file = tempfile.TemporaryFile()
-        fd = dbus.types.UnixFd(temp_file.fileno())
+        with tempfile.TemporaryFile() as temp_file:
+            fd = dbus.types.UnixFd(temp_file.fileno())
 
         if params.expect_close:
             cb_success(fd)

--- a/tests/templates/clipboard.py
+++ b/tests/templates/clipboard.py
@@ -4,14 +4,14 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import init_logger
-
-import dbus.service
-import dbus
 import tempfile
-from gi.repository import GLib
 from dataclasses import dataclass
 
+import dbus
+import dbus.service
+from gi.repository import GLib
+
+from tests.templates.xdp_utils import init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/dynamiclauncher.py
+++ b/tests/templates/dynamiclauncher.py
@@ -28,7 +28,9 @@ class DynamiclauncherParameters:
     launcher_name: str
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "dynamiclauncher_params")

--- a/tests/templates/dynamiclauncher.py
+++ b/tests/templates/dynamiclauncher.py
@@ -4,11 +4,11 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
 from dataclasses import dataclass
 
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/email.py
+++ b/tests/templates/email.py
@@ -27,7 +27,9 @@ class EmailParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "email_params")

--- a/tests/templates/email.py
+++ b/tests/templates/email.py
@@ -4,11 +4,11 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
 from dataclasses import dataclass
 
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/filechooser.py
+++ b/tests/templates/filechooser.py
@@ -28,7 +28,9 @@ class FilechooserParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "filechooser_params")

--- a/tests/templates/filechooser.py
+++ b/tests/templates/filechooser.py
@@ -4,11 +4,11 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
 from dataclasses import dataclass
 
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/geoclue2.py
+++ b/tests/templates/geoclue2.py
@@ -2,12 +2,11 @@
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import init_logger
-
-import dbus.service
 import dbus
-
+import dbus.service
 from dbusmock import mockobject
+
+from tests.templates.xdp_utils import init_logger
 
 BUS_NAME = "org.freedesktop.GeoClue2"
 MAIN_OBJ = "/org/freedesktop/GeoClue2/Manager"
@@ -23,7 +22,7 @@ logger = init_logger(__name__)
 
 class GeoClueClient(mockobject.DBusMockObject):
     def __init__(self, *args, **kwargs):
-        super(GeoClueClient, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.started = False
         self.location = 0

--- a/tests/templates/geoclue2.py
+++ b/tests/templates/geoclue2.py
@@ -92,7 +92,9 @@ class GeoClueClient(mockobject.DBusMockObject):
         )
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     mock.AddMethods(
         MAIN_IFACE,
         [

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -32,7 +32,9 @@ class GlobalshortcutsParameters:
     force_close: int
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "globalshortcuts_params")

--- a/tests/templates/globalshortcuts.py
+++ b/tests/templates/globalshortcuts.py
@@ -4,15 +4,15 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest, ImplSession
+import time
+from dataclasses import dataclass
 
 import dbus
 import dbus.service
-import time
 from dbusmock import MOCK_IFACE
 from gi.repository import GLib
-from dataclasses import dataclass
 
+from tests.templates.xdp_utils import ImplRequest, ImplSession, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -36,7 +36,9 @@ class InhibitParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "inhibit_params")

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -4,14 +4,14 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest, ImplSession
+from dataclasses import dataclass
+from enum import Enum
 
 import dbus.service
-from gi.repository import GLib
-from enum import Enum
 from dbusmock import MOCK_IFACE
-from dataclasses import dataclass
+from gi.repository import GLib
 
+from tests.templates.xdp_utils import ImplRequest, ImplSession, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/inhibit.py
+++ b/tests/templates/inhibit.py
@@ -163,5 +163,5 @@ def QueryEndResponse(self, session_handle):
 
         self.ArmTimer(session_handle)
 
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)

--- a/tests/templates/inputcapture.py
+++ b/tests/templates/inputcapture.py
@@ -4,18 +4,17 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, ImplSession, init_logger
-
+import socket
 from collections import namedtuple
-from itertools import count
-from gi.repository import GLib
 from dataclasses import dataclass
+from itertools import count
+
 import dbus
 import dbus.service
-import socket
+from gi.repository import GLib
 
+from tests.templates.xdp_utils import ImplSession, Response, init_logger
 from tests.xdp_utils import SessionPersistenceMode
-
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/inputcapture.py
+++ b/tests/templates/inputcapture.py
@@ -110,7 +110,7 @@ def CreateSession2(self, session_handle, app_id, options):
         self.session_handles.append(session_handle)
 
         return {"session_handle": session_handle}
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return (2, {})
 
@@ -176,7 +176,7 @@ def Start(self, handle, session_handle, app_id, parent_window, options):
         logger.debug(f"Start with response {response}")
 
         return response.response, response.results
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return (2, {})
 
@@ -204,7 +204,7 @@ def GetZones(self, handle, session_handle, app_id, options):
             self.current_zones = response.results["zones"]
 
         return response.response, response.results
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return (2, {})
 
@@ -273,7 +273,7 @@ def SetPointerBarriers(
         logger.debug(f"SetPointerBarriers with response {response}")
 
         return response.response, response.results
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return (2, {})
 
@@ -349,7 +349,7 @@ def Enable(self, session_handle, app_id, options):
 
             GLib.timeout_add(params.zones_changed_delay, zones_changed)
 
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return (2, {})
 
@@ -364,7 +364,7 @@ def Disable(self, session_handle, app_id, options):
         logger.debug(f"Disable({session_handle}, {options})")
 
         assert session_handle in self.active_session_handles
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return (2, {})
 
@@ -379,7 +379,7 @@ def Release(self, session_handle, app_id, options):
         logger.debug(f"Release({session_handle}, {options})")
 
         assert session_handle in self.active_session_handles
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return (2, {})
 
@@ -405,6 +405,6 @@ def ConnectToEIS(self, session_handle, app_id, options):
         logger.debug(f"ConnectToEis with fd {fd.fileno()}")
 
         return dbus.types.UnixFd(fd)
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         return -1

--- a/tests/templates/inputcapture.py
+++ b/tests/templates/inputcapture.py
@@ -14,7 +14,7 @@ import dbus.service
 from gi.repository import GLib
 
 from tests.templates.xdp_utils import ImplSession, Response, init_logger
-from tests.xdp_utils import SessionPersistenceMode
+from tests.xdp_utils import SessionPersistenceMode, SessionPersistenceModeError
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"
@@ -38,6 +38,16 @@ def make_restore_data(data: str):
         ("GNOME", RESTORE_DATA_VERSION, dbus.String(data, variant_level=1)),
         signature="suv",
     )
+
+
+class RestoreDataError(TypeError):
+    """Exception raised when restore data is invalid."""
+
+    def __init__(self, restore_data: tuple) -> None:
+        self.restore_data = restore_data
+
+    def __str__(self) -> str:
+        return f"Invalid restore_data tuple {self.restore_data}"
 
 
 @dataclass
@@ -146,7 +156,7 @@ def Start(self, handle, session_handle, app_id, parent_window, options):
                     rd for rd in self.restore_datas if rd == restore_data
                 )
             except StopIteration:
-                raise Exception(f"Invalid restore_data tuple {restore_data}")
+                raise RestoreDataError(restore_data)
 
         if persist_mode == SessionPersistenceMode.NONE:
             pass
@@ -157,7 +167,7 @@ def Start(self, handle, session_handle, app_id, parent_window, options):
             if restore_data is None:
                 restore_data = make_restore_data("restore-persistent")
         elif persist_mode is not None:
-            raise Exception(f"Invalid session persistence mode: {persist_mode}")
+            raise SessionPersistenceModeError(persist_mode)
 
         if restore_data and persist_mode in [
             SessionPersistenceMode.TRANSIENT,

--- a/tests/templates/inputcapture.py
+++ b/tests/templates/inputcapture.py
@@ -54,7 +54,9 @@ class InputcaptureParameters:
     allow_persistence: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "inputcapture_params")

--- a/tests/templates/lockdown.py
+++ b/tests/templates/lockdown.py
@@ -4,10 +4,9 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import init_logger
-
 import dbus.service
 
+from tests.templates.xdp_utils import init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/lockdown.py
+++ b/tests/templates/lockdown.py
@@ -17,7 +17,9 @@ MAIN_IFACE = "org.freedesktop.impl.portal.Lockdown"
 logger = init_logger(__name__)
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     mock.AddProperties(

--- a/tests/templates/notification.py
+++ b/tests/templates/notification.py
@@ -4,11 +4,10 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import init_logger
-
 import dbus.service
 from dbusmock import MOCK_IFACE
 
+from tests.templates.xdp_utils import init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/notification.py
+++ b/tests/templates/notification.py
@@ -19,7 +19,9 @@ VERSION = 2
 logger = init_logger(__name__)
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     mock.AddProperties(

--- a/tests/templates/print.py
+++ b/tests/templates/print.py
@@ -29,7 +29,9 @@ class PrintParameters:
     prepare_results: dict
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "print_params")

--- a/tests/templates/print.py
+++ b/tests/templates/print.py
@@ -4,11 +4,11 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
 from dataclasses import dataclass
 
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -175,7 +175,7 @@ def ConnectToEIS(self, session_handle, app_id, options):
         assert self.eis_socket.send(b"HELLO") == 5
 
         return dbus.types.UnixFd(sockets[1])
-    except Exception as e:
+    except dbus.exceptions.DBusException as e:
         logger.critical(e)
         raise e
 

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -34,7 +34,9 @@ class RemotedesktopParameters:
     fail_connect_to_eis: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "remotedesktop_params")

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -177,7 +177,7 @@ def ConnectToEIS(self, session_handle, app_id, options):
         return dbus.types.UnixFd(sockets[1])
     except dbus.exceptions.DBusException as e:
         logger.critical(e)
-        raise e
+        raise
 
 
 @dbus.service.method(MOCK_IFACE, in_signature="s", out_signature="s")

--- a/tests/templates/remotedesktop.py
+++ b/tests/templates/remotedesktop.py
@@ -4,15 +4,15 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest, ImplSession
-
-from dbusmock import MOCK_IFACE
-import dbus
-import dbus.service
 import socket
-from gi.repository import GLib
 from dataclasses import dataclass
 
+import dbus
+import dbus.service
+from dbusmock import MOCK_IFACE
+from gi.repository import GLib
+
+from tests.templates.xdp_utils import ImplRequest, ImplSession, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/screencast.py
+++ b/tests/templates/screencast.py
@@ -4,11 +4,12 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest, ImplSession
+from dataclasses import dataclass
 
 import dbus
 import dbus.service
-from dataclasses import dataclass
+
+from tests.templates.xdp_utils import ImplRequest, ImplSession, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/screencast.py
+++ b/tests/templates/screencast.py
@@ -31,7 +31,9 @@ class ScreenCastParameters:
     pipewire_serial: int
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "screencast_params")

--- a/tests/templates/screenshot.py
+++ b/tests/templates/screenshot.py
@@ -29,7 +29,9 @@ class ScreenshotParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "screenshot_params")

--- a/tests/templates/screenshot.py
+++ b/tests/templates/screenshot.py
@@ -4,11 +4,11 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
-
-import dbus.service
 from dataclasses import dataclass
 
+import dbus.service
+
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/settings.py
+++ b/tests/templates/settings.py
@@ -4,12 +4,12 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import init_logger
+from dataclasses import dataclass
 
 import dbus.service
 from dbusmock import MOCK_IFACE
-from dataclasses import dataclass
 
+from tests.templates.xdp_utils import init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/settings.py
+++ b/tests/templates/settings.py
@@ -26,7 +26,7 @@ class SettingsParameters:
     settings: dict
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "settings_params")

--- a/tests/templates/usb.py
+++ b/tests/templates/usb.py
@@ -30,10 +30,13 @@ class UsbParameters:
     filters: dict
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "usb_params")
+
     mock.usb_params = UsbParameters(
         delay=parameters.get("delay", 200),
         response=parameters.get("response", 0),

--- a/tests/templates/usb.py
+++ b/tests/templates/usb.py
@@ -4,13 +4,13 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
+from dataclasses import dataclass
 
 import dbus
 import dbus.service
 from dbusmock import MOCK_IFACE
-from dataclasses import dataclass
 
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/wallpaper.py
+++ b/tests/templates/wallpaper.py
@@ -4,12 +4,12 @@
 # This file is formatted with Python Black
 # mypy: disable-error-code="misc"
 
-from tests.templates.xdp_utils import Response, init_logger, ImplRequest
+from dataclasses import dataclass
 
 import dbus
 import dbus.service
-from dataclasses import dataclass
 
+from tests.templates.xdp_utils import ImplRequest, Response, init_logger
 
 BUS_NAME = "org.freedesktop.impl.portal.Test"
 MAIN_OBJ = "/org/freedesktop/portal/desktop"

--- a/tests/templates/wallpaper.py
+++ b/tests/templates/wallpaper.py
@@ -27,7 +27,9 @@ class WallpaperParameters:
     expect_close: bool
 
 
-def load(mock, parameters={}):
+def load(mock, parameters=None):
+    parameters = parameters or {}
+
     logger.debug(f"Loading parameters: {parameters}")
 
     assert not hasattr(mock, "wallpaper_params")

--- a/tests/templates/xdp_utils.py
+++ b/tests/templates/xdp_utils.py
@@ -3,11 +3,13 @@
 #
 # This file is formatted with Python Black
 
-from typing import Callable, Dict, Optional, NamedTuple
-from gi.repository import GLib
+import logging
+from collections.abc import Callable
+from typing import NamedTuple
+
 import dbus
 import dbusmock
-import logging
+from gi.repository import GLib
 
 
 def init_logger(name: str) -> logging.Logger:
@@ -32,7 +34,7 @@ logger = init_logger("utils")
 
 class Response(NamedTuple):
     response: int
-    results: Dict
+    results: dict
 
 
 class ImplRequest:
@@ -205,9 +207,9 @@ class ImplSession:
         self.handle = handle
         self.app_id = app_id
         self.closed = False
-        self._close_callback: Optional[Callable] = None
+        self._close_callback: Callable | None = None
 
-        self.mock_object: Optional[dbusmock.DBusMockObject] = None
+        self.mock_object: dbusmock.DBusMockObject | None = None
 
         bus = mock.connection
         proxy = bus.get_object(busname, handle)
@@ -235,7 +237,7 @@ class ImplSession:
 
     def export(
         self,
-        close_callback: Optional[Callable] = None,
+        close_callback: Callable | None = None,
     ) -> "ImplSession":
         """
         Create the session on the bus. If ``close_callback`` is not None, that

--- a/tests/templates/xdp_utils.py
+++ b/tests/templates/xdp_utils.py
@@ -80,7 +80,7 @@ class ImplRequest:
             if callable(response):
                 try:
                     res = response()
-                except Exception as e:
+                except dbus.exceptions.DBusException as e:
                     logger.critical(
                         f"Request {self.handle}: failed getting response: {e}"
                     )
@@ -124,7 +124,7 @@ class ImplRequest:
             if close_callback:
                 try:
                     close_callback()
-                except Exception as e:
+                except dbus.exceptions.DBusException as e:
                     logger.critical(
                         f"Request {self.handle}: failed running close callback: {e}"
                     )

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -3,13 +3,13 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+import os
+import re
+from pathlib import Path
 
 import pytest
-import os
-from pathlib import Path
-import re
 
+import tests.xdp_utils as xdp
 
 ACCOUNT_DATA = {
     "id": "test",

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -3,13 +3,14 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+import os
+from pathlib import Path
 
 import dbus
 import pytest
-import os
-from pathlib import Path
 from gi.repository import GLib
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -3,10 +3,10 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
 import dbus
 import pytest
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -3,13 +3,14 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-import tests.test_inputcapture as inputcapture
+import os
+from enum import Enum
 
 import dbus
 import pytest
-import os
-from enum import Enum
+
+import tests.test_inputcapture as inputcapture
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -30,6 +30,17 @@ class SessionType(Enum):
     INPUT_CAPTURE = 2
 
 
+class ClipboardTypeError(TypeError):
+    """Exception raised when the type of the clipboard is unknown."""
+
+    def __init__(self, dbus_con: dbus.Bus, type: SessionType) -> None:
+        self.dbus_con = dbus_con
+        self.type = type
+
+    def __str__(self) -> str:
+        return f"Unknown session type {self.type} for connection {self.dbus_con}"
+
+
 @pytest.mark.parametrize(
     "type", (SessionType.REMOTE_DESKTOP, SessionType.INPUT_CAPTURE)
 )
@@ -104,7 +115,7 @@ class TestClipboard:
             return self.start_remote_desktop_session(dbus_con)
         if type == SessionType.INPUT_CAPTURE:
             return self.start_input_capture_session(dbus_con)
-        raise Exception("Unknown type")
+        raise ClipboardTypeError(dbus_con, type)
 
     def test_request_clipboard_and_start_session(self, portals, dbus_con, type):
         _, clipboard_enabled = self.start_session(dbus_con, type)

--- a/tests/test_document_fuse.py
+++ b/tests/test_document_fuse.py
@@ -44,7 +44,6 @@ def logv(str):
 
 
 def get_a_count(counter: str):
-    global running_count
     running_count[counter] += 1
     return running_count[counter]
 

--- a/tests/test_document_fuse.py
+++ b/tests/test_document_fuse.py
@@ -188,11 +188,10 @@ def assertDirFiles(path, expected_files, exhaustive=True, volatile_files=None):
             raise AssertionError(
                 f"Expected file {file} not found in dir {path} (all: {found_files})"
             )
-    if exhaustive:
-        if len(remaining) != 0:
-            raise AssertionError(
-                f"Unexpected files {remaining} in dir {path} (all: {found_files})"
-            )
+    if exhaustive and len(remaining) != 0:
+        raise AssertionError(
+            f"Unexpected files {remaining} in dir {path} (all: {found_files})"
+        )
 
 
 class Doc:

--- a/tests/test_document_fuse.py
+++ b/tests/test_document_fuse.py
@@ -12,6 +12,7 @@ import sys
 import traceback
 from collections import defaultdict
 
+import dbus
 import pytest
 from gi.repository import Gio, GLib
 
@@ -139,7 +140,7 @@ def assertFileExist(path):
         info = os.lstat(path)
         if info.st_mode & stat.S_IFREG != stat.S_IFREG:
             raise AssertionError(f"File {path} is not a regular file")
-    except Exception:
+    except dbus.exceptions.DBusException:
         raise AssertionError(f"File {path} doesn't exist")
 
 
@@ -148,7 +149,7 @@ def assertDirExist(path):
         info = os.lstat(path)
         if info.st_mode & stat.S_IFDIR != stat.S_IFDIR:
             raise AssertionError(f"File {path} is not a directory file")
-    except Exception:
+    except dbus.exceptions.DBusException:
         raise AssertionError(f"File {path} doesn't exist")
 
 
@@ -162,7 +163,7 @@ def assertSymlink(path, expected_target):
             raise AssertionError(
                 f"File {path} has wrong target {target}, expected {expected_target}"
             )
-    except Exception:
+    except dbus.exceptions.DBusException:
         raise AssertionError(f"Symlink {path} doesn't exist")
 
 
@@ -171,7 +172,7 @@ def assertFileNotExist(path):
         os.lstat(path)
     except FileNotFoundError:
         return
-    except Exception:
+    except dbus.exceptions.DBusException:
         raise AssertionError(
             f"Got wrong execption {sys.exc_info()[0]} for {path}, expected FileNotFoundError"
         )
@@ -331,7 +332,7 @@ class DocPortal:
         try:
             with open(path) as f:
                 content = f.read()
-        except Exception:
+        except dbus.exceptions.DBusException:
             content = None
         doc = Doc(self, doc_id, path, content)
         self.docs[doc.id] = doc
@@ -1194,7 +1195,7 @@ class Process(mp.Process):
         try:
             mp.Process.run(self)
             self._cconn.send(None)
-        except Exception as e:
+        except dbus.exceptions.DBusException as e:
             tb = traceback.format_exc()
             self._cconn.send((e, tb))
 

--- a/tests/test_document_fuse.py
+++ b/tests/test_document_fuse.py
@@ -3,18 +3,19 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-import pytest
 import errno
+import multiprocessing as mp
 import os
 import random
 import stat
 import sys
-import multiprocessing as mp
 import traceback
 from collections import defaultdict
+
+import pytest
 from gi.repository import Gio, GLib
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture
@@ -90,9 +91,7 @@ def assertRaisesErrno(error_nr, func, *args, **kwargs):
 
     if excinfo.value.errno != error_nr:
         raise AssertionError(
-            "Wrong errno {0} was raised instead of {1}".format(
-                excinfo.value.errno, error_nr
-            )
+            f"Wrong errno {excinfo.value.errno} was raised instead of {error_nr}"
         )
 
 
@@ -102,13 +101,11 @@ def assertRaisesGError(message, code, func, *args, **kwargs):
 
     if not excinfo.value.message.startswith(message):
         raise AssertionError(
-            "Wrong message {0} doesn't start with {1}".format(
-                excinfo.value.message, message
-            )
+            f"Wrong message {excinfo.value.message} doesn't start with {message}"
         )
     if excinfo.value.code != code:
         raise AssertionError(
-            "Wrong code {0} was raised instead of {1}".format(excinfo.value.code, code)
+            f"Wrong code {excinfo.value.code} was raised instead of {code}"
         )
 
 
@@ -134,41 +131,39 @@ def assertSameStat(a, b, b_mode_mask):
         and a.st_mtime == b.st_mtime
         and a.st_ctime == b.st_ctime
     ):
-        raise AssertionError("Stat value {} was not the expected {})".format(a, b))
+        raise AssertionError(f"Stat value {a} was not the expected {b})")
 
 
 def assertFileExist(path):
     try:
         info = os.lstat(path)
         if info.st_mode & stat.S_IFREG != stat.S_IFREG:
-            raise AssertionError("File {} is not a regular file".format(path))
+            raise AssertionError(f"File {path} is not a regular file")
     except Exception:
-        raise AssertionError("File {} doesn't exist".format(path))
+        raise AssertionError(f"File {path} doesn't exist")
 
 
 def assertDirExist(path):
     try:
         info = os.lstat(path)
         if info.st_mode & stat.S_IFDIR != stat.S_IFDIR:
-            raise AssertionError("File {} is not a directory file".format(path))
+            raise AssertionError(f"File {path} is not a directory file")
     except Exception:
-        raise AssertionError("File {} doesn't exist".format(path))
+        raise AssertionError(f"File {path} doesn't exist")
 
 
 def assertSymlink(path, expected_target):
     try:
         info = os.lstat(path)
         if info.st_mode & stat.S_IFLNK != stat.S_IFLNK:
-            raise AssertionError("File {} is not a symlink".format(path))
+            raise AssertionError(f"File {path} is not a symlink")
         target = os.readlink(path)
         if target != expected_target:
             raise AssertionError(
-                "File {} has wrong target {}, expected {}".format(
-                    path, target, expected_target
-                )
+                f"File {path} has wrong target {target}, expected {expected_target}"
             )
     except Exception:
-        raise AssertionError("Symlink {} doesn't exist".format(path))
+        raise AssertionError(f"Symlink {path} doesn't exist")
 
 
 def assertFileNotExist(path):
@@ -178,11 +173,9 @@ def assertFileNotExist(path):
         return
     except Exception:
         raise AssertionError(
-            "Got wrong execption {} for {}, expected FileNotFoundError".format(
-                sys.exc_info()[0], path
-            )
+            f"Got wrong execption {sys.exc_info()[0]} for {path}, expected FileNotFoundError"
         )
-    raise AssertionError("Path {} unexpectedly exists".format(path))
+    raise AssertionError(f"Path {path} unexpectedly exists")
 
 
 def assertDirFiles(path, expected_files, exhaustive=True, volatile_files=None):
@@ -193,16 +186,12 @@ def assertDirFiles(path, expected_files, exhaustive=True, volatile_files=None):
             remaining.remove(file)
         elif file not in volatile_files:
             raise AssertionError(
-                "Expected file {} not found in dir {} (all: {})".format(
-                    file, path, found_files
-                )
+                f"Expected file {file} not found in dir {path} (all: {found_files})"
             )
     if exhaustive:
         if len(remaining) != 0:
             raise AssertionError(
-                "Unexpected files {} in dir {} (all: {})".format(
-                    remaining, path, found_files
-                )
+                f"Unexpected files {remaining} in dir {path} (all: {found_files})"
             )
 
 
@@ -503,7 +492,6 @@ def verify_doc(doc, app_id=None):
         vdir = os.path.dirname(dir)
         info = os.lstat(vdir)
         check_virtual_stat(info)
-        pass
     else:
         info = os.lstat(dir)
         check_virtual_stat(info, doc.is_writable_by(app_id))

--- a/tests/test_document_fuse.py
+++ b/tests/test_document_fuse.py
@@ -996,7 +996,7 @@ def export_a_named_doc(portal, create_file):
 
 
 def export_a_dir_doc(portal):
-    (dir, count) = ensure_real_dir(False)
+    (dir, _) = ensure_real_dir(False)
     doc = portal.add_dir(dir)
     logv("exported (dir) %s as %s" % (dir, doc))
 
@@ -1220,7 +1220,7 @@ class TestDocumentFuse:
             p.join()
 
             if p.exception:
-                error, traceback = p.exception
+                error, _ = p.exception
                 raise error
 
     def test_single_thread(self, portals, xdg_document_portal, dbus_con):

--- a/tests/test_document_fuse.py
+++ b/tests/test_document_fuse.py
@@ -238,11 +238,11 @@ class Doc:
     def __str__(self):
         name = self.id
         if self.is_dir:
-            return "%s(dir)" % (name)
+            return f"{name}(dir)"
         elif self.content is None:
-            return "%s(missing)" % (name)
+            return f"{name}(missing)"
         else:
-            return "%s" % (name)
+            return name
 
 
 class DocPortal:
@@ -952,7 +952,7 @@ def ensure_real_dir_file(create_file):
 def export_a_doc(portal):
     path = ensure_real_dir_file(True)
     doc = portal.add(path)
-    logv("exported %s as %s" % (path, doc))
+    logv(f"exported {path} as {doc}")
 
     lookup = portal.lookup(path)
     assert lookup == doc.id
@@ -981,7 +981,7 @@ def export_a_doc(portal):
 def export_a_named_doc(portal, create_file):
     path = ensure_real_dir_file(create_file)
     doc = portal.add_named(path)
-    logv("exported (named) %s as %s" % (path, doc))
+    logv(f"exported (named) {path} as {doc}")
 
     if create_file:
         lookup = portal.lookup(path)
@@ -997,7 +997,7 @@ def export_a_named_doc(portal, create_file):
 def export_a_dir_doc(portal):
     (dir, _) = ensure_real_dir(False)
     doc = portal.add_dir(dir)
-    logv("exported (dir) %s as %s" % (dir, doc))
+    logv(f"exported (dir) {dir} as {doc}")
 
     lookup = portal.lookup(dir)
     assert lookup == doc.id
@@ -1055,7 +1055,7 @@ def add_an_app(portal, num_docs):
         doc.apps.append(read_app)
         portal.grant_permissions(doc.id, write_app, ["read", "write"])
         doc.apps.append(write_app)
-    logv("granted acces to %s and %s for %s" % (read_app, write_app, ids))
+    logv(f"granted acces to {read_app} and {write_app} for {ids}")
 
 
 def file_transfer_portal_test():
@@ -1176,7 +1176,7 @@ def run_test(iterations, prefix=None, do_ensure_no_remaining=True):
     verify_fs_layout(doc_portal)
 
     for i in range(iterations):
-        log("Checking permissions, pass %d" % (i + 1))
+        log(f"Checking permissions, pass {i + 1}")
         check_perms(doc_portal)
         verify_fs_layout(doc_portal)
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -3,13 +3,14 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-import tests.xdp_doc_utils as xdp_doc
-
-import pytest
-import dbus
-from pathlib import Path
 import os
+from pathlib import Path
+
+import dbus
+import pytest
+
+import tests.xdp_doc_utils as xdp_doc
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -315,7 +315,7 @@ class TestDocuments:
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_bytes(b"test")
 
-        doc_ids, extra = xdp_doc.export_files(
+        doc_ids, _ = xdp_doc.export_files(
             documents_intf,
             [base_path],
             ["read"],

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -115,7 +115,7 @@ class TestDocuments:
         # Try to create a tmp file for an app
         assert not (doc_app1_path / "tmp3").exists()
         xdp_doc.write_bytes_atomic(doc_app1_path / "tmp3", b"tmpdata2")
-        (doc_app1_path / "tmp3").read_bytes() == b"tmpdata2"
+        assert (doc_app1_path / "tmp3").read_bytes() == b"tmpdata2"
         assert not (doc_path / "tmp3").exists()
 
         # Re-Create a file from a fuse document file, in various ways

--- a/tests/test_dynamiclauncher.py
+++ b/tests/test_dynamiclauncher.py
@@ -3,14 +3,14 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-import pytest
-import dbus
 import os
-from pathlib import Path
 import stat
+from pathlib import Path
 
+import dbus
+import pytest
+
+import tests.xdp_utils as xdp
 
 SVG_IMAGE_DATA = """<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" height="16px" width="16px"/>

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -3,11 +3,12 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+import time
 
 import dbus
 import pytest
-import time
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_filechooser.py
+++ b/tests/test_filechooser.py
@@ -3,13 +3,13 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-import dbus
-import pytest
 import os
 from pathlib import Path
 
+import dbus
+import pytest
+
+import tests.xdp_utils as xdp
 
 FILECHOOSER_RESULTS = {
     "uris": ["FILLED OUT LATER"],

--- a/tests/test_globalshortcuts.py
+++ b/tests/test_globalshortcuts.py
@@ -3,11 +3,12 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+import time
 
 import dbus
 import pytest
-import time
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_inhibit.py
+++ b/tests/test_inhibit.py
@@ -3,11 +3,12 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+from enum import Enum, Flag
 
 import dbus
 import pytest
-from enum import Enum, Flag
+
+import tests.xdp_utils as xdp
 
 
 class InhibitFlags(Flag):

--- a/tests/test_inputcapture.py
+++ b/tests/test_inputcapture.py
@@ -568,7 +568,6 @@ class TestInputCapture:
         def cb_disabled(session_handle, options):
             nonlocal disabled_signal_received
             disabled_signal_received = True
-            assert session_handle == session_handle
 
         inputcapture_intf.connect_to_signal("Disabled", cb_disabled)
         session.enable()
@@ -615,7 +614,6 @@ class TestInputCapture:
         def cb_activated(session_handle, options):
             nonlocal activated_signal_received
             activated_signal_received = True
-            assert session_handle == session_handle
             assert "activation_id" in options
             assert "barrier_id" in options
             assert options["barrier_id"] == 10  # template uses first barrier
@@ -628,7 +626,6 @@ class TestInputCapture:
         def cb_deactivated(session_handle, options):
             nonlocal deactivated_signal_received
             deactivated_signal_received = True
-            assert session_handle == session_handle
             assert "activation_id" in options
             assert "cursor_position" in options
             assert options["cursor_position"] == (
@@ -683,7 +680,6 @@ class TestInputCapture:
         def cb_zones_changed(session_handle, options):
             nonlocal zones_changed_signal_received
             zones_changed_signal_received = True
-            assert session_handle == session_handle
 
         inputcapture_intf.connect_to_signal("ZonesChanged", cb_zones_changed)
         session.enable()

--- a/tests/test_inputcapture.py
+++ b/tests/test_inputcapture.py
@@ -3,15 +3,15 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-import dbus
-import pytest
 import socket
-from gi.repository import GLib
 from itertools import count
 from typing import Any
 
+import dbus
+import pytest
+from gi.repository import GLib
+
+import tests.xdp_utils as xdp
 
 counter = count()
 

--- a/tests/test_inputcapture.py
+++ b/tests/test_inputcapture.py
@@ -331,7 +331,7 @@ class TestInputCapture:
         # Request more caps than are supported
         session = InputcaptureSession(dbus_con)
         session.create()
-        response, results = session.start(capabilities=0b111)
+        _, results = session.start(capabilities=0b111)
         caps = results["capabilities"]
         # Returned capabilities must the ones we set up in the params
         assert caps == 0b110
@@ -355,8 +355,8 @@ class TestInputCapture:
 
         session = InputcaptureSession(dbus_con)
         session.create()
-        response, results = session.start()
-        response, results = session.get_zones()
+        _, results = session.start()
+        _, results = session.get_zones()
         for z1, z2 in zip(results["zones"], zones):
             assert z1 == z2
 
@@ -385,8 +385,8 @@ class TestInputCapture:
 
         session = InputcaptureSession(dbus_con)
         session.create()
-        response, results = session.start()
-        response, results = session.get_zones()
+        _, results = session.start()
+        _, results = session.get_zones()
 
         barriers = [
             {
@@ -463,7 +463,7 @@ class TestInputCapture:
                 ),
             },
         ]
-        response, results = session.set_pointer_barriers(barriers=barriers)
+        _, results = session.set_pointer_barriers(barriers=barriers)
         failed_barriers = results["failed_barriers"]
         assert all([id >= 20 for id in failed_barriers])
 

--- a/tests/test_inputcapture.py
+++ b/tests/test_inputcapture.py
@@ -465,7 +465,7 @@ class TestInputCapture:
         ]
         _, results = session.set_pointer_barriers(barriers=barriers)
         failed_barriers = results["failed_barriers"]
-        assert all([id >= 20 for id in failed_barriers])
+        assert all(id >= 20 for id in failed_barriers)
 
         for id in [b["barrier_id"] for b in barriers if b["barrier_id"] >= 20]:
             assert id in failed_barriers

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
-import tests.xdp_utils as xdp
-
-import pytest
 import dbus
+import pytest
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -78,7 +78,9 @@ class NotificationPortal(xdp.GDBusIface):
             "org.freedesktop.portal.Notification",
         )
 
-    def AddNotification(self, id, notification, fds=[]):
+    def AddNotification(self, id, notification, fds=None):
+        if fds is None:
+            fds = []
         return self._call(
             "AddNotification",
             GLib.Variant("(sa{sv})", (id, notification)),
@@ -93,13 +95,15 @@ class NotificationPortal(xdp.GDBusIface):
 
 
 class TestNotification:
-    def add_notification(self, dbus_con, app_id, id, notification, fds=[]):
+    def add_notification(self, dbus_con, app_id, id, notification, fds=None):
         notification_intf = NotificationPortal()
         mock_intf = xdp.get_mock_iface(dbus_con)
 
         method_calls = mock_intf.GetMethodCalls("AddNotification")
         backend_calls = len(method_calls)
 
+        if fds is None:
+            fds = []
         notification_intf.AddNotification(id, notification, fds)
 
         # Check the impl portal was called with the right args

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -3,13 +3,14 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+import os
+import tempfile
+from pathlib import Path
 
 import pytest
-import tempfile
-import os
-from pathlib import Path
-from gi.repository import GLib, Gio
+from gi.repository import Gio, GLib
+
+import tests.xdp_utils as xdp
 
 SVG_IMAGE_DATA = """<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" height="16px" width="16px"/>
@@ -652,4 +653,3 @@ class TestNotification:
                 assert False, "This statement should not be reached"
             except GLib.GError as e:
                 assert e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.DBUS_ERROR)
-                pass

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -221,8 +221,7 @@ class TestNotification:
             ),
         ]
 
-        i = 0
-        for body_in, body_expected in bodies:
+        for i, (body_in, body_expected) in enumerate(bodies):
             notification_in = NOTIFICATION_BASIC.copy()
             notification_in["markup-body"] = GLib.Variant("s", body_in)
 
@@ -241,8 +240,6 @@ class TestNotification:
                 assert body_expected
             except GLib.GError as e:
                 assert "invalid markup-body" in e.message
-
-            i += 1
 
     def test_bad_arg(self, portals, dbus_con, xdp_app_info):
         app_id = xdp_app_info.app_id

--- a/tests/test_openuri.py
+++ b/tests/test_openuri.py
@@ -3,15 +3,15 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-import tests.xdp_doc_utils as xdp_doc
-
-import dbus
-import pytest
 import os
 from pathlib import Path
 from typing import Any
 
+import dbus
+import pytest
+
+import tests.xdp_doc_utils as xdp_doc
+import tests.xdp_utils as xdp
 
 defaults_list = b"""[Default Applications]
 x-scheme-handler/http=furrfix.desktop;

--- a/tests/test_permission_store.py
+++ b/tests/test_permission_store.py
@@ -3,10 +3,10 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
 import dbus
-from gi.repository import GLib, Gio
+from gi.repository import Gio, GLib
+
+import tests.xdp_utils as xdp
 
 
 class PermissionStore(xdp.GDBusIface):

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -166,7 +166,7 @@ class TestPrint:
         print_intf = xdp.get_portal_iface(dbus_con, "Print")
         mock_intf = xdp.get_mock_iface(dbus_con)
 
-        fd, file_path = tempfile.mkstemp(prefix="print_mock_file_", dir=Path.home())
+        fd, _ = tempfile.mkstemp(prefix="print_mock_file_", dir=Path.home())
         os.write(fd, b"print_mock_file")
 
         title = "Test Title"
@@ -301,7 +301,7 @@ class TestPrint:
 
         title = "Test Title"
 
-        fd, file_path = tempfile.mkstemp(prefix="print_mock_file_", dir=Path.home())
+        fd, _ = tempfile.mkstemp(prefix="print_mock_file_", dir=Path.home())
         os.write(fd, b"print_mock_file")
 
         request = xdp.Request(dbus_con, print_intf)

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -3,15 +3,15 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-import dbus
-import pytest
 import os
 import tempfile
 from pathlib import Path
 from typing import Any
 
+import dbus
+import pytest
+
+import tests.xdp_utils as xdp
 
 PRINT_PREPARE_DATA = {
     "token": dbus.UInt32(1337),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
 
-import tests.xdp_utils as xdp
-
 import dbus
 import pytest
 
+import tests.xdp_utils as xdp
 
 CORRECT_APP_ID_DESKTOP = b"""
 [Desktop Entry]

--- a/tests/test_remotedesktop.py
+++ b/tests/test_remotedesktop.py
@@ -3,12 +3,13 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+import socket
+from typing import Any
 
 import dbus
 import pytest
-import socket
-from typing import List, Dict, Any
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture
@@ -226,7 +227,7 @@ class TestRemoteDesktop:
         assert response
         assert response.response == 0
 
-        notifyfuncs: List[Dict[str, Any]] = [
+        notifyfuncs: list[dict[str, Any]] = [
             {"name": "NotifyPointerMotion", "args": (1, 2)},
             {"name": "NotifyPointerMotionAbsolute", "args": (0, 1, 2)},
             {"name": "NotifyPointerButton", "args": (1, 1)},

--- a/tests/test_screencast.py
+++ b/tests/test_screencast.py
@@ -3,10 +3,10 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
 import dbus
 import pytest
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -3,16 +3,16 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
+import os
+import re
+from enum import Flag
+from pathlib import Path
+from typing import Any
 
 import dbus
 import pytest
-from enum import Flag
-from typing import Any
-import os
-from pathlib import Path
-import re
 
+import tests.xdp_utils as xdp
 
 SCREENSHOT_DATA = dbus.Dictionary(
     {

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,11 +3,10 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
 import dbus
 import pytest
 
+import tests.xdp_utils as xdp
 
 SETTINGS_DATA_TEST1 = {
     "org.freedesktop.appearance": dbus.Dictionary(

--- a/tests/test_trash.py
+++ b/tests/test_trash.py
@@ -3,13 +3,14 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
 import os
-import pytest
 import tempfile
 from pathlib import Path
+
+import pytest
 from gi.repository import GLib
+
+import tests.xdp_utils as xdp
 
 
 class TestTrash:

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -52,7 +52,9 @@ def umockdev_has_working_remove():
     # https://github.com/martinpitt/umockdev/releases/tag/0.18.4
     required = (0, 18, 4)
 
-    result = subprocess.run(["umockdev-run", "--version"], stdout=subprocess.PIPE)
+    result = subprocess.run(
+        ["umockdev-run", "--version"], stdout=subprocess.PIPE, check=False
+    )
     if result.returncode != 0:
         return False
     match = re.match(r"^(\d+)\.(\d+)\.(\d+)", result.stdout.decode("UTF-8").strip())

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -3,14 +3,15 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-import pytest
 import os
-import gi
-import subprocess
 import re
+import subprocess
 from typing import assert_never
+
+import gi
+import pytest
+
+import tests.xdp_utils as xdp
 
 gi.require_version("UMockdev", "1.0")
 from gi.repository import GLib, UMockdev  # noqa E402

--- a/tests/test_wallpaper.py
+++ b/tests/test_wallpaper.py
@@ -3,12 +3,13 @@
 #
 # This file is formatted with Python Black
 
-import tests.xdp_utils as xdp
-
-import pytest
 import os
 import tempfile
 from pathlib import Path
+
+import pytest
+
+import tests.xdp_utils as xdp
 
 
 @pytest.fixture

--- a/tests/xdp_doc_utils.py
+++ b/tests/xdp_doc_utils.py
@@ -5,8 +5,8 @@
 
 import os
 from pathlib import Path
-from gi.repository import GLib, Gio
 
+from gi.repository import Gio, GLib
 
 EXPORT_FILES_FLAG_EXPORT_DIR = 8
 

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -818,7 +818,7 @@ class GDBusIface:
         )
 
     def _call(
-        self, method_name: str, args_variant: GLib.Variant, fds: list[int] = []
+        self, method_name: str, args_variant: GLib.Variant, fds: list[int] | None = None
     ) -> GLib.Variant:
         """
         Calls a method synchronously with the arguments passed in args_variant,
@@ -826,8 +826,9 @@ class GDBusIface:
         Returns the result of the dbus call.
         """
         fdlist = Gio.UnixFDList.new()
-        for fd in fds:
-            fdlist.append(fd)
+        if fds:
+            for fd in fds:
+                fdlist.append(fd)
 
         return self._proxy.call_with_unix_fd_list_sync(
             method_name,
@@ -842,7 +843,7 @@ class GDBusIface:
         self,
         method_name: str,
         args_variant: GLib.Variant,
-        fds: list[int] = [],
+        fds: list[int] | None = None,
         cb: Callable[[GLib.Variant], None] | None = None,
     ) -> None:
         """
@@ -851,8 +852,9 @@ class GDBusIface:
         Invokes the callback cb when the call finished.
         """
         fdlist = Gio.UnixFDList.new()
-        for fd in fds:
-            fdlist.append(fd)
+        if fds:
+            for fd in fds:
+                fdlist.append(fd)
 
         def internal_cb(s, res, _):
             res = s.call_finish(res)

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -611,7 +611,7 @@ class Request(Closable):
                 self.response = Response(response, results)
                 if self._mainloop:
                     self._mainloop.quit()
-            except Exception as e:
+            except dbus.exceptions.DBusException as e:
                 self.error = e
 
         self.request_interface = dbus.Interface(proxy, "org.freedesktop.portal.Request")
@@ -677,7 +677,7 @@ class Request(Closable):
 
                 if reply_handler:
                     reply_handler(handle)
-            except Exception as e:
+            except dbus.exceptions.DBusException as e:
                 self.error = e
 
         # Handle any exceptions during the actual method call (not the Request
@@ -688,7 +688,7 @@ class Request(Closable):
                 if error_handler:
                     error_handler(error)
                 self.error = error
-            except Exception as e:
+            except dbus.exceptions.DBusException as e:
                 self.error = e
             finally:
                 if self._mainloop:
@@ -748,7 +748,7 @@ class Session(Closable):
                 self.details = details
                 if self._mainloop:
                     self._mainloop.quit()
-            except Exception as e:
+            except dbus.exceptions.DBusException as e:
                 self.error = e
 
         proxy = bus.get_object("org.freedesktop.portal.Desktop", handle)

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -3,22 +3,22 @@
 #
 # This file is formatted with Python Black
 
-from dbus.mainloop.glib import DBusGMainLoop
-from gi.repository import GLib, Gio, GioUnix
-from itertools import count
-from typing import Any, Dict, Optional, NamedTuple, Callable, List
-from pathlib import Path
-from enum import Enum, IntEnum
+import logging
+import os
+import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum, IntEnum
+from itertools import count
+from pathlib import Path
+from typing import Any, NamedTuple
 from urllib.parse import unquote, urlparse
 
-import os
 import dbus
 import dbus.proxies
 import dbusmock
-import logging
-import subprocess
-
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import Gio, GioUnix, GLib
 
 DBusGMainLoop(set_as_default=True)
 
@@ -27,7 +27,7 @@ DBUS_TIMEOUT = int(os.environ.get("XDP_DBUS_TIMEOUT", "5000"))
 
 _counter = count()
 
-ASV = Dict[str, Any]
+ASV = dict[str, Any]
 
 
 def init_logger(name: str) -> logging.Logger:
@@ -159,7 +159,7 @@ def get_document_portal_iface(bus: dbus.Bus) -> dbus.Interface:
     return dbus.Interface(obj, "org.freedesktop.portal.Documents")
 
 
-def get_mock_iface(bus: dbus.Bus, bus_name: Optional[str] = None) -> dbus.Interface:
+def get_mock_iface(bus: dbus.Bus, bus_name: str | None = None) -> dbus.Interface:
     """
     Returns the mock interface of the xdg-desktop-portal.
     """
@@ -170,7 +170,7 @@ def get_mock_iface(bus: dbus.Bus, bus_name: Optional[str] = None) -> dbus.Interf
     return dbus.Interface(obj, dbusmock.MOCK_IFACE)
 
 
-def portal_interface_name(portal_name: str, domain: Optional[str] = None) -> str:
+def portal_interface_name(portal_name: str, domain: str | None = None) -> str:
     """
     Returns the fully qualified interface for a portal name.
     """
@@ -181,7 +181,7 @@ def portal_interface_name(portal_name: str, domain: Optional[str] = None) -> str
 
 
 def get_portal_iface(
-    bus: dbus.Bus, name: str, domain: Optional[str] = None
+    bus: dbus.Bus, name: str, domain: str | None = None
 ) -> dbus.Interface:
     """
     Returns the dbus interface for a portal name.
@@ -213,7 +213,7 @@ def get_xdp_dbus_object(bus: dbus.Bus) -> dbus.proxies.ProxyObject:
     Returns the main portal object.
     """
     try:
-        obj = getattr(bus, "_xdp_dbus_object")
+        obj = bus._xdp_dbus_object
     except AttributeError:
         obj = bus.get_object(
             "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop"
@@ -502,8 +502,6 @@ class ResponseTimeout(Exception):
     Response in time.
     """
 
-    pass
-
 
 class Closable:
     """
@@ -516,9 +514,9 @@ class Closable:
         # GLib makes assertions in callbacks impossible, so we wrap all
         # callbacks into a try: except and store the error on the request to
         # be raised later when we're back in the main context
-        self.error: Optional[Exception] = None
+        self.error: Exception | None = None
 
-        self._mainloop: Optional[GLib.MainLoop] = None
+        self._mainloop: GLib.MainLoop | None = None
         self._impl_closed = False
         self._bus = bus
 
@@ -595,12 +593,12 @@ class Request(Closable):
         super().__init__(bus, self.handle)
 
         self.interface = interface
-        self.response: Optional[Response] = None
+        self.response: Response | None = None
         self.used = False
         # GLib makes assertions in callbacks impossible, so we wrap all
         # callbacks into a try: except and store the error on the request to
         # be raised later when we're back in the main context
-        self.error: Optional[Exception] = None
+        self.error: Exception | None = None
 
         proxy = bus.get_object("org.freedesktop.portal.Desktop", self.handle)
         self.mock_interface = dbus.Interface(proxy, dbusmock.MOCK_IFACE)
@@ -626,7 +624,7 @@ class Request(Closable):
         """
         return dbus.String(self._handle_token, variant_level=1)
 
-    def call(self, methodname: str, **kwargs) -> Optional[Response]:
+    def call(self, methodname: str, **kwargs) -> Response | None:
         """
         Semi-synchronously call method ``methodname`` on the interface given
         in the Request's constructor. The kwargs must be specified in the
@@ -820,7 +818,7 @@ class GDBusIface:
         )
 
     def _call(
-        self, method_name: str, args_variant: GLib.Variant, fds: List[int] = []
+        self, method_name: str, args_variant: GLib.Variant, fds: list[int] = []
     ) -> GLib.Variant:
         """
         Calls a method synchronously with the arguments passed in args_variant,
@@ -844,8 +842,8 @@ class GDBusIface:
         self,
         method_name: str,
         args_variant: GLib.Variant,
-        fds: List[int] = [],
-        cb: Optional[Callable[[GLib.Variant], None]] = None,
+        fds: list[int] = [],
+        cb: Callable[[GLib.Variant], None] | None = None,
     ) -> None:
         """
         Calls a method asynchronously with the arguments passed in args_variant,
@@ -895,7 +893,7 @@ class FileAccessMode(Enum):
     HIDDEN = "hidden"
 
 
-class ExecutableMock(object):
+class ExecutableMock:
     def __init__(self, executable: str, access_mode: FileAccessMode):
         self.executable = executable
         self.access_mode = access_mode
@@ -906,7 +904,7 @@ class ExecutableMock(object):
         self.path.chmod(0o755)
 
     def get_executable(self):
-        return f"#!/usr/bin/env sh\necho {self.access_mode.value}".encode("utf8")
+        return f"#!/usr/bin/env sh\necho {self.access_mode.value}".encode()
 
 
 class SessionPersistenceMode(IntEnum):

--- a/tests/xdp_utils.py
+++ b/tests/xdp_utils.py
@@ -913,3 +913,13 @@ class SessionPersistenceMode(IntEnum):
     NONE = 0
     TRANSIENT = 1
     PERSISTENT = 2
+
+
+class SessionPersistenceModeError(TypeError):
+    """Exception raised when the session persistence mode is unknown."""
+
+    def __init__(self, persist_mode: SessionPersistenceMode) -> None:
+        self.persist_mode = persist_mode
+
+    def __str__(self) -> str:
+        return f"Unknown session persistence mode: {self.persist_mode}"


### PR DESCRIPTION
See commits.

In future, I would like to use MyPy with [`--strict`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict) to force type checking throughout Python.