### PR TITLE
session-persistence: Fix replace_restore_token_with_data onwership

### DIFF
--- a/desktop-portal/input-capture.c
+++ b/desktop-portal/input-capture.c
@@ -550,17 +550,14 @@ out:
 }
 
 static gboolean
-replace_input_capture_restore_token_with_data (XdpSession *session,
-                                               GVariant **in_out_options,
-                                               GError **error)
+replace_input_capture_restore_token_with_data (XdpSession  *session,
+                                               GVariant   **in_out_options,
+                                               GError     **error)
 {
   InputCaptureSession *input_capture_session = INPUT_CAPTURE_SESSION (session);
-  g_autoptr(GVariant) options = NULL;
   XdpSessionPersistenceMode persist_mode;
 
-  options = *in_out_options;
-
-  if (!g_variant_lookup (options, "persist_mode", "u", &persist_mode))
+  if (!g_variant_lookup (*in_out_options, "persist_mode", "u", &persist_mode))
     persist_mode = XDP_SESSION_PERSISTENCE_MODE_NONE;
 
   input_capture_session->persist_mode = persist_mode;

--- a/desktop-portal/remote-desktop.c
+++ b/desktop-portal/remote-desktop.c
@@ -505,17 +505,14 @@ static XdpOptionKey remote_desktop_select_devices_options[] = {
 };
 
 static void
-replace_remote_desktop_restore_token_with_data (XdpSession *session,
-                                                GVariant **in_out_options,
-                                                GError **error)
+replace_remote_desktop_restore_token_with_data (XdpSession  *session,
+                                                GVariant   **in_out_options,
+                                                GError     **error)
 {
   RemoteDesktopSession *remote_desktop_session = REMOTE_DESKTOP_SESSION (session);
-  g_autoptr(GVariant) options = NULL;
   XdpSessionPersistenceMode persist_mode;
 
-  options = *in_out_options;
-
-  if (!g_variant_lookup (options, "persist_mode", "u", &persist_mode))
+  if (!g_variant_lookup (*in_out_options, "persist_mode", "u", &persist_mode))
     persist_mode = XDP_SESSION_PERSISTENCE_MODE_NONE;
 
   remote_desktop_session->persist_mode = persist_mode;

--- a/desktop-portal/screen-cast.c
+++ b/desktop-portal/screen-cast.c
@@ -472,28 +472,24 @@ static XdpOptionKey screen_cast_select_sources_options[] = {
 };
 
 static gboolean
-replace_screen_cast_restore_token_with_data (XdpSession *session,
-                                             GVariant **in_out_options,
-                                             GError **error)
+replace_screen_cast_restore_token_with_data (XdpSession  *session,
+                                             GVariant   **in_out_options,
+                                             GError     **error)
 {
-  g_autoptr(GVariant) options = NULL;
   XdpSessionPersistenceMode persist_mode;
 
-  options = *in_out_options;
-
-  if (!g_variant_lookup (options, "persist_mode", "u", &persist_mode))
+  if (!g_variant_lookup (*in_out_options, "persist_mode", "u", &persist_mode))
     persist_mode = XDP_SESSION_PERSISTENCE_MODE_NONE;
 
   if (IS_REMOTE_DESKTOP_SESSION (session))
     {
       if (persist_mode != XDP_SESSION_PERSISTENCE_MODE_NONE ||
-          xdp_variant_contains_key (options, "restore_token"))
+          xdp_variant_contains_key (*in_out_options, "restore_token"))
         {
           g_set_error (error,
                        XDG_DESKTOP_PORTAL_ERROR,
                        XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
                        "Remote desktop sessions cannot persist");
-          *in_out_options = g_steal_pointer (&options);
           return FALSE;
         }
     }
@@ -507,10 +503,6 @@ replace_screen_cast_restore_token_with_data (XdpSession *session,
                                                                SCREEN_CAST_PERMISSION_TABLE,
                                                                in_out_options,
                                                                &screen_cast_session->restore_token);
-    }
-  else
-    {
-      *in_out_options = g_steal_pointer (&options);
     }
 
   return TRUE;

--- a/desktop-portal/xdp-session-persistence.c
+++ b/desktop-portal/xdp-session-persistence.c
@@ -246,6 +246,7 @@ xdp_session_persistence_replace_restore_token_with_data (XdpSession *session,
       g_clear_pointer (&value, g_variant_unref);
     }
 
+  g_clear_pointer (in_out_options, g_variant_unref);
   *in_out_options = g_variant_ref_sink (g_variant_builder_end (&options_builder));
 }
 


### PR DESCRIPTION
The xdp_session_persistence_replace_restore_token_with_data function
would takek an in-out GVariant, and then set a new value, but not free
the old value. This API is super confusing and requires the caller to
potentially free the in-out param. This has caused double-free and
memory leak bugs.

This change ensures that the in-out options is always a valid, owned
GVariant, which simplifies the callers.