### PR TITLE
trash: Allow trash directories to have any mode

### DIFF
--- a/desktop-portal/trash.c
+++ b/desktop-portal/trash.c
@@ -215,12 +215,8 @@ get_child_mkdir_p_0700 (int                 fd,
                                   stx,
                                   error);
 
-  if ((stx->stx_mode & ~S_IFMT) != 0700)
-    {
-      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
-                           "Directory already exists with bad permissions");
-      return -1;
-    }
+  if (child >= 0 && (stx->stx_mode & ~S_IFMT) != 0700)
+    g_warning ("Directory %s already exists with bad permissions", path);
 
   return g_steal_fd (&child);
 }


### PR DESCRIPTION
The code was over-eager with what it considers a valid trash directory. While we should make sure that we only create trash dirs which are private to the user (so 0700), there appear to be enough systems where the trash directories have other permissions that we should allow them to be used.

We still emit warnings about this, because it might be unexpected that trashed files are readable or writeable by other users.

Fixes: 37aaaeac ("trash: Implement trashing securely")