### PR TITLE
document-portal: Wake the fuse mainloop thread on teardown

### DIFF
--- a/document-portal/document-portal-fuse.c
+++ b/document-portal/document-portal-fuse.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -117,6 +118,7 @@
 #define DOC_DIR_PERMS_DIR 0500
 
 static GThread *fuse_thread = NULL;
+static pthread_t fuse_pthread;
 static struct fuse_session *session = NULL;
 G_LOCK_DEFINE (session);
 static char *mount_path = NULL;
@@ -3529,6 +3531,18 @@ xdp_fuse_thread (gpointer data)
   struct fuse_session *se;
   const char *path;
 
+  sigset_t usr1_set;
+
+  fuse_pthread = pthread_self ();
+
+  /* The teardown nudge in xdp_fuse_exit() must be deliverable to this
+   * thread; make sure SIGUSR1 is not blocked here even if a future caller
+   * creates this thread from a context with a restrictive signal mask
+   * (e.g. GLib worker threads block all signals). */
+  sigemptyset (&usr1_set);
+  sigaddset (&usr1_set, SIGUSR1);
+  pthread_sigmask (SIG_UNBLOCK, &usr1_set, NULL);
+
   locker = g_mutex_locker_new (&thread_data->lock);
 
   g_cond_signal (&thread_data->cond);
@@ -3587,17 +3601,48 @@ xdp_fuse_thread (gpointer data)
   return NULL;
 }
 
+#if FUSE_VERSION < FUSE_MAKE_VERSION (3, 18)
+/* libfuse >= 3.18 wakes fuse_session_loop_mt()'s control thread itself
+ * (fuse_session_exit() does sem_post() as well as setting the flag, commit
+ * c5dbcdce), so this nudge is only needed - and only compiled in - below
+ * that version. This also means an externally-sent SIGUSR1 keeps its
+ * default (terminate) disposition on libfuse >= 3.18, instead of silently
+ * becoming a no-op everywhere. */
+static void
+fuse_teardown_nudge_handler (int sig)
+{
+  /* Deliberately empty and async-signal-safe: SIGUSR1 only exists to
+   * interrupt the fuse mainloop thread's blocking calls with EINTR during
+   * xdp_fuse_exit(). See the comment there. */
+  (void) sig;
+}
+#endif
+
 gboolean
 xdp_fuse_init (GError **error)
 {
   g_autoptr(XdpDomain) by_app_domain = NULL;
   g_autoptr(XdpDomain) root_domain = NULL;
   XdpFuseThreadData thread_data = {0};
+#if FUSE_VERSION < FUSE_MAKE_VERSION (3, 18)
+  struct sigaction sa = { .sa_handler = fuse_teardown_nudge_handler };
+#endif
   struct statfs stfs;
   struct rlimit rl;
   struct stat st;
   const char *path;
   int statfs_res;
+
+#if FUSE_VERSION < FUSE_MAKE_VERSION (3, 18)
+  /* No SA_RESTART, and do not "simplify" this to signal(): the whole
+   * point of the handler is that the fuse mainloop thread's blocking
+   * sem_wait() returns EINTR when nudged from xdp_fuse_exit(). With
+   * SA_RESTART (which signal() implies on both glibc and musl) the
+   * kernel transparently restarts the wait, the nudge is silently lost,
+   * and the shutdown hang returns with no diagnostic. */
+  sigemptyset (&sa.sa_mask);
+  sigaction (SIGUSR1, &sa, NULL);
+#endif
 
   my_uid = getuid ();
   my_gid = getgid ();
@@ -3685,8 +3730,26 @@ xdp_fuse_exit (void)
         fuse_session_exit (session);
         /* Unmount to force the FUSE kernel interface to disconnect,
          * which will cause blocking read() in fuse_session_loop_mt()
-         * to fail and the loop to exit. */
+         * to fail and the loop to exit. This is not guaranteed to work:
+         * the unmount is lazy, so the FUSE connection stays alive while
+         * any process still holds a reference (e.g. an open fd) into the
+         * mount. On libfuse < 3.18, fuse_session_exit() does not wake the
+         * fuse_session_loop_mt() control thread either, so without help
+         * the join below would block until the last client goes away
+         * (systemd then SIGKILLs us after TimeoutStopSec). Nudge the
+         * mainloop thread with a signal so its interruptible sem_wait()
+         * returns and rechecks the (already set) exited flag; current
+         * libfuse (the 3.16+ headers) documents this signal-after-exit
+         * contract on fuse_session_exit(). libfuse >= 3.18 does this
+         * wakeup itself (fuse_session_exit() also does sem_post()), so
+         * the nudge is compiled out entirely on that range - see the
+         * FUSE_VERSION guard around the handler above.
+         */
         fuse_session_unmount (session);
+#if FUSE_VERSION < FUSE_MAKE_VERSION (3, 18)
+        if (fuse_thread)
+          pthread_kill (fuse_pthread, SIGUSR1);
+#endif
       }
   }
 


### PR DESCRIPTION
### Problem

`xdg-document-portal.service` sometimes hangs ~90 s at session shutdown and is then SIGKILLed (`State 'stop-sigterm' timed out. Killing.`), the #999 signature, but specifically the leg that exists **since 1.21.1**, i.e. since #1896 landed.

### Root cause

#1896 (`02a65086`, `0fcfb2b3`) removed the old signal-based teardown (which had a real async-signal-unsafe deadlock: `g_main_loop_quit()` inside a handler) and left `xdp_fuse_exit()` relying on this chain:

```c
fuse_session_exit (session);
/* Unmount to force the FUSE kernel interface to disconnect,
 * which will cause blocking read() in fuse_session_loop_mt()
 * to fail and the loop to exit. */
fuse_session_unmount (session);
...
g_clear_pointer (&fuse_thread, g_thread_join);
```

Two facts break the chain whenever a client still holds an open fd inside `/run/user/$UID/doc` at shutdown (a running flatpak app with an open document; at session teardown, a race ordinary desktop use loses routinely):

1. **The unmount is lazy.** `fuse_session_unmount()` → `fusermount3 -u -z` → `umount2(..., MNT_DETACH)`. That only detaches the mount point; the superblock, and the FUSE connection with it, stays alive while any reference (an open fd) pins it. The blocking read in the fuse loop does **not** fail.
2. **`fuse_session_exit()` wakes nobody on libfuse < 3.18.0.** It is literally `se->exited = 1;` (3.16.2 `lib/fuse_lowlevel.c`, unchanged through 3.17.4). The `fuse_session_loop_mt()` control thread sleeps in an untimed `sem_wait()` and never rechecks the flag. libfuse fixed this in 3.18.0 (`c5dbcdce`, libfuse/libfuse#997 via libfuse/libfuse#1201); nothing older has the fix (all four 3.17.x releases included), and our floor is `fuse3 >= 3.10.0` (meson.build).

Exit flag set, connection alive, mainloop thread asleep, `g_thread_join()` blocked, SIGKILL at `TimeoutStopSec`.

libfuse's own `fuse_session_exit()` documentation has said since 2023 (commit `75672680`; present in the 3.16+ headers, e.g. 3.16.2 `include/fuse_lowlevel.h:2115-2120`, unchanged through current master):

> This will cause any running event loops to terminate on the next opportunity. If this function is called by a thread that is not a FUSE worker thread, the next opportunity will be when FUSE a request is received [sic] (which may be far in the future if the filesystem is not currently being used by any clients). One way to avoid this delay is to afterwards sent [sic] a signal to the main thread (if fuse_set_signal_handlers() is used, SIGPIPE will cause the main thread to wake-up but otherwise be ignored).

So libfuse explicitly tells a non-worker-thread caller to follow the exit with a signal. The doc frames it as SIGPIPE-to-the-main-thread under `fuse_set_signal_handlers()`, which the portal doesn't use; this patch is the same pattern adapted to the portal's thread structure: the signal goes to the thread that runs the fuse loop, whose `sem_wait()` libfuse's own loop comments as interruptible (3.16.2 `lib/fuse_loop_mt.c:364`). #1896 removed exactly such a signal-after-exit nudge along with the (genuinely broken) handler bodies. The sentence is absent from the older headers in our support range (3.10.5 documents no wake obligation either way), so on those versions the nudge rests on the loop's measured interruptible-`sem_wait()` behavior (matrix below) rather than on doc text.

### Fix

Restore the nudge without restoring the bug:

- a **no-op** SIGUSR1 handler: empty body, trivially async-signal-safe; the old deadlock came from calling `g_main_loop_quit()` *inside* the handler, which this does not reintroduce;
- `pthread_kill (fuse_pthread, SIGUSR1)` in `xdp_fuse_exit()` after `fuse_session_exit()` + `fuse_session_unmount()`, under the session lock. The EINTR interrupts the mainloop thread's `sem_wait()`, which rechecks the already-set exited flag and exits;
- **SIGUSR1, not the SIGHUP the pre-#1896 nudge used**: since #1896 the portal's shutdown path claims SIGHUP via `g_unix_signal_add()`, so reusing it would fire that exit handler a second time; SIGUSR1 is claimed by nothing else in the process (measured: the unpatched daemon's per-thread `SigCgt` masks have no USR1 bit);
- the fuse thread defensively unblocks SIGUSR1 for itself, and the #1896-era comment (whose "will cause blocking read() to fail" claim is what this bug falsifies) is corrected in place;
- everything is guarded by `#if FUSE_VERSION < FUSE_MAKE_VERSION (3, 18)`: on libfuse ≥ 3.18.0 `fuse_session_exit()` already does its own `sem_post()` (`c5dbcdce`), so there the nudge is compiled out entirely rather than left as a runtime no-op, confirmed with `nm` on the built binary (`fuse_teardown_nudge_handler` present when linked against 3.16.2, absent against 3.18.2). This also keeps `kill -USR1`'s default (terminate) disposition on ≥ 3.18.0 instead of silently swallowing it process-wide. The whole `#if` block becomes deletable when the dependency floor reaches 3.18.0.

**One deliberate subtlety (please don't "fix" it in review)**: the handler is installed via `sigaction()` with `sa_flags = 0`. Adding `SA_RESTART` (or simplifying to `signal()`, which implies restart semantics on both glibc and musl) makes the kernel transparently restart the semaphore wait; the nudge is silently consumed and the hang returns with no diagnostic. Measured on glibc 2.42 and musl 1.2.5; a comment in the code carries this.

### Verification

CI can't exercise this (the build containers ship libfuse ≥ 3.18), so the evidence is measured locally:

1. **Minimal reproducer matrix**: a harness replicating `xdp_fuse_exit()`'s exact teardown shape (mt-loop in a thread; SIGTERM → exit → lazy unmount → join), against libfuse built from source at six tags, with and without a client holding an open fd in the mount; every cell run at least twice, hanging cells three times:

   | libfuse | holder, unpatched | holder, patched | no holder (regression guard) |
   |---|---|---|---|
   | 3.10.5 | **hang >15 s** | 0.01 s | 0.00 s |
   | 3.13.1 | **hang >15 s** | 0.01 s | 0.00 s |
   | 3.16.2 | **hang >15 s** | 0.01 s | 0.00 s |
   | 3.17.4 | **hang >15 s** | 0.01 s | 0.00 s |
   | 3.18.2 | 0.01 s | 0.01 s | 0.00 s |
   | master | 0.01 s | 0.01 s | 0.00 s |

   The hang is deterministic on every affected version whenever a holder exists; the patch converts every hanging cell to ≤0.011 s and regresses nothing on fixed libfuse.

2. **The real daemon**: `xdg-document-portal` built from this branch, run under a private session bus + private `XDG_RUNTIME_DIR` with a real FUSE mount, SIGTERM'd while a holder keeps fds open in the mount. Against libfuse 3.16.2: unpatched base **hangs >20 s** (the #999 signature); patched tears down in **~0.05 s**, with no holder, one fd, and a multi-thread holder (4 threads × 4 independent fds) alike. Against libfuse 3.18.2 (mechanism compiled out): ~0.05 s in all four holder variants including holder-killed-mid-teardown, no regression where libfuse already wakes itself.

3. **The exact systemd signature, end-to-end**: a private transient `systemd-run --user` unit (never the live portal service/bus/mount) with `TimeoutStopSec=10s` reproduces the #999 journal block byte-for-byte on the unpatched base + libfuse 3.16.2 + a holder fd:

       …service: State 'stop-sigterm' timed out. Killing.
       …service: Killing process N (pristine-xdg-do) with signal SIGKILL.
       …service: Killing process M (fusermount3) with signal SIGKILL.
       …service: Main process exited, code=killed, status=9/KILL
       …service: Failed with result 'timeout'.

   This includes the resident `fusermount3` helper being SIGKILLed alongside the daemon, matching the thread's field reports. The patched binary in the same unit stops cleanly in ~0.01-0.02 s, 2/2 runs each.

4. The branch builds warning-clean under `-Dwerror=true` + `-Db_sanitize=address` on gcc and clang (CI's matrix), and `meson test` passes locally on both: all unit tests, and every integration test that passes on the unpatched base also passes on the branch (two media-validation failures on my machine fail identically on the base, local-environment artifacts; `test_document_fuse.py` is skipped by its upstream module-level skip).

### What this does and does not explain about #999

- **Fixes**: the lost-wakeup hang on portal ≥ 1.21.1 with libfuse 3.10-3.17.x and any live client at shutdown. That pairing is currently *latent* for most binary distros (they crossed to libfuse 3.18 before taking portal 1.21.1+), but it is live for the declared `fuse3 >= 3.10.0` floor, for backports (portal ≥ 1.21.1 onto Debian 13's fuse3 3.17.2, frozen ~2 more years; Fedora 43 ships 3.16.2; Ubuntu 24.04 3.14.0), and for source-based/pinned setups, where this was found and measured.
- **Does not fix**: the pre-1.21.1 reports in #999 (every reporter there who stated a version was on ≤ 1.20.x, i.e. the signal-race leg that #1896 itself addressed), nor the systemd app.slice/session.slice ordering discussion in that thread, which is a separate concern. I have not found a field report attributable to this second leg yet; I'm stating that plainly rather than claiming this closes the thread. I'd suggest **not** auto-closing #999 with this PR.
- **Residual window, disclosed**: a one-shot signal can in principle be consumed in the instant between the loop's flag-check and re-arming the wait. Only reproducible with an artificial LD_PRELOAD delay shim; never hit in ~90 measured teardowns; crossed once per process lifetime; and its failure mode is exactly the status-quo hang (recovery on holder exit intact); the patch strictly dominates the current code. The window-free mechanism is libfuse ≥ 3.18's `sem_post`, which is why the nudge is framed as deletable once the floor gets there.
- **Behavior change, scoped to libfuse < 3.18.0**: an externally-sent SIGUSR1 no longer terminates the daemon there (handled no-op instead of default terminate). On ≥ 3.18.0 the mechanism is compiled out, so `kill -USR1` behaves as before. Noted for completeness.

<details>
<summary>Alternatives considered</summary>

- **Bump the meson floor to `fuse3 >= 3.18.0`**: mechanically sufficient, but today it would exclude Debian 12/13, Ubuntu 22.04/24.04 LTS, Fedora 43, openSUSE Leap, NixOS 25.05, and it fixes no released 1.21/1.22 binary. Right cleanup later, wrong fix now. (The floor would have to be 3.18.0, not 3.17: the libfuse fix is absent from all 3.17.x releases, verified against 3.17.4 source and by measurement.)
- **Fix it in libfuse / backport libfuse/libfuse#1201 to 3.17.x**: it *is* the root cause and worth pursuing separately upstream, but can't reach the frozen 3.10-3.16 population this project declares support for. Filing separately, not bundled with this PR.
- **Write to the FUSE device fd instead of signaling**: the control thread blocks on an internal libfuse semaphore, not the fd, so it doesn't reach the stuck thread.
- **`pthread_cancel()` the control thread**: skips libfuse's own worker/mutex/semaphore cleanup inside `fuse_session_loop_mt()`; worse than a targeted wake.
- **Revert to the pre-#1896 SIGHUP handlers**: reintroduces the deadlock #1896 fixed. **`TimeoutStopSec` tweaks**: shorter hang, still a hang.

</details>

### Backport

The regression shipped in 1.21.1; candidate for the 1.22.x stable branch. 1.20.x predates #1896 and is unaffected by this leg.
