### PR TITLE
settings: include xdp-dex.h for the dex_scheduler_spawnv fallback

### DIFF
--- a/desktop-portal/settings.c
+++ b/desktop-portal/settings.c
@@ -16,6 +16,7 @@
 
 #include "xdp-context.h"
 #include "xdp-dbus.h"
+#include "xdp-dex.h"
 #include "xdp-impl-dbus.h"
 #include "xdp-portal-config.h"
 #include "xdp-utils.h"


### PR DESCRIPTION
Fixes #2125

`settings.c` calls `dex_scheduler_spawnv()` but never includes `shared/xdp-dex.h`, where the `!HAVE_DEX_SCHEDULER_SPAWNV` fallback declaration lives. On a libdex build without the function, meson reports `dex_scheduler_spawnv ... : NO` and the build fails with an implicit-declaration error at `settings.c:287`.

Adding the include is consistent with the other callers (`xdp-app-info-registry.c`, `xdp-utils.c`) which already include `xdp-dex.h`.

Verified: `gcc -fsyntax-only` on `settings.c` passes after this change.