### PR TITLE
portal-config: Read multiple config files from each directory

### DIFF
--- a/desktop-portal/xdp-portal-config.c
+++ b/desktop-portal/xdp-portal-config.c
@@ -374,9 +374,9 @@ out:
 }
 
 static PortalConfig *
-load_portal_configuration_for_dir (gboolean    opt_verbose,
-                                   const char *base_directory,
-                                   const char *portal_file)
+load_config_file (gboolean    opt_verbose,
+                  const char *base_directory,
+                  const char *portal_file)
 {
   g_autoptr(GKeyFile) key_file = NULL;
   g_autofree char *path = NULL;
@@ -455,7 +455,7 @@ load_config_directory (const char  *dir,
       g_autofree char *portals_conf = NULL;
 
       portals_conf = g_strdup_printf ("%s-portals.conf", desktops[i]);
-      config = load_portal_configuration_for_dir (opt_verbose, dir, portals_conf);
+      config = load_config_file (opt_verbose, dir, portals_conf);
 
       if (config != NULL)
         {
@@ -472,7 +472,7 @@ load_config_directory (const char  *dir,
   {
     g_autoptr(PortalConfig) config = NULL;
 
-    config = load_portal_configuration_for_dir (opt_verbose, dir, "portals.conf");
+    config = load_config_file (opt_verbose, dir, "portals.conf");
     if (config != NULL)
       {
         if (opt_verbose)

--- a/desktop-portal/xdp-portal-config.c
+++ b/desktop-portal/xdp-portal-config.c
@@ -441,11 +441,9 @@ load_config_file (gboolean    opt_verbose,
   return NULL;
 }
 
-/*
- * Returns: %TRUE if configuration was found in @dir
- */
-static PortalConfig *
-load_config_directory (const char  *dir,
+static void
+load_config_directory (GPtrArray   *configs,
+                       const char  *dir,
                        const char **desktops,
                        gboolean     opt_verbose)
 {
@@ -461,11 +459,11 @@ load_config_directory (const char  *dir,
         {
           if (opt_verbose)
             {
-              g_debug ("Using portal configuration file '%s/%s' for desktop '%s'",
+              g_debug ("Loaded portal configuration file '%s/%s' for desktop '%s'",
                        dir, portals_conf, desktops[i]);
             }
 
-          return g_steal_pointer (&config);
+          g_ptr_array_add (configs, g_steal_pointer (&config));
         }
     }
 
@@ -477,15 +475,13 @@ load_config_directory (const char  *dir,
       {
         if (opt_verbose)
           {
-            g_debug ("Using portal configuration file '%s/%s' for non-specific desktop",
+            g_debug ("Loaded portal configuration file '%s/%s' for non-specific desktop",
                      dir, "portals.conf");
           }
 
-        return g_steal_pointer (&config);
+        g_ptr_array_add (configs, g_steal_pointer (&config));
       }
   }
-
-  return NULL;
 }
 
 static GPtrArray *
@@ -493,7 +489,6 @@ load_portal_configurations (XdpPortalConfig *portal_config,
                             gboolean        opt_verbose)
 {
   g_autoptr(GPtrArray) configs = NULL;
-  g_autoptr(PortalConfig) config = NULL;
   g_autofree char *user_portal_dir = NULL;
   const char * const *dirs;
   const char * const *iter;
@@ -509,9 +504,7 @@ load_portal_configurations (XdpPortalConfig *portal_config,
 
   if (portal_dir != NULL)
     {
-      config = load_config_directory (portal_dir, desktops, opt_verbose);
-      if (config)
-        g_ptr_array_add (configs, g_steal_pointer (&config));
+      load_config_directory (configs, portal_dir, desktops, opt_verbose);
       /* All other config directories are ignored when this is set */
       return g_steal_pointer (&configs);
     }
@@ -519,9 +512,7 @@ load_portal_configurations (XdpPortalConfig *portal_config,
   /* $XDG_CONFIG_HOME/xdg-desktop-portal/(DESKTOP-)portals.conf */
   user_portal_dir = g_build_filename (g_get_user_config_dir (), XDP_SUBDIR, NULL);
 
-  config = load_config_directory (user_portal_dir, desktops, opt_verbose);
-  if (config)
-    g_ptr_array_add (configs, g_steal_pointer (&config));
+  load_config_directory (configs, user_portal_dir, desktops, opt_verbose);
 
   /* $XDG_CONFIG_DIRS/xdg-desktop-portal/(DESKTOP-)portals.conf */
   dirs = g_get_system_config_dirs ();
@@ -530,25 +521,18 @@ load_portal_configurations (XdpPortalConfig *portal_config,
     {
       g_autofree char *dir = g_build_filename (*iter, XDP_SUBDIR, NULL);
 
-      config = load_config_directory (dir, desktops, opt_verbose);
-      if (config)
-        g_ptr_array_add (configs, g_steal_pointer (&config));
+      load_config_directory (configs, dir, desktops, opt_verbose);
     }
 
   /* ${sysconfdir}/xdg-desktop-portal/(DESKTOP-)portals.conf */
-  config = load_config_directory (SYSCONFDIR "/" XDP_SUBDIR, desktops, opt_verbose);
-  if (config)
-    g_ptr_array_add (configs, g_steal_pointer (&config));
-
+  load_config_directory (configs, SYSCONFDIR "/" XDP_SUBDIR, desktops, opt_verbose);
 
   /* $XDG_DATA_HOME/xdg-desktop-portal/(DESKTOP-)portals.conf
    * (just for consistency with other XDG specifications) */
   g_clear_pointer (&user_portal_dir, g_free);
   user_portal_dir = g_build_filename (g_get_user_data_dir (), XDP_SUBDIR, NULL);
 
-  config = load_config_directory (user_portal_dir, desktops, opt_verbose);
-  if (config)
-    g_ptr_array_add (configs, g_steal_pointer (&config));
+  load_config_directory (configs, user_portal_dir, desktops, opt_verbose);
 
   /* $XDG_DATA_DIRS/xdg-desktop-portal/(DESKTOP-)portals.conf */
   dirs = g_get_system_data_dirs ();
@@ -557,15 +541,11 @@ load_portal_configurations (XdpPortalConfig *portal_config,
     {
       g_autofree char *dir = g_build_filename (*iter, XDP_SUBDIR, NULL);
 
-      config = load_config_directory (dir, desktops, opt_verbose);
-      if (config)
-        g_ptr_array_add (configs, g_steal_pointer (&config));
+      load_config_directory (configs, dir, desktops, opt_verbose);
     }
 
   /* ${datadir}/xdg-desktop-portal/(DESKTOP-)portals.conf */
-  config = load_config_directory (DATADIR "/" XDP_SUBDIR, desktops, opt_verbose);
-  if (config)
-    g_ptr_array_add (configs, g_steal_pointer (&config));
+  load_config_directory (configs, DATADIR "/" XDP_SUBDIR, desktops, opt_verbose);
 
   return g_steal_pointer (&configs);
 }


### PR DESCRIPTION
Hi!
This is a small follow up to #1867.
On #1867, we started taking into account multiple config files instead of just the first one found, but I feel like we made an oversight when we kept reading a single config file per directory.

Current behavior:
A person uses gnome and kde with a DE-agnostic user-level portal config.
After a while, they want to try out cosmik and want to override the portal used for a single interface on it and not on the other DEs.
They write a cosmik-portals.conf changing it and now all DE-agnostic portal configs they have are ignored on cosmik.

Expected behavior:
cosmik specifig configuration are overlayed over the user's DE-agnostic configs.