### PR TITLE
realtime: skip export when rtkit cannot provide its properties

### DIFF
--- a/desktop-portal/realtime.c
+++ b/desktop-portal/realtime.c
@@ -233,12 +233,13 @@ realtime_class_init (RealtimeClass *klass)
   object_class->finalize = realtime_finalize;
 }
 
-static void
+static gboolean
 load_all_properties (Realtime *realtime)
 {
   GDBusProxy *proxy = realtime->rtkit_proxy;
   const char * properties[] = { "MaxRealtimePriority", "MinNiceLevel", "RTTimeUSecMax" };
   enum prop_type { MAX_REALTIME_PRIORITY, MIN_NICE_LEVEL, RTTIME_USEC_MAX };
+  gboolean success = TRUE;
 
   for (guint i = 0; i < G_N_ELEMENTS (properties); ++i)
     {
@@ -250,14 +251,15 @@ load_all_properties (Realtime *realtime)
       result = g_dbus_proxy_call_sync (proxy,
                                        DBUS_DBUS_IFACE ".Properties.Get",
                                         g_steal_pointer (&parameters),
-                                        G_DBUS_CALL_FLAGS_NONE,
-                                        -1,
-                                        NULL,
-                                        &error);
+                                       G_DBUS_CALL_FLAGS_NONE,
+                                       -1,
+                                       NULL,
+                                       &error);
 
       if (!result)
         {
           g_warning ("Failed to load RealtimeKit property: %s", error->message);
+          success = FALSE;
         }
       else
         {
@@ -279,14 +281,16 @@ load_all_properties (Realtime *realtime)
           g_dbus_proxy_set_cached_property (proxy, properties[i], value);
         }
     }
+
+  return success;
 }
 
 static Realtime *
 realtime_new (void)
 {
-  Realtime *realtime;
   g_autoptr(GError) error = NULL;
   g_autoptr(GDBusProxy) rtkit_proxy = NULL;
+  g_autoptr(Realtime) realtime = NULL;
 
   rtkit_proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
                                                G_DBUS_PROXY_FLAGS_NONE,
@@ -298,9 +302,8 @@ realtime_new (void)
                                                &error);
   if (!rtkit_proxy)
     {
-      /* We continue on so the realtime interface remains exported,
-       * however it will fail to do anything */
       g_warning ("Failed to create RealtimeKit proxy: %s", error->message);
+      return NULL;
     }
 
   realtime = g_object_new (realtime_get_type (), NULL);
@@ -308,10 +311,13 @@ realtime_new (void)
 
   xdp_dbus_realtime_set_version (XDP_DBUS_REALTIME (realtime), 1);
 
-  if (realtime->rtkit_proxy)
-    load_all_properties (realtime);
+  if (!load_all_properties (realtime))
+    {
+      g_warning ("Failed to load RealtimeKit properties at startup");
+      return NULL;
+    }
 
-  return realtime;
+  return g_steal_pointer (&realtime);
 }
 
 void
@@ -320,6 +326,8 @@ init_realtime (XdpContext *context)
   g_autoptr(Realtime) realtime = NULL;
 
   realtime = realtime_new ();
+  if (realtime == NULL)
+    return;
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&realtime)),


### PR DESCRIPTION
## Problem

When rtkit's D-Bus proxy creation or its `Properties.Get` calls fail at
startup, the Realtime portal keeps exporting the interface with the gdbus
skeleton's default value (0) for `RTTimeUSecMax` (and the other two).

This is worse than "does nothing": PipeWire's `module-rt` (loaded in all
clients since 1.4.0) reads the exported `RTTimeUSecMax`, sees a *valid*
0, sets `RLIMIT_RTTIME={0,0}`, and the kernel SIGKILLs the entire
client process on the first realtime tick. Reproduced by two independent
reporters (rtkit present but a startup race, and rtkit absent entirely).
Issue: #2110.

## Root cause

`realtime_new()` deliberately continues even when the rtkit proxy cannot be
created, with the comment "We continue on so the realtime interface
remains exported, however it will fail to do anything". The `!rtkit_proxy`
guard makes the method handlers return an error, but the exported properties stay
at their 0 defaults -- and properties are what PipeWire reads.

## Fix

Make the portal **not export at all** when rtkit cannot provide its
properties:

- `load_all_properties()` now returns whether every property loaded.
- `realtime_new()` returns `NULL` (cleanly finalized via `g_autoptr`) if
  the rtkit proxy cannot be created **or** any property fails to load.
- `init_realtime()` skips `xdp_context_take_and_export_portal()` when
  `realtime_new()` returns `NULL`.

This matches the existing pattern in `init_usb` / `init_location`, which
`return` without exporting when a required dependency is unavailable. A client
now gets an unambiguous `org.freedesktop.DBus.Error.ServiceUnknown` / unknown
method rather than a plausible-looking 0 that the kernel enforces as a
termination sentence.

The change is one file, `desktop-portal/realtime.c`, +19/-11.

## Verification

- Follows the exact guard style of `init_usb()` / `init_location()` in the
  same `desktop-portal/` directory.
- `g_autoptr(Realtime)` was already defined (line 44), so the early
  `return NULL` paths release the proxy correctly through `realtime_finalize()`.

**Automation disclosure**, separate from the commit trailer as the policy
requires: this pull request's changes and this summary were prepared with Claude
Code. I reviewed the diff and verification myself before submitting, and I am the
person accountable for it.

Fixes: https://github.com/flatpak/xdg-desktop-portal/issues/2110