### PR TITLE
blame: Ignore ef50bf5

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,5 @@
 afad7cd2e3faba08be49155eb0c031755b22f24a
 74e087977e0a8ad76ea75a0a433fc9a42af8232d
 
+# Run ruff formatter
+ef50bf5c70c6448827ffde387e7e2d2fd1a8d959


### PR DESCRIPTION
This is only reformatting the codebase after upgrading ruff, so there won't be any need to have it in git blame.

Replacement for https://github.com/flatpak/xdg-desktop-portal/pull/2085.