### PR TITLE
screencast: Fix options double-unref on invalid persistence

### DIFF
--- a/desktop-portal/screen-cast.c
+++ b/desktop-portal/screen-cast.c
@@ -493,6 +493,7 @@ replace_screen_cast_restore_token_with_data (XdpSession *session,
                        XDG_DESKTOP_PORTAL_ERROR,
                        XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
                        "Remote desktop sessions cannot persist");
+          *in_out_options = g_steal_pointer (&options);
           return FALSE;
         }
     }

--- a/tests/test_screencast.py
+++ b/tests/test_screencast.py
@@ -11,7 +11,7 @@ import tests.xdp_utils as xdp
 
 @pytest.fixture
 def required_templates():
-    return {"screencast": {}}
+    return {"remotedesktop": {}, "screencast": {}}
 
 
 def start_stream(dbus_con, screencast_intf):
@@ -63,6 +63,51 @@ class TestScreenCast:
         _node_id, props = streams[0]
         assert "pipewire-serial" in props
         assert props["pipewire-serial"] == 133742
+
+    @pytest.mark.parametrize(
+        "persistence_option",
+        (
+            {"persist_mode": dbus.UInt32(xdp.SessionPersistenceMode.TRANSIENT)},
+            {"restore_token": "restore_token"},
+        ),
+    )
+    def test_remote_desktop_session_cannot_persist(
+        self,
+        portals,
+        dbus_con,
+        persistence_option,
+    ):
+        remotedesktop_intf = xdp.get_portal_iface(dbus_con, "RemoteDesktop")
+
+        request = xdp.Request(dbus_con, remotedesktop_intf)
+        response = request.call(
+            "CreateSession",
+            options={"session_handle_token": "session_token0"},
+        )
+        assert response
+        assert response.response == 0
+
+        session = xdp.Session.from_response(dbus_con, response)
+        screencast_intf = xdp.get_portal_iface(dbus_con, "ScreenCast")
+        request = xdp.Request(dbus_con, screencast_intf)
+
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            request.call(
+                "SelectSources",
+                session_handle=session.handle,
+                options=persistence_option,
+            )
+
+        e = excinfo.value
+        assert e.get_dbus_name() == "org.freedesktop.portal.Error.InvalidArgument"
+        assert e.get_dbus_message() == "Remote desktop sessions cannot persist"
+
+        mock_intf = xdp.get_mock_iface(dbus_con)
+        method_calls = mock_intf.GetMethodCalls("SelectSources")
+        assert len(method_calls) == 0
+
+        # Check that the portal is still alive and responsive.
+        xdp.check_version(dbus_con, "ScreenCast", 6)
 
     @pytest.mark.parametrize(
         "template_params",


### PR DESCRIPTION
`handle_select_sources()` keeps the filtered options in a `g_autoptr(GVariant)` and passes that pointer to `replace_screen_cast_restore_token_with_data()`.

The helper takes ownership of the same reference through another autoptr. For a RemoteDesktop session with persistence enabled, it returns `InvalidArgument` without giving that reference back to the caller. As a result, both autoptrs unref the same `GVariant`, which triggers a GLib critical and can lead to heap corruption or a crash.

Fix this by stealing the local pointer back into `*in_out_options` before returning the error. This keeps ownership with the caller on the failure path. The existing ScreenCast success path is unchanged: there, the local autoptr still cleans up the options variant that was replaced.

Add a regression test for a request containing both a nonzero `persist_mode` and a `restore_token`. The test checks that:

* the existing `InvalidArgument` error and message are unchanged;
* the invalid request is not sent to the backend; and
* the portal is still alive and responsive after the request.

The existing test harness makes GLib criticals fatal, so the regression test detects the invalid cleanup by verifying that the portal remains alive and responsive after rejecting the request.