### PR TITLE
Don't block the main loop on peer disconnect

### DIFF
--- a/desktop-portal/xdp-request.c
+++ b/desktop-portal/xdp-request.c
@@ -180,16 +180,14 @@ get_token (GDBusMethodInvocation *invocation)
 }
 
 static void
-on_peer_disconnect (XdpContext *context,
-                    const char *peer,
-                    gpointer    user_data)
+on_peer_disconnect_in_thread_func (GTask        *task,
+                                   gpointer      source_object,
+                                   gpointer      task_data,
+                                   GCancellable *cancellable)
 {
-  XdpRequest *request = XDP_REQUEST (user_data);
+  XdpRequest *request = XDP_REQUEST (source_object);
 
   REQUEST_AUTOLOCK (request);
-
-  if (g_strcmp0 (request->sender, peer) != 0)
-    return;
 
   if (!request->exported)
     return;
@@ -199,6 +197,30 @@ on_peer_disconnect (XdpContext *context,
 
   xdp_request_unexport (request);
   xdp_context_unclaim_object_path (request->context, request->id);
+}
+
+static void
+on_peer_disconnect (XdpContext *context,
+                    const char *peer,
+                    gpointer    user_data)
+{
+  XdpRequest *request = XDP_REQUEST (user_data);
+  g_autoptr(GTask) task = NULL;
+
+  /* The sender is fixed for the lifetime of the request, so the peer
+   * check is safe without the lock. This lets the main loop skip the
+   * lock for every disconnect event that is not this request's owner,
+   * which would otherwise stall every portal while a handler holds it. */
+  if (g_strcmp0 (request->sender, peer) != 0)
+    return;
+
+  /* The disconnect sequence needs the lock, but taking it here would
+   * block the main loop if a portal handler is currently holding it
+   * (e.g. open-uri blocking on ShowItems for the full D-Bus timeout).
+   * Run it in a worker thread instead. */
+  task = g_task_new (request, NULL, NULL, NULL);
+  g_task_set_source_tag (task, on_peer_disconnect_in_thread_func);
+  g_task_run_in_thread (task, on_peer_disconnect_in_thread_func);
 }
 
 gboolean

--- a/desktop-portal/xdp-session.c
+++ b/desktop-portal/xdp-session.c
@@ -244,18 +244,39 @@ xdp_session_authorize_callback (GDBusInterfaceSkeleton *interface,
 }
 
 static void
+on_peer_disconnect_in_thread_func (GTask        *task,
+                                   gpointer      source_object,
+                                   gpointer      task_data,
+                                   GCancellable *cancellable)
+{
+  XdpSession *session = XDP_SESSION (source_object);
+
+  SESSION_AUTOLOCK_UNREF (g_object_ref (session));
+
+  xdp_session_close (session, FALSE);
+}
+
+static void
 on_peer_disconnect (XdpContext *context,
                     const char *peer,
                     gpointer    user_data)
 {
   XdpSession *session = XDP_SESSION (user_data);
+  g_autoptr(GTask) task = NULL;
 
-  SESSION_AUTOLOCK (session);
-
+  /* The sender is fixed after session init, so the peer check is safe
+   * without the lock. This keeps the main loop from taking the session
+   * lock on every disconnect event, which would stall portals while a
+   * handler holds it (e.g. screen-cast joining a PipeWire thread). */
   if (g_strcmp0 (session->sender, peer) != 0)
     return;
 
-  xdp_session_close (session, FALSE);
+  /* The disconnect sequence needs the lock, but taking it here would
+   * block the main loop if a portal handler is currently holding it.
+   * Run it in a worker thread instead. */
+  task = g_task_new (session, NULL, NULL, NULL);
+  g_task_set_source_tag (task, on_peer_disconnect_in_thread_func);
+  g_task_run_in_thread (task, on_peer_disconnect_in_thread_func);
 }
 
 static gboolean


### PR DESCRIPTION
Closes #2093. Replaces #2107, which took the wrong layer (it moved the `PEER_DISCONNECT` emit off the main loop in `xdp-context.c`); this PR instead fixes the disconnect handler itself.

`OpenDirectory` was reported as taking exactly 25 seconds whenever the file manager has to be D-Bus activated. The mechanism the reporter identified is right, but it needs much less to trigger than the report assumes, and the damage is wider: while it happens, **every portal is unresponsive for every client**, not just the caller.

## What actually happens

- A portal handler (e.g. `open-uri.c` `handle_open_in_thread_func`) takes `REQUEST_AUTOLOCK(request)` and holds it across a blocking call. For `ShowItems` that call has `timeout = -1`, i.e. the GDBus default of 25 seconds.
- `xdp-context.c` emits `peer-disconnect` on the **main loop** for every unique name that leaves the bus.
- `xdp-request.c` `on_peer_disconnect` (and the session equivalent) take the *same* request/session lock.

So the main loop parks in `on_peer_disconnect` until the blocking call gives up, and every other portal stalls with it.

## Measurements

A file manager stub that delays its `ShowItems` reply, and an unrelated `OpenURI.SchemeSupported` call timed from a third connection:

| in flight | peer disconnect | probe |
|---|---|---|
| nothing | yes | 0.01s |
| OpenDirectory | no | 0.01s |
| OpenDirectory | yes | **6.70s** |

No Nautilus, no GTK and no call back into the portal are needed. Any unrelated client dropping off the session bus is enough.

## The fix

Move the disconnect work off the main loop. `on_peer_disconnect` for requests and sessions now:

- does the peer check **lock-free** (the sender is fixed for the object's lifetime, so it never changes while the request/session exists), which lets the main loop skip the lock for every disconnect event that is not this object's owner, and
- runs the lock-taking disconnect sequence in a **worker thread** (`g_task_run_in_thread`), so a handler holding the lock no longer parks the main loop. The sequence is still serialized by the lock, so there is no double close/unexport.

This covers both the reported `ShowItems` stall and the same-shape session case (`ScreenCast.OpenPipeWireRemote` joining a PipeWire thread under the session lock, #2091). `xdp-session-persistence.c` is intentionally left alone: its handler uses its own `transient_permissions_lock`, not the request/session lock.

## Testing

A regression test was written and used to validate this, then dropped from the diff at swick's request (too specific for this issue; the libdex port will make the remaining lock sites moot anyway).
