### PR TITLE
input-capture: Propagate error when connecting to EIS fails

### DIFF
--- a/desktop-portal/input-capture.c
+++ b/desktop-portal/input-capture.c
@@ -1424,7 +1424,8 @@ handle_connect_to_eis (XdpDbusInputCapture   *object,
                                                              &error))
     {
       g_warning ("Failed to ConnectToEIS: %s", error->message);
-      out_fd_list = g_unix_fd_list_new ();
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
   input_capture_session->state = INPUT_CAPTURE_SESSION_STATE_DISABLED;


### PR DESCRIPTION
We already do this in the RemoteDesktop portal, and the state we end up if we take this path results in a an abort in the complete call below because of the NULL `fd`.

Closes: https://github.com/flatpak/xdg-desktop-portal/issues/2073