### PR TITLE
open-uri: Don't hold the request lock across ShowItems

### DIFF
--- a/desktop-portal/xdp-context.c
+++ b/desktop-portal/xdp-context.c
@@ -69,6 +69,7 @@ struct _XdpContext
   GHashTable *exported_portals; /* iface name -> GDBusInterfaceSkeleton */
   GHashTable *registered_object_paths; /* char *object_path set */
   GMutex registered_object_paths_lock;
+  GThreadPool *peer_disconnect_pool;
 
   GCancellable *cancellable;
 };
@@ -122,6 +123,12 @@ xdp_context_dispose (GObject *object)
   g_clear_object (&context->lockdown_impl);
   g_clear_object (&context->access_impl);
   g_clear_object (&context->app_info_registry);
+
+  if (context->peer_disconnect_pool)
+    {
+      g_thread_pool_free (context->peer_disconnect_pool, FALSE, TRUE);
+      context->peer_disconnect_pool = NULL;
+    }
 
   if (context->registered_object_paths)
     {
@@ -360,13 +367,35 @@ xdp_context_get_portal (XdpContext *context,
   return g_hash_table_lookup (context->exported_portals, interface);
 }
 
+/* Emitted from a worker thread, never from the main loop.
+ *
+ * The handlers take the per-request and per-session locks, and those locks are
+ * held across blocking work: open-uri holds the request lock for the whole of
+ * handle_open_in_thread_func(), which includes a synchronous ShowItems call to
+ * the file manager. Emitting on the main loop parks the whole daemon behind
+ * that for as long as the blocking work lasts.
+ *
+ * The pool is a dedicated one rather than the shared pool behind
+ * g_task_run_in_thread(), because handlers that block would otherwise starve
+ * every other GTask user in the process, GDBus method dispatch included.
+ */
+static void
+emit_peer_disconnect_in_thread (gpointer data,
+                                gpointer user_data)
+{
+  XdpContext *context = XDP_CONTEXT (user_data);
+  g_autofree char *peer = data;
+
+  g_signal_emit (context, signals[PEER_DISCONNECT], 0, peer);
+}
+
 static void
 on_peer_disconnect (const char *name,
                     gpointer    user_data)
 {
   XdpContext *context = XDP_CONTEXT (user_data);
 
-  g_signal_emit (context, signals[PEER_DISCONNECT], 0, name);
+  g_thread_pool_push (context->peer_disconnect_pool, g_strdup (name), NULL);
 
   dex_future_disown (xdp_app_info_registry_delete_future (context->app_info_registry,
                                                           name));
@@ -401,6 +430,9 @@ xdp_context_register (XdpContext       *context,
   portal_errors = XDG_DESKTOP_PORTAL_ERROR;
 
   g_set_object (&context->connection, connection);
+
+  context->peer_disconnect_pool =
+    g_thread_pool_new (emit_peer_disconnect_in_thread, context, -1, FALSE, NULL);
 
   context->peer_disconnect_handle_id =
     xdp_connection_track_peer_disconnect (connection,

--- a/tests/test_openuri.py
+++ b/tests/test_openuri.py
@@ -4,11 +4,15 @@
 # This file is formatted with Python Black
 
 import os
+import subprocess
+import sys
+import time
 from pathlib import Path
 from typing import Any
 
 import dbus
 import pytest
+from gi.repository import GLib
 
 import tests.xdp_doc_utils as xdp_doc
 import tests.xdp_utils as xdp
@@ -77,6 +81,34 @@ def required_templates():
         "appchooser": {},
         "lockdown": {},
     }
+
+
+# Answers ShowItems after a delay, without blocking its own main loop, so a
+# request stays pending in the portal for a known amount of time.
+SLOW_FILE_MANAGER = """
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+
+class FileManager1(dbus.service.Object):
+    @dbus.service.method("org.freedesktop.FileManager1",
+                         in_signature="ass", out_signature="",
+                         async_callbacks=("ok", "err"))
+    def ShowItems(self, uris, startup_id, ok, err):
+        GLib.timeout_add(SHOW_ITEMS_DELAY_MS, lambda: ok() or False)
+
+
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+bus = dbus.SessionBus()
+name = dbus.service.BusName("org.freedesktop.FileManager1", bus)
+FileManager1(bus, "/org/freedesktop/FileManager1")
+print("ready", flush=True)
+GLib.MainLoop().run()
+"""
+
+SHOW_ITEMS_DELAY_MS = 5000
 
 
 class TestOpenURI:
@@ -361,6 +393,78 @@ class TestOpenURI:
         assert path.startswith("file:///")
 
         assert Path(path[7:]) == Path(file_path).parent
+
+    def test_dir_peer_disconnect_does_not_block_portal(
+        self, portals, dbus_con, xdp_app_info
+    ):
+        """A peer dropping off the bus while OpenDirectory is waiting on the
+        file manager must not stall the portal for everyone else.
+
+        The worker thread holds the request lock across the ShowItems call, so
+        emitting peer-disconnect on the main loop parked the whole daemon there
+        until that call timed out.
+        """
+        address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+        openuri_intf = xdp.get_portal_iface(dbus_con, "OpenURI")
+
+        file_manager = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                f"SHOW_ITEMS_DELAY_MS = {SHOW_ITEMS_DELAY_MS}\n" + SLOW_FILE_MANAGER,
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        assert file_manager.stdout is not None
+        assert file_manager.stdout.readline().strip() == "ready"
+
+        def probe() -> float:
+            bus = dbus.bus.BusConnection(address)
+            proxy = bus.get_object(
+                "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop"
+            )
+            start = time.monotonic()
+            dbus.Interface(proxy, "org.freedesktop.portal.OpenURI").SchemeSupported(
+                "https", {}, timeout=20
+            )
+            elapsed = time.monotonic() - start
+            bus.close()
+            return elapsed
+
+        try:
+            file_path = Path.home() / "openuri_peer_disconnect_file"
+            file_path.write_text("openuri_peer_disconnect_file")
+            fd = os.open(file_path.absolute().as_posix(), os.O_RDONLY)
+
+            request = xdp.Request(dbus_con, openuri_intf)
+            openuri_intf.OpenDirectory(
+                "",
+                dbus.types.UnixFd(fd),
+                dbus.Dictionary({"handle_token": request.handle_token}, signature="sv"),
+                reply_handler=lambda *args: None,
+                error_handler=lambda *args: None,
+            )
+            os.close(fd)
+
+            # Flush the call and let the worker reach ShowItems.
+            loop = GLib.MainLoop()
+            GLib.timeout_add(1000, lambda: loop.quit() or False)
+            loop.run()
+
+            # The portal is responsive while the file manager is busy.
+            assert probe() < 1.0
+
+            # Some unrelated peer goes away.
+            victim = dbus.bus.BusConnection(address)
+            victim.get_unique_name()
+            victim.close()
+            time.sleep(0.3)
+
+            assert probe() < 1.0
+        finally:
+            file_manager.terminate()
+            file_manager.wait()
 
     def test_scheme_supported(self, portals, dbus_con):
         openuri_intf = xdp.get_portal_iface(dbus_con, "OpenURI")


### PR DESCRIPTION
Closes #2093.

`OpenDirectory` was reported as taking exactly 25 seconds whenever the file manager has to be
D-Bus activated. The mechanism the reporter identified is right, but it needs much less to trigger
than the report assumes, and the damage is wider: while it happens, **every portal is unresponsive
for every client**, not just the caller.

## What actually happens

- `open-uri.c:591` takes `REQUEST_AUTOLOCK (request)` and holds it for the whole of
  `handle_open_in_thread_func()`, which includes
- `open-uri.c:715`, a synchronous `ShowItems` call with `timeout = -1`, i.e. the GDBus default of
  25 seconds. That is where the reported 25.03s comes from: the timeout is the only thing that
  ends it.
- `shared/xdp-utils.c:67` runs on the main loop and fires for every unique name that leaves the
  bus, and
- `xdp-request.c:183` takes that same request mutex there.

So the main loop parks in `on_peer_disconnect` until the blocking call gives up.

## Measurements

A file manager stub that delays its `ShowItems` reply by 8s, and an unrelated
`OpenURI.SchemeSupported` call timed from a third connection:

| in flight | peer disconnect | probe |
|---|---|---|
| nothing | yes | 0.01s |
| OpenDirectory | no | 0.01s |
| OpenDirectory | yes | **6.70s** |

No Nautilus, no GTK and no call back into the portal are needed. Any unrelated client dropping off
the session bus is enough. `RUN_IN_THREAD` does not protect the other portals either: the probe
method is exported with it (`open-uri.c:1171`) and still stalls, because GDBus dispatches the
invocation on the main context before handing it to the thread pool.

## The fix

Drop the request lock around the `ShowItems` call and take it again afterwards. Nothing touched in
between belongs to the request: the fd is stolen out of it at `open-uri.c:605`, and the uri is
built from locals.

The request can be closed while the lock is not held, so the worker re-checks `request->exported`
before emitting the response. That check is load-bearing rather than defensive:
`xdp_request_unexport()` (`xdp-request.c:296`) does an unconditional `g_object_unref()`, so without
it a caller that disconnects at the wrong moment gets the request unexported twice.

An earlier revision of this PR moved the `PEER_DISCONNECT` emit off the main loop instead. That was
the wrong layer, and it is gone: `xdp-context.c` is untouched here.

## Testing

- New regression test in `tests/test_openuri.py`. It **fails on unpatched main at 3.70s** on the
  probe after the disconnect, while the probe before it still passes, and passes with this change.
- Full `meson test`: 28 ok, 0 failed, 1 skipped.
- The re-check path was exercised directly under an ASAN build matching CI
  (`-Db_sanitize=address -Db_lundef=false`): 15 callers killed while their own requests were parked
  inside `ShowItems`, so `on_peer_disconnect` unexports underneath the worker in exactly the window
  where the lock is not held. No use-after-free, no double unref, no crash, and the portal keeps
  serving afterwards. That stress is not in the diff, it is slow and process-heavy; happy to add it
  if you want it as an installed test.

## Note on #2091

`ScreenCast: OpenPipeWireRemote` holds the **session** lock across a PipeWire teardown, which is
the same shape one layer over. This PR does not address it, since the fix here is specific to the
open-uri call site.
