### PR TITLE
Fix a race between apps Request.Close() and the impl creating its ImplRequest

### DIFF
--- a/data/org.freedesktop.impl.portal.Account.xml
+++ b/data/org.freedesktop.impl.portal.Account.xml
@@ -59,5 +59,16 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
       <arg type="a{sv}" name="results" direction="out"/>
     </method>
+
+    <!--
+        request-version:
+
+        The version of the :doc:`org.freedesktop.impl.portal.Request`
+        interface supported by this backend. See that interface's
+        documentation for details.
+
+        If this property is not present, version 1 is assumed.
+    -->
+    <property name="request-version" type="u" access="read"/>
   </interface>
 </node>

--- a/data/org.freedesktop.impl.portal.Request.xml
+++ b/data/org.freedesktop.impl.portal.Request.xml
@@ -17,6 +17,13 @@
 
       The portal can abort the interaction by calling
       :ref:`org.freedesktop.impl.portal.Request.Close` on the Request object.
+
+      This interface does not have its own version property. Instead,
+      the version of the Request interface supported by a backend is
+      advertised via a ``request-version`` property on each impl portal
+      interface (e.g. org.freedesktop.impl.portal.Account). Backends
+      that do not have a ``request-version`` property are assumed to
+      support version 1.
   -->
   <interface name="org.freedesktop.impl.portal.Request">
 
@@ -28,5 +35,21 @@
     -->
     <method name="Close">
     </method>
+
+    <!--
+        Created:
+
+        Emitted by the backend right after exporting the Request object.
+        The portal waits for this signal before exporting the frontend
+        request, ensuring that a Close call from the app can be forwarded
+        to the backend.
+
+        Backends that support this signal advertise it via the
+        ``request-version`` property on their impl portal interfaces.
+
+        Since: 2
+    -->
+    <signal name="Created">
+    </signal>
   </interface>
 </node>

--- a/desktop-portal/account.c
+++ b/desktop-portal/account.c
@@ -6,142 +6,34 @@
 
 #include "account.h"
 
-#include <errno.h>
-#include <fcntl.h>
-#include <locale.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-
 #include <gio/gio.h>
 
+#include "xdp-app-info.h"
 #include "xdp-context.h"
 #include "xdp-dbus.h"
 #include "xdp-documents.h"
 #include "xdp-impl-dbus.h"
 #include "xdp-portal-config.h"
-#include "xdp-request.h"
+#include "xdp-request-dex.h"
 #include "xdp-utils.h"
 
-typedef struct _Account Account;
-typedef struct _AccountClass AccountClass;
-
-struct _Account
+struct _XdpAccount
 {
   XdpDbusAccountSkeleton parent_instance;
 
+  XdpContext *context;
   XdpDbusImplAccount *impl;
 };
 
-struct _AccountClass
-{
-  XdpDbusAccountSkeletonClass parent_class;
-};
+#define XDP_TYPE_ACCOUNT (xdp_account_get_type ())
+G_DECLARE_FINAL_TYPE (XdpAccount,
+                      xdp_account,
+                      XDP, ACCOUNT,
+                      XdpDbusAccountSkeleton)
 
-GType account_get_type (void);
-static void account_iface_init (XdpDbusAccountIface *iface);
-
-G_DEFINE_TYPE_WITH_CODE (Account, account, XDP_DBUS_TYPE_ACCOUNT_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_ACCOUNT,
-                                                account_iface_init));
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (Account, g_object_unref)
-
-static void
-send_response_in_thread_func (GTask        *task,
-                              gpointer      source_object,
-                              gpointer      task_data,
-                              GCancellable *cancellable)
-{
-  XdpRequest *request = task_data;
-  guint response;
-  GVariant *results;
-  g_auto(GVariantBuilder) new_results =
-    G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
-  g_autoptr(GVariant) idv = NULL;
-  g_autoptr(GVariant) namev = NULL;
-  const char *image;
-
-  REQUEST_AUTOLOCK (request);
-
-  response = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (request), "response"));
-  results = (GVariant *)g_object_get_data (G_OBJECT (request), "results");
-
-  if (response != 0)
-    goto out;
-
-  idv = g_variant_lookup_value (results, "id", G_VARIANT_TYPE_STRING);
-  namev = g_variant_lookup_value (results, "name", G_VARIANT_TYPE_STRING);
-
-  g_variant_builder_add (&new_results, "{sv}", "id", idv);
-  g_variant_builder_add (&new_results, "{sv}", "name", namev);
-
-  if (g_variant_lookup (results, "image", "&s", &image))
-    {
-      g_autofree char *ruri = NULL;
-      g_autoptr(GError) error = NULL;
-
-      if (xdp_app_info_is_host (request->app_info))
-        ruri = g_strdup (image);
-      else
-        ruri = xdp_register_document (image,
-                                      xdp_app_info_get_id (request->app_info),
-                                      xdp_app_info_get_gappinfo (request->app_info),
-                                      XDP_DOCUMENT_FLAG_NONE,
-                                      &error);
-
-      if (ruri == NULL)
-        {
-          g_warning ("Failed to register %s: %s", image, error->message);
-        }
-      else
-        {
-          g_debug ("convert uri '%s' -> '%s'\n", image, ruri);
-          g_variant_builder_add (&new_results, "{sv}", "image", g_variant_new_string (ruri));
-        }
-    }
-
-out:
-  if (request->exported)
-    {
-      xdp_dbus_request_emit_response (XDP_DBUS_REQUEST (request),
-                                      response,
-                                      g_variant_builder_end (&new_results));
-      xdp_request_unexport (request);
-    }
-}
-
-static void
-get_user_information_done (GObject *source,
-                           GAsyncResult *result,
-                           gpointer data)
-{
-  g_autoptr(XdpRequest) request = data;
-  guint response = 2;
-  g_autoptr(GVariant) results = NULL;
-  g_autoptr(GError) error = NULL;
-  g_autoptr(GTask) task = NULL;
-
-  if (!xdp_dbus_impl_account_call_get_user_information_finish (XDP_DBUS_IMPL_ACCOUNT (source),
-                                                               &response,
-                                                               &results,
-                                                               result,
-                                                               &error))
-    {
-      g_dbus_error_strip_remote_error (error);
-      g_warning ("Backend call failed: %s", error->message);
-    }
-
-  g_object_set_data (G_OBJECT (request), "response", GINT_TO_POINTER (response));
-  if (results)
-    g_object_set_data_full (G_OBJECT (request), "results", g_variant_ref (results), (GDestroyNotify)g_variant_unref);
-
-  task = g_task_new (NULL, NULL, NULL, NULL);
-  g_task_set_source_tag (task, get_user_information_done);
-  g_task_set_task_data (task, g_object_ref (request), g_object_unref);
-  g_task_run_in_thread (task, send_response_in_thread_func);
-}
+G_DEFINE_FINAL_TYPE (XdpAccount,
+                     xdp_account,
+                     XDP_DBUS_TYPE_ACCOUNT_SKELETON);
 
 static gboolean
 validate_reason (const char  *key,
@@ -154,8 +46,10 @@ validate_reason (const char  *key,
 
   if (g_utf8_strlen (string, -1) > 256)
     {
-      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR, XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
-                   "Not accepting overly long reasons");
+      g_set_error_literal (error,
+                           XDG_DESKTOP_PORTAL_ERROR,
+                           XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                           "Not accepting overly long reasons");
       return FALSE;
     }
 
@@ -167,108 +61,162 @@ static XdpOptionKey user_information_options[] = {
 };
 
 static gboolean
-handle_get_user_information (XdpDbusAccount *object,
+handle_get_user_information (XdpDbusAccount        *object,
                              GDBusMethodInvocation *invocation,
-                             const gchar *arg_parent_window,
-                             GVariant *arg_options)
+                             const char            *arg_parent_window,
+                             GVariant              *arg_options)
 {
-  Account *account = (Account *) object;
-  XdpRequest *request = xdp_request_from_invocation (invocation);
-  const char *app_id = xdp_app_info_get_id (request->app_info);
+  XdpAccount *account = XDP_ACCOUNT (object);
+  XdpAppInfo *app_info = xdp_invocation_get_app_info (invocation);
+  g_autoptr(XdpRequestDex) request = NULL;
+  g_autoptr(GVariant) options = NULL;
   g_autoptr(GError) error = NULL;
-  g_autoptr(XdpDbusImplRequest) impl_request = NULL;
-  g_auto(GVariantBuilder) options =
+  g_autoptr(XdpDbusImplAccountGetUserInformationResult) result = NULL;
+  g_auto(GVariantBuilder) new_results =
     G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+  g_autoptr(GVariant) idv = NULL;
+  g_autoptr(GVariant) namev = NULL;
+  unsigned int impl_request_version;
+  const char *image;
 
-  g_debug ("Handling GetUserInformation");
+  {
+    g_auto(GVariantBuilder) options_builder =
+      G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
 
-  REQUEST_AUTOLOCK (request);
+    xdp_filter_options (arg_options, &options_builder,
+                        user_information_options, G_N_ELEMENTS (user_information_options),
+                        NULL, NULL);
+    options = g_variant_ref_sink (g_variant_builder_end (&options_builder));
+  }
 
-  impl_request = xdp_dbus_impl_request_proxy_new_sync (
-    g_dbus_proxy_get_connection (G_DBUS_PROXY (account->impl)),
-    G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
-    g_dbus_proxy_get_name (G_DBUS_PROXY (account->impl)),
-    request->id,
-    NULL, &error);
+  impl_request_version = xdp_dbus_impl_account_get_request_version (account->impl);
 
-  if (!impl_request)
+  request = dex_await_object (xdp_request_dex_new (account->context,
+                                                   app_info,
+                                                   G_DBUS_INTERFACE_SKELETON (object),
+                                                   G_DBUS_PROXY (account->impl),
+                                                   impl_request_version,
+                                                   arg_options),
+                              &error);
+  if (!request)
     {
-      g_dbus_method_invocation_return_gerror (invocation, error);
+      g_dbus_method_invocation_return_gerror (g_steal_pointer (&invocation),
+                                              error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  xdp_request_set_impl_request (request, impl_request);
-  xdp_request_export (request, g_dbus_method_invocation_get_connection (invocation));
+  {
+    g_autoptr(DexFuture) impl_future = NULL;
 
-  xdp_filter_options (arg_options, &options,
-                      user_information_options, G_N_ELEMENTS (user_information_options),
-                      NULL, NULL);
+    impl_future = xdp_dbus_impl_account_call_get_user_information_future (
+        account->impl,
+        xdp_request_dex_get_object_path (request),
+        xdp_app_info_get_id (app_info),
+        arg_parent_window,
+        options);
 
-  g_debug ("options filtered");
+    dex_await (xdp_request_dex_export (request), NULL);
 
-  xdp_dbus_impl_account_call_get_user_information (account->impl,
-                                                   request->id,
-                                                   app_id,
-                                                   arg_parent_window,
-                                                   g_variant_builder_end (&options),
-                                                   NULL,
-                                                   get_user_information_done,
-                                                   g_object_ref (request));
+    xdp_dbus_account_complete_get_user_information (object,
+                                                    g_steal_pointer (&invocation),
+                                                    xdp_request_dex_get_object_path (request));
 
-  xdp_dbus_account_complete_get_user_information (object, invocation,
-                                                 request->id);
+    result = dex_await_boxed (g_steal_pointer (&impl_future), &error);
+  }
+
+  if (!result)
+    {
+      g_dbus_error_strip_remote_error (error);
+      g_warning ("Backend call failed: %s", error->message);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  if (result->response != XDG_DESKTOP_PORTAL_RESPONSE_SUCCESS)
+    {
+      xdp_request_dex_emit_response (request, result->response, NULL);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  idv = g_variant_lookup_value (result->results, "id", G_VARIANT_TYPE_STRING);
+  namev = g_variant_lookup_value (result->results, "name", G_VARIANT_TYPE_STRING);
+
+  g_variant_builder_add (&new_results, "{sv}", "id", idv);
+  g_variant_builder_add (&new_results, "{sv}", "name", namev);
+
+  if (g_variant_lookup (result->results, "image", "&s", &image))
+    {
+      g_autofree char *ruri = NULL;
+      g_autoptr(GError) image_error = NULL;
+
+      if (xdp_app_info_is_host (app_info))
+        ruri = g_strdup (image);
+      else
+        ruri = xdp_register_document (image,
+                                      xdp_app_info_get_id (app_info),
+                                      xdp_app_info_get_gappinfo (app_info),
+                                      XDP_DOCUMENT_FLAG_NONE,
+                                      &image_error);
+
+      if (ruri == NULL)
+        g_warning ("Failed to register %s: %s", image, image_error->message);
+      else
+        g_variant_builder_add (&new_results, "{sv}", "image", g_variant_new_string (ruri));
+    }
+
+  xdp_request_dex_emit_response (request, result->response,
+                                 g_variant_builder_end (&new_results));
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static void
-account_iface_init (XdpDbusAccountIface *iface)
+xdp_account_dispose (GObject *object)
 {
-  iface->handle_get_user_information = handle_get_user_information;
-}
-
-static void
-account_dispose (GObject *object)
-{
-  Account *account = (Account *) object;
+  XdpAccount *account = XDP_ACCOUNT (object);
 
   g_clear_object (&account->impl);
 
-  G_OBJECT_CLASS (account_parent_class)->dispose (object);
+  G_OBJECT_CLASS (xdp_account_parent_class)->dispose (object);
 }
 
 static void
-account_init (Account *account)
+xdp_account_init (XdpAccount *account)
 {
 }
 
 static void
-account_class_init (AccountClass *klass)
+xdp_account_class_init (XdpAccountClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  object_class->dispose = account_dispose;
+  object_class->dispose = xdp_account_dispose;
 }
 
-static Account *
-account_new (XdpDbusImplAccount *impl)
+static XdpAccount *
+xdp_account_new (XdpContext         *context,
+                 XdpDbusImplAccount *impl)
 {
-  Account *account;
+  XdpAccount *account;
 
-  account = g_object_new (account_get_type (), NULL);
+  account = g_object_new (XDP_TYPE_ACCOUNT, NULL);
+  account->context = context;
   account->impl = g_object_ref (impl);
 
-  xdp_dbus_account_set_version (XDP_DBUS_ACCOUNT (account), 1);
+  g_signal_connect (account, "handle-get-user-information",
+                    G_CALLBACK (handle_get_user_information), NULL);
 
   g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (account->impl), G_MAXINT);
+
+  xdp_dbus_account_set_version (XDP_DBUS_ACCOUNT (account), 1);
 
   return account;
 }
 
-void
-init_account (XdpContext *context)
+DexFuture *
+init_account (gpointer user_data)
 {
-  g_autoptr(Account) account = NULL;
+  XdpContext *context = XDP_CONTEXT (user_data);
+  g_autoptr(XdpAccount) account = NULL;
   GDBusConnection *connection = xdp_context_get_connection (context);
   XdpPortalConfig *config = xdp_context_get_config (context);
   XdpImplConfig *impl_config;
@@ -277,24 +225,25 @@ init_account (XdpContext *context)
 
   impl_config = xdp_portal_config_find (config, ACCOUNT_DBUS_IMPL_IFACE);
   if (impl_config == NULL)
-    return;
+    return dex_future_new_true ();
 
-  impl = xdp_dbus_impl_account_proxy_new_sync (connection,
-                                               G_DBUS_PROXY_FLAGS_NONE,
-                                               impl_config->dbus_name,
-                                               DESKTOP_DBUS_PATH,
-                                               NULL,
-                                               &error);
+  impl = dex_await_object (xdp_dbus_impl_account_proxy_new_future (connection,
+                                                                   G_DBUS_PROXY_FLAGS_NONE,
+                                                                   impl_config->dbus_name,
+                                                                   DESKTOP_DBUS_PATH),
+                           &error);
 
   if (impl == NULL)
     {
       g_warning ("Failed to create account proxy: %s", error->message);
-      return;
+      return dex_future_new_false ();
     }
 
-  account = account_new (impl);
+  account = xdp_account_new (context, impl);
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&account)),
-                                      XDP_CONTEXT_EXPORT_FLAGS_RUN_IN_THREAD);
+                                      XDP_CONTEXT_EXPORT_FLAGS_RUN_IN_FIBER);
+
+  return dex_future_new_true ();
 }

--- a/desktop-portal/account.h
+++ b/desktop-portal/account.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <libdex.h>
+
 #include "xdp-types.h"
 
-void init_account (XdpContext *context);
+DexFuture * init_account (gpointer user_data);

--- a/desktop-portal/xdp-context.c
+++ b/desktop-portal/xdp-context.c
@@ -492,7 +492,7 @@ xdp_context_register (XdpContext       *context,
   init_screenshot (context);
   init_background (context);
   init_wallpaper (context);
-  init_account (context);
+  init_portal_in_fiber (context, init_account);
   init_email (context);
   init_global_shortcuts (context);
   init_dynamic_launcher (context);

--- a/desktop-portal/xdp-request-dex.c
+++ b/desktop-portal/xdp-request-dex.c
@@ -25,6 +25,85 @@ typedef struct _XdpRequestDex
   gboolean responded;
 } XdpRequestDex;
 
+/**
+ * XdpRequestDex:
+ *
+ * A future-based Request implementation.
+ *
+ * ## Lifecycle
+ *
+ * [ctor@RequestDex.new] creates the request and a proxy for the impl
+ * request, but does not export the request on the bus.
+ *
+ * The request must only be exported after the backend has created the
+ * impl request object, because a `Close` call on the exported request
+ * is forwarded to the impl request. [method@RequestDex.export]
+ * handles this: when `impl_request_version` (passed to
+ * [ctor@RequestDex.new]) is 2 or higher, the returned future resolves
+ * only after the backend emits the `Created` signal on the impl
+ * request. With older backends the future resolves immediately; there
+ * is a small race in that case where a `Close` from the app may
+ * arrive before the backend has created the impl request. The caller
+ * should pass the `request-version` property from the impl portal
+ * interface.
+ *
+ * The D-Bus method call must only be completed to the app after the
+ * export, so that the request object path the app receives is
+ * immediately usable for `Close`.
+ *
+ * ## Response handling
+ *
+ * Use [method@RequestDex.emit_response] to send a `Response` signal
+ * to the app. Calling it more than once is a programming error.
+ *
+ * If the request is disposed without a response having been sent
+ * (e.g. on error paths), dispose automatically emits
+ * `XDG_DESKTOP_PORTAL_RESPONSE_OTHER`. Portal handlers can therefore
+ * simply return on failure and let the `g_autoptr` cleanup take care
+ * of notifying the app.
+ *
+ * ## Long-lived call pattern
+ *
+ * When the backend impl call blocks for the entire duration of the
+ * request (e.g. waiting for user interaction), the portal must issue
+ * the backend call first, then await the export, then complete the
+ * D-Bus method call, and finally await the backend result:
+ *
+ * ```c
+ * request = dex_await_object (xdp_request_dex_new (...), &error);
+ * impl_future = xdp_dbus_impl_foo_call_bar_future (impl, ...,
+ *     xdp_request_dex_get_object_path (request), ...);
+ * dex_await (xdp_request_dex_export (request), NULL);
+ * xdp_dbus_foo_complete_bar (object, g_steal_pointer (&invocation),
+ *     xdp_request_dex_get_object_path (request));
+ * result = dex_await_boxed (g_steal_pointer (&impl_future), &error);
+ * ```
+ *
+ * The backend call must be issued before the export so that the
+ * export's `Created` signal wait does not deadlock: the backend
+ * creates the impl request (and emits `Created`) only in response
+ * to the method call.
+ *
+ * ## Immediate-return pattern
+ *
+ * When the backend impl call returns immediately and the request
+ * lives until something else happens, the reply itself proves the
+ * impl request exists. The portal can await the reply, then export:
+ *
+ * ```c
+ * request = dex_await_object (xdp_request_dex_new (...), &error);
+ * dex_await (xdp_dbus_impl_foo_call_bar_future (impl, ...,
+ *     xdp_request_dex_get_object_path (request), ...),
+ *     &error);
+ * dex_await (xdp_request_dex_export (request), NULL);
+ * xdp_dbus_foo_complete_bar (object, g_steal_pointer (&invocation),
+ *     xdp_request_dex_get_object_path (request));
+ * ```
+ *
+ * This pattern has no race because the method reply guarantees the
+ * backend has created the impl request object.
+ */
+
 static void xdp_request_skeleton_iface_init (XdpDbusRequestIface *iface);
 
 G_DEFINE_FINAL_TYPE_WITH_CODE (XdpRequestDex,

--- a/desktop-portal/xdp-request-dex.c
+++ b/desktop-portal/xdp-request-dex.c
@@ -20,6 +20,7 @@ typedef struct _XdpRequestDex
   XdpDbusImplRequest *impl_request;
   GDBusInterfaceSkeleton *skeleton;
   char *id;
+  unsigned int impl_request_version;
   gboolean exported;
   gboolean responded;
 } XdpRequestDex;
@@ -157,6 +158,7 @@ typedef struct _RequestImplProxyCreateData {
   XdpAppInfo *app_info;
   GDBusInterfaceSkeleton *skeleton;
   char *id;
+  unsigned int impl_request_version;
 } RequestImplProxyCreateData;
 
 static void
@@ -206,6 +208,7 @@ on_impl_request_proxy_created (DexFuture *future,
   request->impl_request = g_steal_pointer (&impl_request);
   request->skeleton = g_steal_pointer (&data->skeleton);
   request->id = g_steal_pointer (&data->id);
+  request->impl_request_version = data->impl_request_version;
   g_signal_connect_object (request->context, "peer-disconnect",
                            G_CALLBACK (on_peer_disconnect),
                            request,
@@ -225,6 +228,7 @@ xdp_request_dex_new (XdpContext             *context,
                      XdpAppInfo             *app_info,
                      GDBusInterfaceSkeleton *skeleton,
                      GDBusProxy             *proxy_impl,
+                     unsigned int            impl_request_version,
                      GVariant               *arg_options)
 {
   g_autoptr(DexFuture) future = NULL;
@@ -272,6 +276,7 @@ xdp_request_dex_new (XdpContext             *context,
   data->app_info = g_object_ref (app_info);
   data->skeleton = g_object_ref (skeleton);
   data->id = g_steal_pointer (&id);
+  data->impl_request_version = impl_request_version;
 
   future = dex_future_then (future,
                             on_impl_request_proxy_created,
@@ -281,18 +286,37 @@ xdp_request_dex_new (XdpContext             *context,
   return g_steal_pointer (&future);
 }
 
-gboolean
-xdp_request_dex_export (XdpRequestDex  *request,
-                        GError        **error)
+static DexFuture *
+do_export (DexFuture *future,
+           gpointer   user_data)
 {
+  XdpRequestDex *request = XDP_REQUEST_DEX (user_data);
+  g_autoptr(GError) error = NULL;
+
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (request),
                                          g_dbus_interface_skeleton_get_connection (request->skeleton),
                                          request->id,
-                                         error))
-    return FALSE;
+                                         &error))
+    return dex_future_new_for_error (g_steal_pointer (&error));
 
   request->exported = TRUE;
-  return TRUE;
+  return dex_future_new_for_boolean (TRUE);
+}
+
+DexFuture *
+xdp_request_dex_export (XdpRequestDex *request)
+{
+  DexFuture *precondition;
+
+  if (request->impl_request_version >= 2)
+    precondition = xdp_dbus_impl_request_wait_created_future (request->impl_request);
+  else
+    precondition = dex_future_new_for_boolean (TRUE);
+
+  return dex_future_then (precondition,
+                          do_export,
+                          g_object_ref (request),
+                          g_object_unref);
 }
 
 void

--- a/desktop-portal/xdp-request-dex.h
+++ b/desktop-portal/xdp-request-dex.h
@@ -17,10 +17,10 @@ DexFuture * xdp_request_dex_new (XdpContext             *context,
                                  XdpAppInfo             *app_info,
                                  GDBusInterfaceSkeleton *skeleton,
                                  GDBusProxy             *proxy_impl,
+                                 unsigned int            impl_request_version,
                                  GVariant               *arg_options);
 
-gboolean xdp_request_dex_export (XdpRequestDex  *request,
-                                 GError        **error);
+DexFuture * xdp_request_dex_export (XdpRequestDex *request);
 
 void xdp_request_dex_emit_response (XdpRequestDex                *request,
                                     XdgDesktopPortalResponseEnum  response,

--- a/tests/templates/account.py
+++ b/tests/templates/account.py
@@ -26,6 +26,7 @@ class AccountParameters:
     response: int
     results: dict
     expect_close: bool
+    request_version: int
 
 
 def load(mock, parameters=None):
@@ -39,6 +40,16 @@ def load(mock, parameters=None):
         response=parameters.get("response", 0),
         results=parameters.get("results", {}),
         expect_close=parameters.get("expect-close", False),
+        request_version=parameters.get("request-version", 1),
+    )
+
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary(
+            {
+                "request-version": dbus.UInt32(mock.account_params.request_version),
+            }
+        ),
     )
 
 
@@ -59,6 +70,7 @@ def GetUserInformation(self, handle, app_id, window, options, cb_success, cb_err
         logger,
         cb_success,
         cb_error,
+        request_version=params.request_version,
     )
 
     if params.expect_close:

--- a/tests/templates/xdp_utils.py
+++ b/tests/templates/xdp_utils.py
@@ -57,6 +57,7 @@ class ImplRequest:
         logger: logging.Logger,
         cb_success: Callable,
         cb_error: Callable,
+        request_version: int = 1,
     ):
         self.mock = mock
         bus = mock.connection
@@ -66,6 +67,7 @@ class ImplRequest:
         self.logger = logger
         self.cb_success = cb_success
         self.cb_error = cb_error
+        self.request_version = request_version
 
     def respond(
         self,
@@ -162,6 +164,15 @@ class ImplRequest:
                 )
             ],
         )
+
+        if self.request_version >= 2:
+            request_obj = dbusmock.get_object(self.handle)
+            request_obj.EmitSignal(
+                interface="org.freedesktop.impl.portal.Request",
+                name="Created",
+                signature="",
+                sigargs=(),
+            )
 
     def _unexport(self):
         self.mock.RemoveObject(self.handle)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -122,3 +122,24 @@ class TestAccount:
 
         # Only true if the impl.Request was closed too
         assert request.closed
+
+    @pytest.mark.parametrize(
+        "template_params",
+        ({"account": {"expect-close": True, "request-version": 2}},),
+    )
+    def test_close_request_v2(self, portals, dbus_con):
+        account_intf = xdp.get_portal_iface(dbus_con, "Account")
+
+        request = xdp.Request(dbus_con, account_intf)
+        request.schedule_close(1000)
+        options = {
+            "reason": "reason",
+        }
+        request.call(
+            "GetUserInformation",
+            window="",
+            options=options,
+        )
+
+        # Only true if the impl.Request was closed too
+        assert request.closed


### PR DESCRIPTION
Fixes https://github.com/flatpak/xdg-desktop-portal/issues/854.

The big issue is that this requires a signal from the impl Request for the frontend to know that it's safe to export the Request to the app. We also don't have versioning on the impl Request interface, so we need the portal to provide the Request version.

Unfortunately all of this means that the frontend must rewrite the portal with libdex, then add a property to the portal, and then impls need to support impl Request v2.

Depends on: https://github.com/flatpak/xdg-desktop-portal/pull/2100

/cc @jadahl @AdrianVovk or anyone else who wants to dig into this mess