### PR TITLE
screencast: Fix annotation issue in OpenPipeWireRemote

### DIFF
--- a/data/org.freedesktop.portal.ScreenCast.xml
+++ b/data/org.freedesktop.portal.ScreenCast.xml
@@ -263,9 +263,9 @@
 
         Open a file descriptor to the PipeWire remote where the screen cast
         streams are available. The file descriptor should be used to create a
-        <classname>pw_core</classname> object, by using
-        <function>pw_context_connect_fd</function>. Only the screen cast stream
-        nodes will be available from this PipeWire node.
+        ``pw_core`` object, by using ``pw_context_connect_fd``.
+        Only the screen cast stream nodes will be available from
+        this PipeWire node.
     -->
     <method name="OpenPipeWireRemote">
       <annotation name="org.gtk.GDBus.C.Name" value="open_pipewire_remote"/>


### PR DESCRIPTION
`<class>` and `<function>` are HTML tags and interpreted as literal strings, and will not apply any formatting in RST. Replace them with two backticks either side of the class/function name to give them the intended code style formatting

| Before | After |
|----------|--------|
| <img width="984" height="488" alt="Screenshot From 2026-08-05 12-03-01" src="https://github.com/user-attachments/assets/886be9a2-8ae8-48f9-85e0-01a3497c75e5" /> |  <img width="984" height="488" alt="Screenshot From 2026-08-05 12-11-59" src="https://github.com/user-attachments/assets/ee213b08-c07f-416d-8689-43f1b17f7683" /> |