### PR TITLE
Fix deadlock when selecting many files in a sandboxed application

### DIFF
--- a/document-portal/document-portal.c
+++ b/document-portal/document-portal.c
@@ -980,6 +980,21 @@ document_add_full (int                      *fd,
       g_ptr_array_index(paths,i) = g_steal_pointer (&path);
     }
 
+  /* Check if app has direct access before locking db.
+   * This avoids holding the database mutex across external subprocess
+   * spawns which could lead to long fuse latency or even deadlock if
+   * the external helper does fuse ops.
+   */
+  for (i = 0; i < n_args; i++)
+    {
+      DocumentAddFullFlags flags = documents_flags[i];
+      if ((flags & DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP) != 0 &&
+          app_has_file_access (target_app_id, target_perms, g_ptr_array_index (paths, i)))
+        {
+          g_set_str ((char **) &g_ptr_array_index (ids, i), "");
+        }
+    }
+
   {
     XDP_AUTOLOCK (db); /* Lock once for all ops */
 
@@ -989,11 +1004,15 @@ document_add_full (int                      *fd,
         DocumentPermissionFlags caller_base_perms = DOCUMENT_PERMISSION_FLAGS_GRANT_PERMISSIONS |
                                                     DOCUMENT_PERMISSION_FLAGS_READ;
         DocumentPermissionFlags caller_write_perms = DOCUMENT_PERMISSION_FLAGS_WRITE;
-        gboolean reuse_existing, persistent, as_needed_by_app, is_dir;
+        gboolean reuse_existing, persistent, is_dir;
+
+        /* Skip if app already has direct file access */
+        if (g_ptr_array_index (ids, i) != NULL &&
+            g_strcmp0 (g_ptr_array_index (ids, i), "") == 0)
+          continue;
 
         flags = documents_flags[i];
         reuse_existing = (flags & DOCUMENT_ADD_FLAGS_REUSE_EXISTING) != 0;
-        as_needed_by_app = (flags & DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP) != 0;
         persistent = (flags & DOCUMENT_ADD_FLAGS_PERSISTENT) != 0;
         is_dir = (flags & DOCUMENT_ADD_FLAGS_DIRECTORY) != 0;
 
@@ -1003,13 +1022,6 @@ document_add_full (int                      *fd,
 
         const char *path = g_ptr_array_index(paths,i);
         g_assert (path != NULL);
-
-        if (as_needed_by_app &&
-            app_has_file_access (target_app_id, target_perms, path))
-          {
-            g_set_str ((char **) &g_ptr_array_index (ids, i), "");
-            continue;
-          }
 
         if (g_ptr_array_index(ids,i) == NULL)
           {
@@ -1175,8 +1187,6 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
     if (!reuse_existing)
       caller_perms |= DOCUMENT_PERMISSION_FLAGS_DELETE;
 
-    XDP_AUTOLOCK (db);
-
     if (as_needed_by_app &&
         app_has_file_access (target_app_id, target_perms, path))
       {
@@ -1184,6 +1194,8 @@ portal_add_named_full (GDBusMethodInvocation *invocation,
       }
     else
       {
+        XDP_AUTOLOCK (db);
+
         id = do_create_doc (&parent_st_buf, handle, path, reuse_existing, persistent, FALSE);
 
         if (app_id[0] != '\0' && g_strcmp0 (app_id, target_app_id) != 0)

--- a/shared/xdp-utils.c
+++ b/shared/xdp-utils.c
@@ -589,6 +589,7 @@ xdp_spawn_full (const char * const  *argv,
   GInputStream *in;
   g_autoptr(GOutputStream) out = NULL;
   g_autoptr(GMainLoop) loop = NULL;
+  g_autoptr(GMainContext) context = NULL;
   SpawnData data = {0};
   g_autofree char *commandline = NULL;
 
@@ -605,7 +606,10 @@ xdp_spawn_full (const char * const  *argv,
   if (subp == NULL)
     return NULL;
 
-  loop = g_main_loop_new (NULL, FALSE);
+  context = g_main_context_new ();
+  g_main_context_push_thread_default (context);
+
+  loop = g_main_loop_new (context, FALSE);
 
   data.loop = loop;
   data.refs = 2;
@@ -623,6 +627,8 @@ xdp_spawn_full (const char * const  *argv,
   g_subprocess_wait_async (subp, NULL, spawn_exit_cb, &data);
 
   g_main_loop_run (loop);
+
+  g_main_context_pop_thread_default (context);
 
   if (data.error)
     {

--- a/tests/test-xdp-utils.c
+++ b/tests/test-xdp-utils.c
@@ -194,6 +194,40 @@ test_app_id_via_systemd_unit (void)
 }
 #endif /* HAVE_LIBSYSTEMD */
 
+static gboolean default_context_dispatched = FALSE;
+
+static gboolean
+idle_cb (gpointer data)
+{
+  default_context_dispatched = TRUE;
+  return G_SOURCE_REMOVE;
+}
+
+static void
+test_spawn_isolates_context (void)
+{
+  g_autoptr(GError) error = NULL;
+  g_autofree char *output = NULL;
+  g_autoptr(GSource) source = g_idle_source_new ();
+
+  g_source_set_callback (source, idle_cb, NULL, NULL);
+  g_source_attach (source, NULL); /* Attached to default global GMainContext */
+
+  default_context_dispatched = FALSE;
+
+  output = xdp_spawn (&error, "true", NULL);
+  g_assert_no_error (error);
+
+  /* The nested main loop in xdp_spawn_full() must run on a dedicated
+   * GMainContext and must NOT dispatch events attached to the default
+   * GMainContext. */
+  g_assert_false (default_context_dispatched);
+
+  /* Now iterate the default context and verify the idle source is dispatched */
+  g_main_context_iteration (NULL, FALSE);
+  g_assert_true (default_context_dispatched);
+}
+
 int main (int argc, char **argv)
 {
   g_test_init (&argc, &argv, NULL);
@@ -205,5 +239,6 @@ int main (int argc, char **argv)
 #if HAVE_LIBSYSTEMD
   g_test_add_func ("/app-id-via-systemd-unit", test_app_id_via_systemd_unit);
 #endif
+  g_test_add_func ("/spawn/isolates-context", test_spawn_isolates_context);
   return g_test_run ();
 }

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -4,6 +4,8 @@
 # This file is formatted with Python Black
 
 import os
+import threading
+import time
 from pathlib import Path
 
 import dbus
@@ -334,6 +336,89 @@ class TestDocuments:
 
         host_path = xdp_doc.get_host_path_attr(mountpoint / doc_id / "a" / "b" / "c")
         assert host_path == base_path / "b" / "c"
+
+    def test_add_as_needed_by_app_reentrancy(
+        self, xdg_document_portal, dbus_con, xdp_bin_path
+    ):
+        documents_intf = xdp.get_document_portal_iface(dbus_con)
+
+        # 1. Create a document so we can perform a concurrent Info call on it
+        content1 = b"file1-content"
+        file1 = Path(os.environ["TMPDIR"]) / "test-doc-1"
+        xdp_doc.write_bytes_atomic(file1, content1)
+        doc_id1 = xdp_doc.export_file(documents_intf, file1)
+        assert doc_id1
+
+        # 2. Prepare file2 to be exported with DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP
+        file2 = Path(os.environ["TMPDIR"]) / "test-doc-2"
+        xdp_doc.write_bytes_atomic(file2, b"file2-content")
+
+        # 3. Create mock 'flatpak' that delays response slightly
+        mock_flatpak = xdp_bin_path / "flatpak"
+        mock_flatpak.write_text("#!/bin/sh\n/bin/sleep 0.2\necho 'read-write'\n")
+        mock_flatpak.chmod(0o755)
+
+        # 4. Prepare concurrent D-Bus interface and warm it up so sender is cached
+        concurrent_bus = dbus.SessionBus(private=True)
+        concurrent_obj = concurrent_bus.get_object(
+            "org.freedesktop.portal.Documents",
+            "/org/freedesktop/portal/documents",
+        )
+        concurrent_intf = dbus.Interface(
+            concurrent_obj, "org.freedesktop.portal.Documents"
+        )
+        path, _apps = concurrent_intf.Info(doc_id1)
+        assert path
+
+        # 5. Launch concurrent thread issuing an Info D-Bus call while AddFull is in-flight
+        concurrent_result = []
+        concurrent_error = []
+
+        def call_info():
+            try:
+                time.sleep(0.05)
+                res = concurrent_intf.Info(doc_id1, timeout=5)
+                concurrent_result.append(res)
+            except dbus.exceptions.DBusException as e:
+                concurrent_error.append(e)
+
+        thread = threading.Thread(target=call_info)
+        thread.start()
+
+        DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP = 1 << 2
+        file2_fd = os.open(file2.absolute().as_posix(), os.O_PATH | os.O_CLOEXEC)
+        deadlock_detected = False
+        try:
+            try:
+                doc_ids, _extra = documents_intf.AddFull(
+                    [file2_fd],
+                    DOCUMENT_ADD_FLAGS_AS_NEEDED_BY_APP,
+                    "org.test.App",
+                    ["read"],
+                    byte_arrays=True,
+                    timeout=2,
+                )
+            except dbus.exceptions.DBusException as e:
+                if "NoReply" in str(e) or "Timeout" in str(e):
+                    deadlock_detected = True
+                    raise AssertionError(
+                        "Deadlock detected: AddFull timed out waiting for reply"
+                    ) from e
+                raise
+            finally:
+                thread.join(timeout=2)
+                if thread.is_alive():
+                    deadlock_detected = True
+
+            assert not thread.is_alive(), "Concurrent Info call timed out (deadlock!)"
+            assert not concurrent_error, f"Concurrent call failed: {concurrent_error}"
+            assert len(concurrent_result) == 1
+            assert doc_ids == [""]
+        finally:
+            os.close(file2_fd)
+            if deadlock_detected:
+                xdg_document_portal.kill()
+                xdg_document_portal.wait()
 
 
 try:


### PR DESCRIPTION
As described in #2133, selecting many (100s) files in a sandboxed application such as snap-confined Firefox can lead to a deadlock in the xdg-desktop-portal due to the locking and glib main loop context around spawning the access-checking helper process. Fix both xdg_spawn to use its own context to limit event sources, and also the lock scope around the document db. Also add tests that pass with the fixes in place but fail without them.