### PR TITLE
tests: Only run portal tests when the portal is built

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -83,35 +83,8 @@ if pymod.find_installation('python3', modules: ['xdist'], required: false).found
   pytest_args += ['-n', '5']
 endif
 
-pytest_files = [
-  'test_account.py',
-  'test_background.py',
-  'test_camera.py',
-  'test_clipboard.py',
-  'test_documents.py',
-  'test_document_fuse.py',
-  'test_dynamiclauncher.py',
-  'test_email.py',
-  'test_filechooser.py',
-  'test_globalshortcuts.py',
-  'test_inhibit.py',
-  'test_inputcapture.py',
-  'test_location.py',
-  'test_notification.py',
-  'test_openuri.py',
-  'test_permission_store.py',
-  'test_print.py',
-  'test_registry.py',
-  'test_remotedesktop.py',
-  'test_settings.py',
-  'test_screencast.py',
-  'test_screenshot.py',
-  'test_shutdown.py',
-  'test_trash.py',
-  'test_usb.py',
-  'test_wallpaper.py',
-]
-
+# Portals that are only built when their dependency is available cannot be
+# tested when it is missing: the interface is not on the bus at all.
 tests = {
   'account': {},
   'background': {},
@@ -125,7 +98,7 @@ tests = {
   'globalshortcuts': {},
   'inhibit': {},
   'inputcapture': {},
-  'location': {},
+  'location': {'enabled': have_geoclue},
   'notification': {'timeout': 225},
   'openuri': {},
   'permission_store': {},
@@ -137,7 +110,7 @@ tests = {
   'screenshot': {},
   'shutdown': {},
   'trash': {},
-  'usb': {},
+  'usb': {'enabled': have_gudev},
   'wallpaper': {},
 }
 
@@ -166,7 +139,15 @@ template_files = [
   'templates/xdp_utils.py',
 ]
 
+pytest_files = []
+
 foreach testname, params : tests
+  if not params.get('enabled', true)
+    continue
+  endif
+
+  pytest_files += 'test_@0@.py'.format(testname)
+
   test(
     'integration/@0@'.format(testname),
     run_test,


### PR DESCRIPTION
`location.c` is only compiled `if have_geoclue` and `usb.c` only `if have_gudev`
(`desktop-portal/meson.build:114` and `:120`), but `tests/meson.build` registered and
installed `integration/location` and `integration/usb` unconditionally. Without the
dependency the interface never reaches the bus, so the test fails instead of being left out.

This adds an `enabled` key to the existing test table, gated on the same variable that gates
the portal, and builds the installed test file list from that table so the list and the table
cannot drift apart.

The issue reports the geoclue half. I measured the gudev half separately and it fails the same
way, so both are fixed here. Happy to narrow this to location only if you would rather keep the
change tight.

## Verification

All measured on the CI build image `ghcr.io/flatpak/xdg-desktop-portal:2026-07-31.0`, configured
with `-Dtests=enabled -Dinstalled-tests=true`.

Before the change:

| build | test | result |
| --- | --- | --- |
| default | `integration/location` | OK, 6.98s |
| `-Dgeoclue=disabled` | `integration/location` | FAIL, exit status 1 |
| `-Dgudev=disabled` | `integration/usb` | FAIL, exit status 1 |

After the change, full `meson test` run:

| build | registered integration tests | result |
| --- | --- | --- |
| default | 26, location and usb present | Ok 28, Fail 0, Skipped 1 |
| `-Dgeoclue=disabled` | 25, location absent | Ok 27, Fail 0, Skipped 1 |
| `-Dgudev=disabled` | 25, usb absent | Ok 27, Fail 0, Skipped 1 |

The single skip is `document_fuse`, which skips itself, and it is skipped on the default build too.

`meson install` into a DESTDIR confirms the installed-tests side:

- default: 26 `.test` files, both `test_location.py` and `test_usb.py` installed
- `-Dgeoclue=disabled`: no `integration-location.test`, `test_location.py` not installed
- `-Dgudev=disabled`: no `integration-usb.test`, `test_usb.py` not installed

`pre-commit` with the repo config passes on all files, and `gitlint` passes on the commit.

Closes #2094
