### PR TITLE
po: Update Swedish translation

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -1,13 +1,15 @@
 # Swedish translation for xdg-desktop-portal.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+# Sebastian Rasmussen <sebras@gmail.com>, 2016.
+# Anders Jonsson <anders.jonsson@norsjovallen.se>, 2020, 2022, 2023, 2024, 2025, 2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: xdg-desktop-portal master\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-07 13:57+0200\n"
-"PO-Revision-Date: 2026-01-24 22:26+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/flatpak/xdg-desktop-portal/issues\n"
+"POT-Creation-Date: 2026-07-31 21:12+0000\n"
+"PO-Revision-Date: 2026-03-19 00:32+0100\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -17,22 +19,22 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.8\n"
 
-#: src/background.c:941
+#: desktop-portal/background.c:919
 #, c-format
 msgid "Allow %s to Run in the Background?"
 msgstr "Tillåt %s att köra i bakgrunden?"
 
-#: src/background.c:945
+#: desktop-portal/background.c:923
 #, c-format
 msgid "%s wants to be started automatically and run in the background"
 msgstr "%s vill startas automatiskt och köras i bakgrunden."
 
-#: src/background.c:947
+#: desktop-portal/background.c:925
 #, c-format
 msgid "%s wants to run in the background"
 msgstr "%s vill köra i bakgrunden."
 
-#: src/background.c:948
+#: desktop-portal/background.c:926
 msgid ""
 "The ‘run in background’ permission can be changed at any time from the app "
 "settings"
@@ -40,166 +42,168 @@ msgstr ""
 "Rättigheten ”kör i bakgrund” kan ändras när som helst från "
 "programinställningarna"
 
-#: src/background.c:952
+#: desktop-portal/background.c:930
 msgid "Don't allow"
 msgstr "Tillåt inte"
 
-#: src/background.c:953 src/screenshot.c:275 src/wallpaper.c:192
+#: desktop-portal/background.c:931 desktop-portal/screenshot.c:261
+#: desktop-portal/wallpaper.c:174
 msgid "Allow"
 msgstr "Tillåt"
 
-#: src/camera.c:105
+#: desktop-portal/camera.c:90
 #, c-format
 msgid "Allow %s to Use the Camera?"
 msgstr "Tillåt %s att använda kameran?"
 
-#: src/camera.c:106
+#: desktop-portal/camera.c:91
 #, c-format
 msgid "%s wants to access the camera"
 msgstr "%s vill komma åt kameran"
 
-#: src/camera.c:110
+#: desktop-portal/camera.c:95
 msgid "Allow Apps to Use the Camera?"
 msgstr "Tillåt program att använda kameran?"
 
-#: src/camera.c:111
+#: desktop-portal/camera.c:96
 msgid "An app wants to access the camera"
 msgstr "Ett program vill komma åt kameran"
 
-#: src/camera.c:114 src/screenshot.c:327 src/wallpaper.c:208
+#: desktop-portal/camera.c:99 desktop-portal/screenshot.c:313
+#: desktop-portal/wallpaper.c:190
 msgid "This permission can be changed at any time from the privacy settings"
 msgstr "Denna rättighet kan ändras när som helst från sekretessinställningarna"
 
-#: src/dynamic-launcher.c:127
+#: desktop-portal/dynamic-launcher.c:109
 #, c-format
 msgid "Desktop file id missing .desktop suffix: %s"
 msgstr "Desktop-filens ID saknar .desktop-ändelse: %s"
 
-#: src/dynamic-launcher.c:138
+#: desktop-portal/dynamic-launcher.c:120
 #, c-format
 msgid "Desktop file id is not valid"
 msgstr "Desktop-filens ID är ogiltigt"
 
-#: src/dynamic-launcher.c:316
+#: desktop-portal/dynamic-launcher.c:298
 #, c-format
 msgid "Desktop entry given to Install() not a valid key file"
 msgstr "Desktop-post som ges till Install() är inte en giltig nyckelfil"
 
-#: src/dynamic-launcher.c:329
+#: desktop-portal/dynamic-launcher.c:311
 #, c-format
 msgid "Desktop entry given to Install() must have exactly one group"
 msgstr "Desktop-post som ges till Install() måste ha exakt en grupp"
 
-#: src/dynamic-launcher.c:367
+#: desktop-portal/dynamic-launcher.c:350
 #, c-format
 msgid "Token given is invalid: %s"
 msgstr "Angiven token är ogiltig: %s"
 
-#: src/dynamic-launcher.c:410
+#: desktop-portal/dynamic-launcher.c:393
 #, c-format
 msgid "Desktop entry given to Install() not valid"
 msgstr "Desktop-post som ges till Install() är ogiltig"
 
-#: src/dynamic-launcher.c:419 src/dynamic-launcher.c:879
-#: src/dynamic-launcher.c:928
+#: desktop-portal/dynamic-launcher.c:402 desktop-portal/dynamic-launcher.c:878
+#: desktop-portal/dynamic-launcher.c:927
 #, c-format
 msgid "Desktop file exceeds max size (%d): %s"
 msgstr "Desktop-filen överskrider maximal storlek (%d): %s"
 
-#: src/dynamic-launcher.c:603
-#, fuzzy, c-format
+#: desktop-portal/dynamic-launcher.c:600
+#, c-format
 msgid "Given URI is invalid: %s"
-msgstr "Angiven URL är ogiltig: %s"
+msgstr "Angiven URI är ogiltig: %s"
 
-#: src/dynamic-launcher.c:625
+#: desktop-portal/dynamic-launcher.c:622
 #, c-format
 msgid "Invalid launcher type: %x"
 msgstr "Ogiltig startartyp: %x"
 
-#: src/dynamic-launcher.c:632
+#: desktop-portal/dynamic-launcher.c:629
 #, c-format
 msgid "Unsupported launcher type: %x"
 msgstr "Startartyp som inte stöds: %x"
 
-#: src/dynamic-launcher.c:698 src/dynamic-launcher.c:773
+#: desktop-portal/dynamic-launcher.c:695 desktop-portal/dynamic-launcher.c:770
 msgid "Dynamic launcher icon failed validation"
 msgstr "Dynamisk startarikon kunde inte valideras"
 
-#: src/dynamic-launcher.c:789
+#: desktop-portal/dynamic-launcher.c:788
 #, c-format
 msgid "RequestInstallToken() not allowed for app id %s"
 msgstr "RequestInstallToken() inte tillåtet för program-ID %s"
 
-#: src/dynamic-launcher.c:968
+#: desktop-portal/dynamic-launcher.c:967
 #, c-format
 msgid "Desktop file '%s' icon at unrecognized path"
 msgstr "Desktop-filen ”%s” har ikon på okänd sökväg"
 
-#: src/dynamic-launcher.c:991
+#: desktop-portal/dynamic-launcher.c:990
 #, c-format
 msgid "Desktop file '%s' icon failed to serialize"
 msgstr "Desktop-filen ”%s” har ikon som inte kunde serialiseras"
 
-#: src/dynamic-launcher.c:1030
+#: desktop-portal/dynamic-launcher.c:1029
 #, c-format
 msgid "No dynamic launcher exists with id '%s'"
 msgstr "Ingen dynamisk startare finns med ID ”%s”"
 
-#: src/dynamic-launcher.c:1049
+#: desktop-portal/dynamic-launcher.c:1048
 #, c-format
 msgid "Failed to create GDesktopAppInfo for launcher with id '%s'"
 msgstr "Misslyckades med att skapa GDesktopAppInfo för startare med ID ”%s”"
 
-#: src/location.c:555
+#: desktop-portal/location.c:535
 msgid "Deny Access"
 msgstr "Neka åtkomst"
 
-#: src/location.c:557
+#: desktop-portal/location.c:537
 msgid "Grant Access"
 msgstr "Bevilja åtkomst"
 
-#: src/location.c:563
+#: desktop-portal/location.c:543
 #, c-format
 msgid "Allow %s to Access Your Location?"
 msgstr "Tillåt %s att komma åt din plats?"
 
-#: src/location.c:573
+#: desktop-portal/location.c:553
 #, c-format
 msgid "%s wants to use your location"
 msgstr "%s vill använda din plats"
 
-#: src/location.c:579
+#: desktop-portal/location.c:559
 msgid "Allow Apps to Access Your Location?"
 msgstr "Ge program åtkomst till din plats?"
 
-#: src/location.c:580
+#: desktop-portal/location.c:560
 msgid "An app wants to use your location"
 msgstr "Ett program vill använda din plats"
 
-#: src/location.c:583
+#: desktop-portal/location.c:563
 msgid "Location access can be changed at any time from the privacy settings"
 msgstr "Platsåtkomst kan ändras när som helst från sekretessinställningarna"
 
-#: src/screenshot.c:273 src/wallpaper.c:190
+#: desktop-portal/screenshot.c:259 desktop-portal/wallpaper.c:172
 msgid "Deny"
 msgstr "Neka"
 
-#: src/screenshot.c:299
+#: desktop-portal/screenshot.c:285
 #, c-format
 msgid "Allow %s to Take Screenshots?"
 msgstr "Tillåt %s att ta skärmbilder?"
 
-#: src/screenshot.c:300
+#: desktop-portal/screenshot.c:286
 #, c-format
 msgid "%s wants to take screenshots at any time"
 msgstr "%s vill ta skärmbilder när som helst"
 
-#: src/screenshot.c:304
+#: desktop-portal/screenshot.c:290
 #, c-format
 msgid "Allow %s to Take a Screenshot?"
 msgstr "Tillåt %s att ta en skärmbild?"
 
-#: src/screenshot.c:305
+#: desktop-portal/screenshot.c:291
 #, c-format
 msgid "%s wants to take a screenshot"
 msgstr "%s vill ta en skärmbild"
@@ -207,49 +211,49 @@ msgstr "%s vill ta en skärmbild"
 #. Note: this will set the screenshot permission for all unsandboxed
 #. * apps for which an app ID can't be determined.
 #.
-#: src/screenshot.c:316
+#: desktop-portal/screenshot.c:302
 msgid "Allow Apps to Take Screenshots?"
 msgstr "Tillåt program att ta skärmbilder?"
 
-#: src/screenshot.c:317
+#: desktop-portal/screenshot.c:303
 msgid "An app wants to take screenshots at any time"
 msgstr "Ett program vill kunna ta skärmbilder när som helst"
 
-#: src/screenshot.c:321
+#: desktop-portal/screenshot.c:307
 msgid "Allow to Take a Screenshot?"
 msgstr "Tillåt att ta en skärmbild?"
 
-#: src/screenshot.c:322
+#: desktop-portal/screenshot.c:308
 msgid "An app wants to take a screenshot"
 msgstr "Ett program vill ta en skärmbild"
 
-#: src/settings.c:196 src/settings.c:235
+#: desktop-portal/settings.c:178 desktop-portal/settings.c:217
 msgid "Requested setting not found"
 msgstr "Begärd inställning hittades inte"
 
-#: src/usb.c:1333
+#: desktop-portal/usb.c:1308
 msgid "Device not available"
 msgstr "Enhet inte tillgänglig"
 
-#: src/usb.c:1347
+#: desktop-portal/usb.c:1322
 msgid "Not allowed"
 msgstr "Inte tillåtet"
 
-#: src/wallpaper.c:198
+#: desktop-portal/wallpaper.c:180
 #, c-format
 msgid "Allow %s to Set Backgrounds?"
 msgstr "Tillåt %s att ställa in bakgrunder?"
 
-#: src/wallpaper.c:199
+#: desktop-portal/wallpaper.c:181
 #, c-format
 msgid "%s wants to change the background image"
 msgstr "%s vill ändra bakgrundsbilden"
 
-#: src/wallpaper.c:204
+#: desktop-portal/wallpaper.c:186
 msgid "Allow Apps to Set Backgrounds?"
 msgstr "Tillåt program att ställa in bakgrunder?"
 
-#: src/wallpaper.c:205
+#: desktop-portal/wallpaper.c:187
 msgid "An app wants to change the background image"
 msgstr "Ett program vill ändra bakgrundsbilden"
 


### PR DESCRIPTION
Update translation in Swedish from Damned Lies: https://l10n.gnome.org/vertimus/2517/1021/112/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.